### PR TITLE
Add support for GeoIP Regional Database

### DIFF
--- a/src/http/modules/ngx_http_geoip_module.c
+++ b/src/http/modules/ngx_http_geoip_module.c
@@ -899,6 +899,10 @@ ngx_http_geoip_cleanup(void *data)
     if (gcf->country) {
         GeoIP_delete(gcf->country);
     }
+    
+	if (gcf->region) {
+        GeoIP_delete(gcf->region);
+    }
 
     if (gcf->org) {
         GeoIP_delete(gcf->org);


### PR DESCRIPTION
We bought a Regional Database from MaxMind and discovered that tengine didn't support it. This patch adds support.
