### PR TITLE
Fix build process

### DIFF
--- a/auto/make
+++ b/auto/make
@@ -525,7 +525,7 @@ END
             -e "s/\//$ngx_regex_dirsep/g"`
 
         ngx_dso_link=${CORE_LINK:+`echo $CORE_LINK \
-            | sed -e "s/\//$ngx_regex_dirsep%%/g" -e "s/^/$ngx_long_regex_cont/"`}
+            | sed -e "s/\//$ngx_regex_dirsep/g" -e "s/^/$ngx_long_regex_cont/"`}
 
         ngx_dso_feture_lib=`echo $DSO_LIBS | awk 'BEGIN { FS="|" } \
             {for (i=1; i<=NF; i++) print $i}' | awk -v module_name=$ngx_shared_modules \


### PR DESCRIPTION
Without the patch build process fails on CentOS machine when eg. trying to build perl module in. I believe those 2 extra percent signs are just a typo.
