### PR TITLE
Increase the size of the error string to 4096 bytes

### DIFF
--- a/src/core/ngx_log.h
+++ b/src/core/ngx_log.h
@@ -86,7 +86,7 @@ struct ngx_log_s {
 };
 
 
-#define NGX_MAX_ERROR_STR   2048
+#define NGX_MAX_ERROR_STR   4096
 
 
 /*********************************/


### PR DESCRIPTION
In some cases, the size of the error log string is not enough, so we increase it from 2048 to 4096.
