### PR TITLE
Added msleep() on reload to allow new processes to start.

### DIFF
--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -277,6 +277,9 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
             ngx_procs_start(cycle, 1);
 #endif
 
+            /* allow new processes to start */
+            ngx_msleep(100);
+
             live = 1;
             close_old_pipe = 1;
             ngx_signal_worker_processes(cycle,


### PR DESCRIPTION
This is expected to ensure smoother operation on reload (and with less
chance of listen queue overflows).

https://github.com/taobao/tengine/commit/779e37c26a0cead355f42351e3b36390a8ae3ffc
