### PR TITLE
fixed proxy chunked response security problem

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1865,6 +1865,10 @@ data:
 
     }
 
+    if (ctx->size < 0 || ctx->length < 0) {
+        goto invalid;
+    }
+
     return rc;
 
 done:


### PR DESCRIPTION
http://mailman.nginx.org/pipermail/nginx-announce/2013/000114.html

A security problem related to CVE-2013-2028 was identified,
affecting some previous nginx versions if proxy_pass to
untrusted upstream HTTP servers is used.

The problem may lead to a denial of service or a disclosure of a
worker process memory on a specially crafted response from an
upstream proxied server.
