### PR TITLE
fixed a possible risk bug with the request input filter module

### DIFF
--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -138,6 +138,10 @@ ngx_http_read_client_request_body(ngx_http_request_t *r,
 
         rc = ngx_http_top_input_body_filter(r, &buf);
         if (rc != NGX_OK) {
+            if (rc == NGX_ERROR) {
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
+
             return rc;
         }
 
@@ -332,6 +336,10 @@ ngx_http_do_read_client_request_body(ngx_http_request_t *r)
 
             rc = ngx_http_top_input_body_filter(r, &buf);
             if (rc != NGX_OK) {
+                if (rc == NGX_ERROR) {
+                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+                }
+
                 return rc;
             }
 


### PR DESCRIPTION
In some third party input filter modules, if the filter function returns
with NGX_ERROR, the request will stuck in the event cycle and can't call the
finalized function again.
