### PR TITLE
CPU亲缘性

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -1354,15 +1354,22 @@ ngx_set_cpu_affinity(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_str_t        *value;
     ngx_uint_t        i, j, n;
 
-    if (ccf->cpu_affinity) {
+    if (ccf->cpu_affinity || ccf->cpu_affinity_n) {
         return "is duplicate";
     }
 
     value = cf->args->elts;
 
-    if (ngx_strncasecmp((u_char *) "auto", value[1].data, 4) == 0) {
+    if (ngx_strcasecmp((u_char *) "auto", value[1].data) == 0) {
 
         ccf->cpu_affinity = NGX_CONF_UNSET_PTR;
+
+        return NGX_CONF_OK;
+    }
+
+    if (ngx_strcasecmp((u_char *) "off", value[1].data) == 0) {
+
+        ccf->cpu_affinity_n = 1;
 
         return NGX_CONF_OK;
     }

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -65,7 +65,7 @@ ngx_int_t              ngx_threads_n;
 #endif
 
 #if (NGX_HAVE_CPU_AFFINITY)
-CPU_SET_T             *cpu_affinity;
+CPU_SET_T             *cpu_affinity = NULL;
 #endif
 
 static u_char  master_process[] = "master process";
@@ -405,6 +405,17 @@ ngx_start_worker_processes(ngx_cycle_t *cycle, ngx_int_t n, ngx_int_t type)
 
         ngx_pass_open_channel(cycle, &ch);
     }
+
+#if (NGX_HAVE_CPU_AFFINITY)
+
+    /**
+     * Disable CPU affinity on the new respawn workers, otherwise nginx will
+     * bind them to the same CPU.
+     */
+
+    cpu_affinity = NULL;
+
+#endif
 }
 
 


### PR DESCRIPTION
feature: add option 'off' to 'worker_cpu_affinity' directive
feature: disable cpu affinity when a worker is respawn
