### PR TITLE
add include <sys/sysinfo.h>

### DIFF
--- a/src/os/unix/ngx_sysinfo.c
+++ b/src/os/unix/ngx_sysinfo.c
@@ -7,6 +7,10 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 
+#if (NGX_HAVE_SYSINFO)
+#include <sys/sysinfo.h>
+#endif
+
 
 ngx_int_t
 ngx_getloadavg(ngx_int_t avg[], ngx_int_t nelem, ngx_log_t *log)


### PR DESCRIPTION
添加 include <sys/sysinfo.h>，解决在cygwin下面无法编译的问题。
