### PR TITLE
upstream check: fix the check status "down" for a single server.

### DIFF
--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -470,7 +470,7 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
         peer = &rrp->peers->peer[0];
 #if (NGX_HTTP_UPSTREAM_CHECK)
         if (ngx_http_upstream_check_peer_down(peer->check_index)) {
-            return NGX_BUSY;
+            goto failed;
         }
 #endif
 


### PR DESCRIPTION
If a single server is marked down by upstream check module, it will
return 502 directly before.

This fix can use the backup server eventually for sure in the above
case.
