### PR TITLE
disable 408 response record any access log with empty request.

### DIFF
--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -320,8 +320,10 @@ ngx_http_log_handler(ngx_http_request_t *r)
         return NGX_OK;
     }
 
-    if (r->headers_out.status == NGX_HTTP_BAD_REQUEST && !lcf->log_empty_request
-        && (r->header_in && r->header_in->last == r->header_in->start))
+    if (!lcf->log_empty_request
+        && (r->header_in && r->header_in->last == r->header_in->start)
+        && (r->headers_out.status == NGX_HTTP_BAD_REQUEST
+            || r->headers_out.status == NGX_HTTP_REQUEST_TIME_OUT))
     {
         return NGX_OK;
     }


### PR DESCRIPTION
In SSL application, Chrome browser may establish extra connections
and doesn't send any data. This will cause a 408 record in the access.log.
Now we could disable this meaningless record with directive 'log_empty_request'.
