### PR TITLE
added the test directive to Makefile

### DIFF
--- a/auto/install
+++ b/auto/install
@@ -131,8 +131,7 @@ esac
 cat << END                                                    >> $NGX_MAKEFILE
 
 test:	$NGX_OBJS/nginx
-	TEST_NGINX_BINARY=$NGX_TEST_BINARY prove -I `pwd`/tests/nginx-tests/nginx-tests/lib tests/nginx-tests/nginx-tests
-	TEST_NGINX_BINARY=$NGX_TEST_BINARY prove -I `pwd`/tests/nginx-tests/nginx-tests/lib tests/nginx-tests/cases
+	TEST_NGINX_BINARY=$NGX_TEST_BINARY prove -v -I `pwd`/tests/nginx-tests/nginx-tests/lib tests/nginx-tests/nginx-tests tests/nginx-tests/cases
 
 END
 


### PR DESCRIPTION
added the test directive to Makefile.

Now you can run the test cases  after your build the Tengine binary:

```
make test
```

It will run all the test cases under the "tests/nginx-tests" directory.
