### PR TITLE
lua模块是支持dso的

### DIFF
--- a/auto/options
+++ b/auto/options
@@ -1,3 +1,4 @@
+
 # Copyright (C) Igor Sysoev
 # Copyright (C) Nginx, Inc.
 


### PR DESCRIPTION
Tengine的一大亮点就是LUA模块，DSO也是亮点。
但LUA模块支持模块方式在编译帮助里却没有表现出来，可能对入门学习Tengine的同学不太友好。
