### PR TITLE
health check: check return value @size of send() or recv()

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -1100,10 +1100,12 @@ ngx_http_upstream_check_send_handler(ngx_event_t *event)
         }
 #endif
 
-        if (size >= 0) {
+        if (size > 0) {
             ctx->send.pos += size;
-        } else if (size == NGX_AGAIN) {
+
+        } else if (size == 0 || size == NGX_AGAIN) {
             return;
+
         } else {
             c->error = 1;
             goto check_send_fail;
@@ -1216,6 +1218,12 @@ ngx_http_upstream_check_recv_handler(ngx_event_t *event)
     switch (rc) {
 
     case NGX_AGAIN:
+        /* The peer has closed its half side of the connection. */
+        if (size == 0) {
+            ngx_http_upstream_check_status_update(peer, 0);
+            break;
+        }
+
         return;
 
     case NGX_ERROR:


### PR DESCRIPTION
- check active close from peer in ngx_http_upstream_check_recv_handler():
  
  If there is no data to receive, we finish the health check before timeout.
  Note that, without this patch, timeout handler will do it for us.
- send data later when send() returns 0 in ngx_http_upstream_check_send_handler():
  
  When the remote tcp receive buffer has been filled up or the local send
  buffer is completely full, send() could easily returns 0.
  In this case, we should send data later just like we handle NGX_AGAIN.
  
  A good example from nginx is in ngx_mail_send(), which does the same thing
  for `n == 0` and `n == NGX_AGAIN`.

This patch has been commited to https://github.com/yaoweibin/nginx_upstream_check_module/commit/fa09be5eaedd24db07518abb8517a6b10e6d7fb0
and https://github.com/yaoweibin/nginx_upstream_check_module/commit/1999558e09839f250b636fc6b21ce87ac125f207
