### PR TITLE
bugfix: if you have not added the processes block in your conf file, you...

### DIFF
--- a/src/proc/ngx_proc.h
+++ b/src/proc/ngx_proc.h
@@ -83,7 +83,4 @@ extern ngx_module_t  ngx_procs_module;
 extern ngx_module_t  ngx_proc_core_module;
 
 
-
-
-
 #endif /* _NGX_PROC_H_INCLUDED_ */


### PR DESCRIPTION
bugfix: if you have not added the processes block in your conf file, you will get a coredump when you call ngx_proc_get_conf or ngx_proc_get_main_conf.
