### PR TITLE
New feature: sysguard suppport memfree.

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -305,6 +305,17 @@ ngx_feature_test="double loadavg[1];
 . auto/feature
 
 
+ngx_feature="/proc/meminfo"
+ngx_feature_name="NGX_HAVE_PROC_MEMINFO"
+ngx_feature_run=yes
+ngx_feature_incs="#include <fcntl.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test='int fd;
+                  if (open("/proc/meminfo", O_RDONLY) == -1) return 1;'
+. auto/feature
+
+
 ngx_feature="sched_yield()"
 ngx_feature_name="NGX_HAVE_SCHED_YIELD"
 ngx_feature_run=no

--- a/src/core/ngx_parse.c
+++ b/src/core/ngx_parse.c
@@ -33,6 +33,12 @@ ngx_parse_size(ngx_str_t *line)
         scale = 1024 * 1024;
         break;
 
+    case 'G':
+    case 'g':
+        len--;
+        scale = 1024 * 1024 * 1024;
+        break;
+
     default:
         scale = 1;
     }

--- a/src/http/modules/ngx_http_sysguard_module.c
+++ b/src/http/modules/ngx_http_sysguard_module.c
@@ -15,6 +15,8 @@ typedef struct {
     ngx_str_t   load_action;
     ngx_int_t   swap;
     ngx_str_t   swap_action;
+    size_t      free;
+    ngx_str_t   free_action;
     time_t      interval;
 
     ngx_uint_t  log_level;
@@ -113,9 +115,10 @@ ngx_module_t  ngx_http_sysguard_module = {
 
 
 static time_t    ngx_http_sysguard_cached_load_exptime;
-static time_t    ngx_http_sysguard_cached_swap_exptime;
+static time_t    ngx_http_sysguard_cached_mem_exptime;
 static ngx_int_t ngx_http_sysguard_cached_load;
 static ngx_int_t ngx_http_sysguard_cached_swapstat;
+static size_t    ngx_http_sysguard_cached_free;
 
 
 static ngx_int_t
@@ -140,23 +143,25 @@ ngx_http_sysguard_update_load(ngx_http_request_t *r, time_t exptime)
 
 
 static ngx_int_t
-ngx_http_sysguard_update_swap(ngx_http_request_t *r, time_t exptime)
+ngx_http_sysguard_update_mem(ngx_http_request_t *r, time_t exptime)
 {
     ngx_int_t      rc;
     ngx_meminfo_t  m;
 
-    ngx_http_sysguard_cached_swap_exptime = ngx_time() + exptime;
+    ngx_http_sysguard_cached_mem_exptime = ngx_time() + exptime;
 
     rc = ngx_getmeminfo(&m, r->connection->log);
     if (rc == NGX_ERROR) {
 
         ngx_http_sysguard_cached_swapstat = 0;
+        ngx_http_sysguard_cached_free = NGX_CONF_UNSET_SIZE;
 
         return NGX_ERROR;
     }
 
     ngx_http_sysguard_cached_swapstat = m.totalswap == 0
         ? 0 : (m.totalswap - m.freeswap) * 100 / m.totalswap;
+    ngx_http_sysguard_cached_free = m.freeram + m.cachedram + m.bufferram;
 
     return NGX_OK;
 }
@@ -198,25 +203,25 @@ ngx_http_sysguard_handler(ngx_http_request_t *r)
 
     /* load */
 
-    if (glcf->load >= 0) {
+    if (glcf->load != NGX_CONF_UNSET) {
 
         if (ngx_http_sysguard_cached_load_exptime < ngx_time()) {
             ngx_http_sysguard_update_load(r, glcf->interval);
         }
 
         ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "http sysguard handler load: %i %i %V %V",
-                       ngx_http_sysguard_cached_load,
-                       glcf->load,
+                       "http sysguard handler load: %1.3f %1.3f %V %V",
+                       ngx_http_sysguard_cached_load * 1.0 / 1000,
+                       glcf->load * 1.0 / 1000,
                        &r->uri,
                        &glcf->load_action);
 
         if (ngx_http_sysguard_cached_load > glcf->load) {
 
             ngx_log_error(glcf->log_level, r->connection->log, 0,
-                          "sysguard load limited, current:%i conf:%i",
-                          ngx_http_sysguard_cached_load,
-                          glcf->load);
+                          "sysguard load limited, current:%1.3f conf:%1.3f",
+                          ngx_http_sysguard_cached_load * 1.0 / 1000,
+                          glcf->load * 1.0 / 1000);
 
             return ngx_http_sysguard_do_redirect(r, &glcf->load_action);
         }
@@ -224,10 +229,10 @@ ngx_http_sysguard_handler(ngx_http_request_t *r)
 
     /* swap */
 
-    if (glcf->swap >= 0) {
+    if (glcf->swap != NGX_CONF_UNSET) {
 
-        if (ngx_http_sysguard_cached_swap_exptime < ngx_time()) {
-            ngx_http_sysguard_update_swap(r, glcf->interval);
+        if (ngx_http_sysguard_cached_mem_exptime < ngx_time()) {
+            ngx_http_sysguard_update_mem(r, glcf->interval);
         }
 
         ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
@@ -246,6 +251,36 @@ ngx_http_sysguard_handler(ngx_http_request_t *r)
 
             return ngx_http_sysguard_do_redirect(r, &glcf->swap_action);
         }
+    }
+
+    /* mem free */
+
+    if (glcf->free != NGX_CONF_UNSET_SIZE) {
+
+        if (ngx_http_sysguard_cached_mem_exptime < ngx_time()) {
+            ngx_http_sysguard_update_mem(r, glcf->interval);
+        }
+
+        if (ngx_http_sysguard_cached_free != NGX_CONF_UNSET_SIZE) {
+
+            ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http sysguard handler free: %uz %uz %V %V",
+                           ngx_http_sysguard_cached_free,
+                           glcf->free,
+                           &r->uri,
+                           &glcf->free_action);
+
+            if (ngx_http_sysguard_cached_free < glcf->free) {
+
+                ngx_log_error(glcf->log_level, r->connection->log, 0,
+                              "sysguard free limited, current:%uzM conf:%uzM",
+                              ngx_http_sysguard_cached_free / 1024 / 1024,
+                              glcf->free / 1024 / 1024);
+
+                return ngx_http_sysguard_do_redirect(r, &glcf->free_action);
+            }
+        }
+
     }
 
     return NGX_DECLINED;
@@ -272,6 +307,7 @@ ngx_http_sysguard_create_conf(ngx_conf_t *cf)
     conf->enable = NGX_CONF_UNSET;
     conf->load = NGX_CONF_UNSET;
     conf->swap = NGX_CONF_UNSET;
+    conf->free = NGX_CONF_UNSET_SIZE;
     conf->interval = NGX_CONF_UNSET;
     conf->log_level = NGX_CONF_UNSET_UINT;
 
@@ -288,8 +324,10 @@ ngx_http_sysguard_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->enable, prev->enable, 0);
     ngx_conf_merge_str_value(conf->load_action, prev->load_action, "");
     ngx_conf_merge_str_value(conf->swap_action, prev->swap_action, "");
-    ngx_conf_merge_value(conf->load, prev->load, -1);
-    ngx_conf_merge_value(conf->swap, prev->swap, -1);
+    ngx_conf_merge_str_value(conf->free_action, prev->free_action, "");
+    ngx_conf_merge_value(conf->load, prev->load, NGX_CONF_UNSET);
+    ngx_conf_merge_value(conf->swap, prev->swap, NGX_CONF_UNSET);
+    ngx_conf_merge_size_value(conf->free, prev->free, NGX_CONF_UNSET_SIZE);
     ngx_conf_merge_value(conf->interval, prev->interval, 1);
     ngx_conf_merge_uint_value(conf->log_level, prev->log_level, NGX_LOG_ERR);
 
@@ -360,7 +398,7 @@ ngx_http_sysguard_mem(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
     ngx_http_sysguard_conf_t  *glcf = conf;
 
-    ngx_str_t  *value;
+    ngx_str_t  *value, ss;
     ngx_uint_t  i;
 
     value = cf->args->elts;
@@ -401,6 +439,43 @@ ngx_http_sysguard_mem(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
         glcf->swap_action.data = value[i].data + 7;
         glcf->swap_action.len = value[i].len - 7;
+
+        return NGX_CONF_OK;
+
+    } else if (ngx_strncmp(value[i].data, "free=", 5) == 0) {
+
+        if (glcf->free != NGX_CONF_UNSET_SIZE) {
+            return "is duplicate";
+        }
+
+        ss.data = value[i].data + 5;
+        ss.len = value[i].len - 5;
+
+        glcf->free = ngx_parse_size(&ss);
+        if (glcf->free == (size_t) NGX_ERROR) {
+            goto invalid;
+        }
+
+        if (cf->args->nelts == 2) {
+            return NGX_CONF_OK;
+        }
+
+        i++;
+
+        if (ngx_strncmp(value[i].data, "action=", 7) != 0) {
+            goto invalid;
+        }
+
+        if (value[i].len == 7) {
+            goto invalid;
+        }
+
+        if (value[i].data[7] != '/' && value[i].data[7] != '@') {
+            goto invalid;
+        }
+
+        glcf->free_action.data = value[i].data + 7;
+        glcf->free_action.len = value[i].len - 7;
 
         return NGX_CONF_OK;
     }

--- a/src/os/unix/ngx_linux_config.h
+++ b/src/os/unix/ngx_linux_config.h
@@ -87,11 +87,6 @@ extern ssize_t sendfile(int s, int fd, int32_t *offset, size_t size);
 #endif
 
 
-#if (NGX_HAVE_SYSINFO)
-#include <sys/sysinfo.h>
-#endif
-
-
 #if (NGX_HAVE_FILE_AIO)
 #include <sys/syscall.h>
 #include <linux/aio_abi.h>

--- a/src/os/unix/ngx_solaris.h
+++ b/src/os/unix/ngx_solaris.h
@@ -9,6 +9,10 @@
 #define _NGX_SOLARIS_H_INCLUDED_
 
 
+#if (NGX_HAVE_GETLOADAVG)
+#include <sys/loadavg.h>
+#endif
+
 ngx_chain_t *ngx_solaris_sendfilev_chain(ngx_connection_t *c, ngx_chain_t *in,
     off_t limit);
 

--- a/src/os/unix/ngx_sysinfo.c
+++ b/src/os/unix/ngx_sysinfo.c
@@ -47,34 +47,189 @@ ngx_getloadavg(ngx_int_t avg[], ngx_int_t nelem, ngx_log_t *log)
 #else
 
     ngx_log_error(NGX_LOG_EMERG, log, 0,
-                  "getloadavg is unsurpported under current os");
+                  "getloadavg is unsupported under current os");
 
     return NGX_ERROR;
 #endif
 }
+
+#if (NGX_HAVE_PROC_MEMINFO)
+
+static ngx_file_t                   ngx_meminfo_file;
+
+#define NGX_MEMINFO_FILE            "/proc/meminfo"
+#define NGX_MEMINFO_MAX_NAME_LEN    16
 
 
 ngx_int_t
 ngx_getmeminfo(ngx_meminfo_t *meminfo, ngx_log_t *log)
 {
-#if (NGX_HAVE_SYSINFO)
-    struct sysinfo s;
+    u_char              buf[2048];
+    u_char             *p, *start, *last;
+    size_t             *sz = NULL;
+    ssize_t             n, len;
+    ngx_fd_t            fd;
+    enum {
+        sw_name = 0,
+        sw_value_start,
+        sw_value,
+        sw_skipline,
+        sw_newline,
+    } state;
 
-    if (sysinfo(&s)) {
+    ngx_memzero(meminfo, sizeof(ngx_meminfo_t));
+
+    if (ngx_meminfo_file.fd == 0) {
+
+        fd = ngx_open_file(NGX_MEMINFO_FILE, NGX_FILE_RDONLY,
+                           NGX_FILE_OPEN,
+                           NGX_FILE_DEFAULT_ACCESS);
+
+        if (fd == NGX_INVALID_FILE) {
+            ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+                          ngx_open_file_n " \"%s\" failed",
+                          NGX_MEMINFO_FILE);
+
+            return NGX_ERROR;
+        }
+
+        ngx_meminfo_file.name.data = (u_char *) NGX_MEMINFO_FILE;
+        ngx_meminfo_file.name.len = ngx_strlen(NGX_MEMINFO_FILE);
+
+        ngx_meminfo_file.fd = fd;
+    }
+
+    ngx_meminfo_file.log = log;
+    n = ngx_read_file(&ngx_meminfo_file, buf, sizeof(buf) - 1, 0);
+    if (n == NGX_ERROR) {
+        ngx_log_error(NGX_LOG_ALERT, log, ngx_errno,
+                      ngx_read_file_n " \"%s\" failed",
+                      NGX_MEMINFO_FILE);
+
         return NGX_ERROR;
     }
 
-    meminfo->totalram = s.totalram;
-    meminfo->freeram = s.freeram;
-    meminfo->sharedram = s.sharedram;
-    meminfo->bufferram = s.bufferram;
-    meminfo->totalswap = s.totalswap;
-    meminfo->freeswap = s.freeswap;
+    p = buf;
+    start = buf;
+    last = buf + n;
+    state = sw_name;
+
+    for (; p < last; p++) {
+
+        if (*p == '\n') {
+            state = sw_newline;
+        }
+
+        switch (state) {
+
+        case sw_name:
+            if (*p != ':') {
+                continue;
+            }
+
+            len = p - start;
+            sz = NULL;
+
+            switch (len) {
+            case 6:
+                /* Cached */
+                if (meminfo->cachedram == 0 &&
+                    ngx_strncmp(start, "Cached", len) == 0)
+                {
+                    sz = &meminfo->cachedram;
+                }
+                break;
+            case 7:
+                /* Buffers MemFree */
+                if (meminfo->bufferram == 0 &&
+                    ngx_strncmp(start, "Buffers", len) == 0)
+                {
+                    sz = &meminfo->bufferram;
+                } else if (meminfo->freeram == 0 &&
+                           ngx_strncmp(start, "MemFree", len) == 0)
+                {
+                    sz = &meminfo->freeram;
+                }
+                break;
+            case 8:
+                /* MemTotal SwapFree */
+                if (meminfo->totalram == 0 &&
+                    ngx_strncmp(start, "MemTotal", len) == 0)
+                {
+                    sz = &meminfo->totalram;
+                } else if (meminfo->freeswap == 0 &&
+                           ngx_strncmp(start, "SwapFree", len) == 0)
+                {
+                    sz = &meminfo->freeswap;
+                }
+                break;
+            case 9:
+                /* SwapTotal */
+                if (meminfo->totalswap == 0 &&
+                    ngx_strncmp(start, "SwapTotal", len) == 0)
+                {
+                    sz = &meminfo->totalswap;
+                }
+                break;
+            }
+
+            if (sz == NULL) {
+                state = sw_skipline;
+                continue;
+            }
+
+            state = sw_value_start;
+
+            continue;
+
+        case sw_value_start:
+
+            if (*p == ' ') {
+                continue;
+            }
+
+            start = p;
+            state = sw_value;
+
+            continue;
+
+        case sw_value:
+
+            if (*p >= '0' && *p <= '9') {
+                continue;
+            }
+
+            *(sz) =  ngx_atosz(start, p - start) * 1024;
+
+            state = sw_skipline;
+
+            continue;
+
+        case sw_skipline:
+
+            continue;
+
+        case sw_newline:
+
+            state = sw_name;
+            start = p + 1;
+
+            continue;
+        }
+    }
 
     return NGX_OK;
-#else
-    ngx_log_error(NGX_LOG_EMERG, log, 0,
-                  "getmeminfo is unsurpported under current os");
-    return NGX_ERROR;
-#endif
 }
+
+#else
+
+ngx_int_t
+ngx_getmeminfo(ngx_meminfo_t *meminfo, ngx_log_t *log)
+{
+    ngx_log_error(NGX_LOG_EMERG, log, 0,
+                  "getmeminfo is unsupported under current os");
+
+    return NGX_ERROR;
+}
+
+#endif

--- a/src/os/unix/ngx_sysinfo.h
+++ b/src/os/unix/ngx_sysinfo.h
@@ -12,11 +12,12 @@
 #include <ngx_core.h>
 
 
+/* in bytes */
 typedef struct {
     size_t totalram;
     size_t freeram;
-    size_t sharedram;
     size_t bufferram;
+    size_t cachedram;
     size_t totalswap;
     size_t freeswap;
 } ngx_meminfo_t;

--- a/tests/nginx-tests/cases/expires_by_types.t
+++ b/tests/nginx-tests/cases/expires_by_types.t
@@ -1,9 +1,5 @@
 #!/usr/bin/perl
 
-# (C) Maxim Dounin
-
-# Test for fastcgi backend.
-
 ###############################################################################
 
 use warnings;

--- a/tests/nginx-tests/cases/http_error_page_merge.t
+++ b/tests/nginx-tests/cases/http_error_page_merge.t
@@ -1,7 +1,5 @@
 #!/usr/bin/perl
 
-# (C) Maxim Dounin
-
 # Tests for error_page directive (inherit).
 
 ###############################################################################


### PR DESCRIPTION
1. Read memory info from /proc/meminfo other than sysinfo call.
2. ngx_parse_size support G/g.
3. sysguard supports mem_free: sysguard_mem free=size action=/busy;
