### PR TITLE
Least conn check

### DIFF
--- a/src/http/modules/ngx_http_upstream_least_conn_module.c
+++ b/src/http/modules/ngx_http_upstream_least_conn_module.c
@@ -203,6 +203,16 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
             continue;
         }
 
+#if (NGX_HTTP_UPSTREAM_CHECK)
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "get least_conn peer, check_index: %ui",
+                       peer->check_index);
+
+        if (ngx_http_upstream_check_peer_down(peer->check_index)) {
+            continue;
+        }
+#endif
+
         if (peer->max_fails
             && peer->fails >= peer->max_fails
             && now - peer->checked <= peer->fail_timeout)
@@ -255,6 +265,16 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
             if (peer->down) {
                 continue;
             }
+
+#if (NGX_HTTP_UPSTREAM_CHECK)
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "get least_conn peer, check_index: %ui",
+                           peer->check_index);
+
+            if (ngx_http_upstream_check_peer_down(peer->check_index)) {
+                continue;
+            }
+#endif
 
             if (lcp->conns[i] * best->weight != lcp->conns[p] * peer->weight) {
                 continue;

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
@@ -239,3 +239,83 @@ GET /
 --- request
 GET /
 --- response_body_like: ^<(.*)>$
+
+=== TEST 12: the http_check test-single server, least conn
+--- http_config
+    upstream test{
+        server blog.163.com:80;
+        least_conn;
+
+        check interval=3000 rise=1 fall=5 timeout=2000 type=http;
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- request
+GET /
+--- response_body_like: ^<(.*)>$
+
+=== TEST 13: the http_check test-multi_server, least conn
+--- http_config
+    upstream test{
+        server blog.163.com:80;
+        server blog.163.com:81;
+        least_conn;
+
+        check interval=3000 rise=1 fall=5 timeout=2000 type=http;
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- request
+GET /
+--- response_body_like: ^<(.*)>$
+
+=== TEST 14: the http_check test, least conn
+--- http_config
+    upstream test{
+        server blog.163.com:80;
+        server blog.163.com:81;
+        least_conn;
+
+        check interval=3000 rise=1 fall=5 timeout=2000 type=http;
+        check_http_send "GET /foo HTTP/1.0\r\n\r\n";
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- request
+GET /
+--- error_code: 502
+--- response_body_like: ^.*$
+
+=== TEST 15: the http_check without check directive, least conn
+--- http_config
+    upstream test{
+        server blog.163.com:80;
+        server blog.163.com:81;
+        least_conn;
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- request
+GET /
+--- response_body_like: ^<(.*)>$

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/ssl_hello_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/ssl_hello_check.t
@@ -26,7 +26,7 @@ __DATA__
     location / {
         proxy_pass https://test;
     }
-
+   
 --- request
 GET /
 --- response_body_like: ^<(.*)>[\r\n\s\t]*$
@@ -70,3 +70,24 @@ GET /
 --- request
 GET /
 --- response_body_like: ^<(.*)>[\r\n\s\t]*$
+
+=== TEST 4: the ssl_hello_check test with least_conn
+--- http_config
+    upstream test{
+        server www.alipay.com:443;
+        server www.alipay.com:444;
+        server www.alipay.com:445;
+        least_conn;
+
+        check interval=4000 rise=1 fall=5 timeout=2000 type=ssl_hello;
+    }
+
+--- config
+    location / {
+        proxy_pass https://test;
+    }
+
+--- request
+GET /
+--- response_body_like: ^<(.*)>[\r\n\s\t]*$
+

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/tcp_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/tcp_check.t
@@ -69,3 +69,24 @@ GET /
 --- request
 GET /
 --- response_body_like: ^<(.*)>$
+
+=== TEST 3: the tcp_check test with least_conn;
+--- http_config
+    upstream test{
+        server blog.163.com:80;
+        server blog.163.com:81;
+        server blog.163.com:82;
+        least_conn;
+
+        check interval=3000 rise=1 fall=5 timeout=1000 type=tcp;
+    }
+
+--- config
+    location / { 
+        proxy_pass http://test;
+    }
+
+--- request
+GET /
+--- response_body_like: ^<(.*)>$
+


### PR DESCRIPTION
为nginx-1.2.2中引入的least_conn模块加入upstream_check的patch
