### PR TITLE
added request_non_buffered feature to http proxy and fastcgi module

### DIFF
--- a/docs/modules/ngx_http_core_module.md
+++ b/docs/modules/ngx_http_core_module.md
@@ -1,0 +1,53 @@
+# Name #
+
+**ngx\_http\_core\_module**
+
+Tengine added some enhancements to this module. The new directives are listed below.
+
+
+# Directives #
+
+## client\_body\_buffers ##
+
+Syntax: **client\_body\_buffers** `number size`
+
+Default: 16 4k/8k
+
+Context: `http, server, location`
+                                 
+Specify the number and size of buffers used when reading non buffered client request body, all the buffers are stored in the memory. Buffers are allocated only on demand. By default, the buffer size is equal to your OS's pagesize. The total buffer size should be larger than `client_body_postpone_size`, otherwise, it will be enlarged by force.
+
+## client\_body\_postpone\_size ##
+
+Syntax: **client\_body\_postpone\_size** `size`
+
+Default: 64k
+
+Context: `http, server, location`
+
+When you turn off the `proxy_request_buffering` or `fastcgi_request_buffering`, Tengine will send the body to backend either it receives more than `size` data or the whole request body has been received. It can save the connection and reduce the network system call number with backend. 
+                                 
+## proxy\_request\_buffering ##
+
+Syntax: **proxy\_request\_buffering** `on | off`
+
+Default: `on`
+
+Context: `http, server, location`
+
+Specify the request body will be buffered to the disk or not. If it's off, the request body will be stored in the memory and sent to backend after Tengine receives more than `client_body_postpone_size` data. It can avoid the disk IO with large request body.
+
+By default in the buffered mode, the whole request body larger than the `client_body_buffer_size` will always be saved into the disk. This behavior may increase the server load greatly with heavy upload application.
+
+Note that, if you turn it off, the nginx retry mechanism with unsuccessful response will be broken after you sent part of the request to backend. It just returns 500 directly when it encounters an unsuccessful response. This directive also breaks these variables: $request_body, $request_body_file. You should not use them any more while their values are incomplete.
+
+## fastcgi\_request\_buffering ##
+
+Syntax: **fastcgi\_request\_buffering** `on | off`
+
+Default: `on`
+
+Context: `http, server, location`
+
+The same as `proxy_request_buffering`.
+

--- a/docs/modules/ngx_http_core_module_cn.md
+++ b/docs/modules/ngx_http_core_module_cn.md
@@ -1,0 +1,53 @@
+# 模块名 #
+
+**ngx\_http\_core\_module**
+
+Tengine针对此模块进行了增强，下面列出了一些增加的指令。
+
+
+# 指令 #
+
+## client\_body\_buffers ##
+
+Syntax: **client\_body\_buffers** `number size`
+
+Default: 16 4k/8k
+
+Context: `http, server, location`
+                                 
+当不缓存上传的请求body到磁盘时，指定每块缓存块大小和数量。所有的缓存块都保存在内存中，并且是按需分配的。默认情况下，缓存块等于系统页的大小。总缓存大小必须大于`client_body_postpone_size`指令的大小。
+
+## client\_body\_postpone\_size ##
+
+Syntax: **client\_body\_postpone\_size** `size`
+
+Default: 64k
+
+Context: `http, server, location`
+
+当打开`proxy_request_buffering`或`fastcgi_request_buffering`指令，设置不缓存请求body到磁盘时，tengine每当接受到大于`client_body_postpone_size`大小的数据或者整个请求都发送完毕，才会往后端发送数据。这可以减少与后端服务器建立的连接数，并减少网络IO的次数。
+                                 
+## proxy\_request\_buffering ##
+
+Syntax: **proxy\_request\_buffering** `on | off`
+
+Default: `on`
+
+Context: `http, server, location`
+
+指定当上传请求body时是否要将body缓存到磁盘。如果设成off，请求body只会被保存到内存，每当tengine接收到大于`client_body_postpone_size`的数据时，就发送这部分数据到后端服务器。
+
+默认情况下，当请求body大于`client_body_buffer_size`时，就会被保存到磁盘。这会增加磁盘IO，对于上传应用来说，服务器的负载会明显增加。
+
+需要注意的是，如果你配置成off且已经发出部分数据，tengine的重试机制就会失效。如果后端返回异常响应，tengine就会直接返回500。此时$request_body，$request_body_file也会不可用，他们保存的可能是不完整的内容。
+
+## fastcgi\_request\_buffering ##
+
+Syntax: **fastcgi\_request\_buffering** `on | off`
+
+Default: `on`
+
+Context: `http, server, location`
+
+用法跟`proxy_request_buffering`指令一样。
+

--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -66,8 +66,10 @@ typedef struct {
     u_char                        *last;
     ngx_uint_t                     type;
     size_t                         length;
+    size_t                         output_padding;
     size_t                         padding;
 
+    unsigned                       output_done:1;
     unsigned                       fastcgi_stdout:1;
     unsigned                       large_stderr:1;
 
@@ -132,9 +134,12 @@ static ngx_int_t ngx_http_fastcgi_eval(ngx_http_request_t *r,
 #if (NGX_HTTP_CACHE)
 static ngx_int_t ngx_http_fastcgi_create_key(ngx_http_request_t *r);
 #endif
+static void ngx_http_fastcgi_last_record(ngx_http_fastcgi_header_t *h);
 static ngx_int_t ngx_http_fastcgi_create_request(ngx_http_request_t *r);
 static ngx_int_t ngx_http_fastcgi_reinit_request(ngx_http_request_t *r);
 static ngx_int_t ngx_http_fastcgi_process_header(ngx_http_request_t *r);
+static ngx_int_t ngx_http_fastcgi_output_filter_init(void *data);
+static ngx_int_t ngx_http_fastcgi_output_filter(void *data, ngx_chain_t *in);
 static ngx_int_t ngx_http_fastcgi_input_filter_init(void *data);
 static ngx_int_t ngx_http_fastcgi_input_filter(ngx_event_pipe_t *p,
     ngx_buf_t *buf);
@@ -230,6 +235,13 @@ static ngx_command_t  ngx_http_fastcgi_commands[] = {
       ngx_conf_set_access_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_fastcgi_loc_conf_t, upstream.store_access),
+      NULL },
+
+    { ngx_string("fastcgi_request_buffering"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_fastcgi_loc_conf_t, upstream.request_buffering),
       NULL },
 
     { ngx_string("fastcgi_ignore_client_abort"),
@@ -620,6 +632,17 @@ ngx_http_fastcgi_handler(ngx_http_request_t *r)
     u->abort_request = ngx_http_fastcgi_abort_request;
     u->finalize_request = ngx_http_fastcgi_finalize_request;
     r->state = 0;
+
+    r->request_buffering = flcf->upstream.request_buffering;
+    if (r->headers_in.content_length_n <= 0) {
+        r->request_buffering = 1;
+    }
+
+    if (!r->request_buffering) {
+        u->output_filter_init = ngx_http_fastcgi_output_filter_init;
+        u->output_filter = ngx_http_fastcgi_output_filter;
+        u->output_filter_ctx = r;
+    }
 
     u->buffering = 1;
 
@@ -1057,8 +1080,14 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
     h->padding_length = 0;
     h->reserved = 0;
 
-    h = (ngx_http_fastcgi_header_t *) b->last;
-    b->last += sizeof(ngx_http_fastcgi_header_t);
+    /*
+     * Don't send the last FASTCGI_STDIN record, It will be sent in the
+     * output filter
+     */
+    if (r->request_buffering) {
+        h = (ngx_http_fastcgi_header_t *) b->last;
+        b->last += sizeof(ngx_http_fastcgi_header_t);
+    }
 
     if (flcf->upstream.pass_request_body) {
         body = r->upstream->request_bufs;
@@ -1165,6 +1194,19 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
         r->upstream->request_bufs = cl;
     }
 
+    if (r->request_buffering) {
+        ngx_http_fastcgi_last_record(h);
+    }
+
+    cl->next = NULL;
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_fastcgi_last_record(ngx_http_fastcgi_header_t *h)
+{
     h->version = 1;
     h->type = NGX_HTTP_FASTCGI_STDIN;
     h->request_id_hi = 0;
@@ -1173,10 +1215,6 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
     h->content_length_lo = 0;
     h->padding_length = 0;
     h->reserved = 0;
-
-    cl->next = NULL;
-
-    return NGX_OK;
 }
 
 
@@ -1196,6 +1234,188 @@ ngx_http_fastcgi_reinit_request(ngx_http_request_t *r)
     f->large_stderr = 0;
 
     r->state = 0;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_fastcgi_output_filter_init(void *data)
+{
+    ngx_http_request_t      *r = data;
+
+    /*
+     * Remove the r->request_body from request_bufs.
+     * This part buffer will be processed in the output filter.
+     */
+    r->upstream->request_bufs = NULL;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_fastcgi_output_filter(void *data, ngx_chain_t *in)
+{
+    size_t                     len, padding;
+    ngx_buf_t                 *b;
+    ngx_uint_t                 split;
+    ngx_chain_t              **last_out, *cl;
+    ngx_http_request_t        *r = data;
+    ngx_http_fastcgi_ctx_t    *f;
+    ngx_http_request_body_t   *rb;
+    ngx_http_fastcgi_header_t *h;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http fastcgi output filter");
+
+    f = ngx_http_get_module_ctx(r, ngx_http_fastcgi_module);
+    rb = r->request_body;
+
+    if (r->upstream->request_bufs == NULL) {
+        last_out = &r->upstream->request_bufs;
+    } else {
+        cl = r->upstream->request_bufs;
+
+        while (cl->next) {
+            cl = cl->next;
+        }
+
+        last_out = &cl->next;
+    }
+
+    if (in == NULL) {
+
+        if (!f->output_done && rb->rest == 0) {
+            goto last_chunk;
+        }
+
+        return NGX_OK;
+    }
+
+    while (in) {
+
+        split = 0;
+
+        len = ngx_buf_size(in->buf);
+        if (len == 0) {
+            in = in->next;
+            continue;
+        }
+
+        /*
+         * limit the output buffer to be 32k, fastcgi record can't be
+         * larger than 64k.
+         */
+        if (len > 32768) {
+            split = 1;
+            len = 32768;
+        }
+
+        cl = ngx_alloc_chain_link(r->pool);
+        if (cl == NULL) {
+            return NGX_ERROR;
+        }
+
+        *last_out = cl;
+        last_out = &cl->next;
+
+        b = ngx_create_temp_buf(r->pool,
+                sizeof(ngx_http_fastcgi_header_t) + f->output_padding);
+        if (b == NULL) {
+            return NGX_ERROR;
+        }
+
+        cl->buf = b;
+
+        if (f->output_padding) {
+            ngx_memzero(b->last, f->output_padding);
+            b->last += f->output_padding;
+            f->output_padding = 0;
+        }
+
+        h = (ngx_http_fastcgi_header_t *) b->last;
+        b->last += sizeof(ngx_http_fastcgi_header_t);
+
+        padding = 8 - len % 8;
+        padding = (padding == 8) ? 0 : padding;
+
+        h->version = 1;
+        h->type = NGX_HTTP_FASTCGI_STDIN;
+        h->request_id_hi = 0;
+        h->request_id_lo = 1;
+        h->content_length_hi = (u_char) ((len >> 8) & 0xff);
+        h->content_length_lo = (u_char) (len & 0xff);
+        h->padding_length = (u_char) padding;
+        h->reserved = 0;
+
+        f->output_padding = padding;
+
+        cl = ngx_alloc_chain_link(r->pool);
+        if (cl == NULL) {
+            return NGX_ERROR;
+        }
+
+        *last_out = cl;
+        last_out = &cl->next;
+
+        if (!split) {
+            cl->buf = in->buf;
+        } else {
+            b = ngx_calloc_buf(r->pool);
+            if (b == NULL) {
+                return NGX_ERROR;
+            }
+
+            cl->buf = b;
+
+            b->temporary = 1;
+            b->start = b->pos = in->buf->pos;
+            b->end = b->last = in->buf->pos + len;
+
+            in->buf->pos = in->buf->pos + len;
+
+            continue;
+        }
+
+        in = in->next;
+    }
+
+    if (rb->rest) {
+        *last_out = NULL;
+        return NGX_OK;
+    }
+
+last_chunk:
+
+    cl = ngx_alloc_chain_link(r->pool);
+    if (cl == NULL) {
+        return NGX_ERROR;
+    }
+
+    *last_out = cl;
+
+    b = ngx_create_temp_buf(r->pool, sizeof(ngx_http_fastcgi_header_t)
+                                     + f->output_padding);
+    if (b == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (f->output_padding) {
+        ngx_memzero(b->last, f->output_padding);
+        b->last += f->output_padding;
+        f->output_padding = 0;
+    }
+
+    h = (ngx_http_fastcgi_header_t *) b->last;
+    b->last += sizeof(ngx_http_fastcgi_header_t);
+
+    ngx_http_fastcgi_last_record(h);
+
+    cl->buf = b;
+    cl->next = NULL;
+
+    f->output_done = 1;
 
     return NGX_OK;
 }
@@ -2088,6 +2308,7 @@ ngx_http_fastcgi_create_loc_conf(ngx_conf_t *cf)
 
     conf->upstream.store = NGX_CONF_UNSET;
     conf->upstream.store_access = NGX_CONF_UNSET_UINT;
+    conf->upstream.request_buffering = NGX_CONF_UNSET;
     conf->upstream.buffering = NGX_CONF_UNSET;
     conf->upstream.ignore_client_abort = NGX_CONF_UNSET;
 
@@ -2157,6 +2378,9 @@ ngx_http_fastcgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_uint_value(conf->upstream.store_access,
                               prev->upstream.store_access, 0600);
+
+    ngx_conf_merge_value(conf->upstream.request_buffering,
+                         prev->upstream.request_buffering, 1);
 
     ngx_conf_merge_value(conf->upstream.buffering,
                               prev->upstream.buffering, 1);

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -120,6 +120,8 @@ ngx_int_t ngx_http_send_special(ngx_http_request_t *r, ngx_uint_t flags);
 
 ngx_int_t ngx_http_read_client_request_body(ngx_http_request_t *r,
     ngx_http_client_body_handler_pt post_handler);
+ngx_int_t ngx_http_do_read_non_buffered_client_request_body(
+    ngx_http_request_t *r);
 
 ngx_int_t ngx_http_send_header(ngx_http_request_t *r);
 ngx_int_t ngx_http_special_response_handler(ngx_http_request_t *r,

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -379,6 +379,20 @@ static ngx_command_t  ngx_http_core_commands[] = {
       offsetof(ngx_http_core_loc_conf_t, client_body_buffer_size),
       NULL },
 
+    { ngx_string("client_body_buffers"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
+      ngx_conf_set_bufs_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_core_loc_conf_t, client_body_buffers),
+      NULL },
+
+    { ngx_string("client_body_postpone_size"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_core_loc_conf_t, client_body_postpone_size),
+      NULL },
+
     { ngx_string("client_body_timeout"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_msec_slot,
@@ -3495,6 +3509,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
      *     clcf->default_type = { 0, NULL };
      *     clcf->error_log = NULL;
      *     clcf->try_files = NULL;
+     *     clcf->client_body_buffers = { 0, 0 };
      *     clcf->client_body_path = NULL;
      *     clcf->regex = NULL;
      *     clcf->exact_match = 0;
@@ -3509,6 +3524,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
     clcf->error_pages = NGX_CONF_UNSET_PTR;
     clcf->client_max_body_size = NGX_CONF_UNSET;
     clcf->client_body_buffer_size = NGX_CONF_UNSET_SIZE;
+    clcf->client_body_postpone_size = NGX_CONF_UNSET_SIZE;
     clcf->client_body_timeout = NGX_CONF_UNSET_MSEC;
     clcf->satisfy = NGX_CONF_UNSET_UINT;
     clcf->if_modified_since = NGX_CONF_UNSET_UINT;
@@ -3775,6 +3791,53 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_size_value(conf->client_body_buffer_size,
                               prev->client_body_buffer_size,
                               (size_t) 2 * ngx_pagesize);
+    ngx_conf_merge_bufs_value(conf->client_body_buffers,
+                              prev->client_body_buffers,
+                              16, ngx_pagesize);
+
+    if (conf->client_body_buffers.num < 2) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "there must be at least 2 \"client_body_buffers\"");
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_conf_merge_size_value(conf->client_body_postpone_size,
+                              prev->client_body_postpone_size,
+                              64 * 1024);
+
+    if (conf->client_max_body_size <
+        (off_t)(conf->client_body_buffers.num *
+                conf->client_body_buffers.size)) {
+
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "client_max_body_size %O should be greater than "
+                           "total postpone buffer size %O",
+                           conf->client_max_body_size,
+                           (off_t)(conf->client_body_buffers.num *
+                                   conf->client_body_buffers.size));
+
+        conf->client_body_buffers.num = 1 + (conf->client_max_body_size /
+                                             conf->client_body_buffers.size);
+    }
+
+    if ((off_t)conf->client_body_postpone_size > conf->client_max_body_size) {
+        conf->client_body_postpone_size = conf->client_max_body_size;
+    }
+
+    if (conf->client_body_postpone_size >
+        (conf->client_body_buffers.num * conf->client_body_buffers.size)) {
+
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "client_body_postpone_size %uz should be less "
+                           "than total postpone buffer size %O",
+                           conf->client_body_postpone_size,
+                           (off_t)(conf->client_body_buffers.num *
+                                   conf->client_body_buffers.size));
+
+        conf->client_body_buffers.num = 1 + (conf->client_body_postpone_size /
+                                             conf->client_body_buffers.size);
+    }
+
     ngx_conf_merge_msec_value(conf->client_body_timeout,
                               prev->client_body_timeout, 60000);
 

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -355,6 +355,8 @@ struct ngx_http_core_loc_conf_s {
     off_t         directio;                /* directio */
     off_t         directio_alignment;      /* directio_alignment */
 
+    ngx_bufs_t    client_body_buffers;
+    size_t        client_body_postpone_size;
     size_t        client_body_buffer_size; /* client_body_buffer_size */
     size_t        send_lowat;              /* send_lowat */
     size_t        postpone_output;         /* postpone_output */

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -507,6 +507,8 @@ ngx_http_init_request(ngx_event_t *rev)
 
     r->method = NGX_HTTP_UNKNOWN;
 
+    r->request_buffering = 1;
+
     r->headers_in.content_length_n = -1;
     r->headers_in.keep_alive_n = -1;
     r->headers_out.content_length_n = -1;

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -283,6 +283,18 @@ typedef struct {
     off_t                             rest;
     ngx_chain_t                      *to_write;
     ngx_http_client_body_handler_pt   post_handler;
+
+    /* For non buffered request body */
+    ngx_chain_t                      *out;
+    ngx_chain_t                      *busy;
+    ngx_chain_t                      *free;
+    ngx_chain_t                      *last;
+    ngx_chain_t                     **last_out;
+    off_t                             postpone_size;
+    ngx_int_t                         num;
+    unsigned                          buffered:1;
+    unsigned                          flush:1;
+    unsigned                          nomem:1;
 } ngx_http_request_body_t;
 
 
@@ -461,6 +473,7 @@ struct ngx_http_request_s {
     unsigned                          uri_changed:1;
     unsigned                          uri_changes:4;
 
+    unsigned                          request_buffering:1;
     unsigned                          request_body_in_single_buf:1;
     unsigned                          request_body_in_file_only:1;
     unsigned                          request_body_in_persistent_file:1;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -13,6 +13,12 @@ static void ngx_http_read_client_request_body_handler(ngx_http_request_t *r);
 static ngx_int_t ngx_http_do_read_client_request_body(ngx_http_request_t *r);
 static ngx_int_t ngx_http_write_request_body(ngx_http_request_t *r,
     ngx_chain_t *body);
+
+static ngx_int_t ngx_http_read_non_buffered_client_request_body(
+    ngx_http_request_t *r, ngx_http_client_body_handler_pt post_handler);
+static void ngx_http_read_non_buffered_client_request_body_handler(
+    ngx_http_request_t *r);
+static ngx_int_t ngx_http_request_body_get_buf(ngx_http_request_t *r);
 static ngx_int_t ngx_http_read_discarded_request_body(ngx_http_request_t *r);
 static ngx_int_t ngx_http_test_expect(ngx_http_request_t *r);
 
@@ -61,6 +67,10 @@ ngx_http_read_client_request_body(ngx_http_request_t *r,
         return NGX_OK;
     }
 
+    if (!r->request_buffering) {
+        return ngx_http_read_non_buffered_client_request_body(r, post_handler);
+    }
+
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
     if (r->headers_in.content_length_n == 0) {
@@ -85,6 +95,8 @@ ngx_http_read_client_request_body(ngx_http_request_t *r,
      *     rb->bufs = NULL;
      *     rb->buf = NULL;
      *     rb->rest = 0;
+     *     rb->postpone_size = 0;
+     *     rb->num = 0;
      */
 
     preread = r->header_in->last - r->header_in->pos;
@@ -489,6 +501,334 @@ ngx_http_write_request_body(ngx_http_request_t *r, ngx_chain_t *body)
     }
 
     rb->temp_file->offset += n;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_read_non_buffered_client_request_body(ngx_http_request_t *r,
+    ngx_http_client_body_handler_pt post_handler)
+{
+    size_t                     preread;
+    ngx_buf_t                 *b, buf;
+    ngx_int_t                  rc;
+    ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (r->headers_in.content_length_n == 0) {
+        post_handler(r);
+        return NGX_OK;
+    }
+
+    rb = r->request_body;
+
+    rb->post_handler = post_handler;
+
+    preread = r->header_in->last - r->header_in->pos;
+
+    if (preread) {
+
+        /* there is the pre-read part of the request body */
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http client no buffered request body preread %uz",
+                       preread);
+
+        b = ngx_calloc_buf(r->pool);
+        if (b == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        b->temporary = 1;
+        b->start = r->header_in->pos;
+        b->pos = r->header_in->pos;
+        b->last = r->header_in->last;
+        b->end = r->header_in->end;
+
+        buf.start = r->header_in->pos;
+        buf.pos = r->header_in->pos;
+        buf.last = (off_t) preread >= r->headers_in.content_length_n
+                 ? r->header_in->pos + (size_t) r->headers_in.content_length_n
+                 : r->header_in->last;
+        buf.end = r->header_in->end;
+
+        rc = ngx_http_top_input_body_filter(r, &buf);
+        if (rc != NGX_OK) {
+            return rc;
+        }
+
+        rb->bufs = ngx_alloc_chain_link(r->pool);
+        if (rb->bufs == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        rb->bufs->buf = b;
+        rb->bufs->next = NULL;
+
+        rb->buf = b;
+
+        if ((off_t) preread >= r->headers_in.content_length_n) {
+
+            /* the whole request body was pre-read */
+
+            r->header_in->pos += (size_t) r->headers_in.content_length_n;
+            r->request_length += r->headers_in.content_length_n;
+            b->last = r->header_in->pos;
+            b->last_buf = 1;
+
+            post_handler(r);
+
+            return NGX_OK;
+        }
+
+        /*
+         * to not consider the body as pipelined request in
+         * ngx_http_set_keepalive()
+         */
+        r->header_in->pos = r->header_in->last;
+
+        r->request_length += preread;
+
+        rb->rest = r->headers_in.content_length_n - preread;
+
+        if (rb->rest <= (off_t) (b->end - b->last)) {
+
+            /* the whole request body could be placed in r->header_in */
+            goto read_body;
+        }
+
+        rb->last_out = &rb->bufs->next;
+
+    } else {
+        rb->rest = r->headers_in.content_length_n;
+        rb->last_out = &rb->bufs;
+    }
+
+read_body:
+
+    rb->buffered = 1;
+    rb->postpone_size = preread;
+
+    rc = ngx_http_do_read_non_buffered_client_request_body(r);
+
+    if (rc == NGX_AGAIN) {
+
+        if (rb->buffered) {
+            r->read_event_handler =
+                ngx_http_read_non_buffered_client_request_body_handler;
+        }
+
+    } else if (rc == NGX_OK || rc == NGX_DECLINED) {
+        post_handler(r);
+    }
+
+    return rc;
+}
+
+
+static void
+ngx_http_read_non_buffered_client_request_body_handler(ngx_http_request_t *r)
+{
+    ngx_int_t  rc;
+
+    if (r->connection->read->timedout) {
+        r->connection->timedout = 1;
+        ngx_http_finalize_request(r, NGX_HTTP_REQUEST_TIME_OUT);
+        return;
+    }
+
+    rc = ngx_http_do_read_non_buffered_client_request_body(r);
+
+    if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+        ngx_http_finalize_request(r, rc);
+    }
+
+    if (rc == NGX_OK || rc == NGX_DECLINED) {
+        r->request_body->post_handler(r);
+    }
+}
+
+
+ngx_int_t
+ngx_http_do_read_non_buffered_client_request_body(ngx_http_request_t *r)
+{
+    size_t                     size;
+    ssize_t                    n;
+    ngx_buf_t                  buf;
+    ngx_int_t                  rc;
+    ngx_connection_t          *c;
+    ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    c = r->connection;
+    rb = r->request_body;
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http read no buffered client request body");
+
+    for ( ;; ) {
+        for ( ;; ) {
+
+            if ((rb->buf == NULL) || (rb->buf->end == rb->buf->last)) {
+
+                rc = ngx_http_request_body_get_buf(r);
+
+                if (rc == NGX_ERROR) {
+                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+
+                } else if (rc == NGX_DECLINED) {
+
+                    /* The buffers are full */
+                    return NGX_DECLINED;
+                }
+            }
+
+            size = rb->buf->end - rb->buf->last;
+
+            if ((off_t) size > rb->rest) {
+                size = (size_t) rb->rest;
+            }
+
+            n = c->recv(c, rb->buf->last, size);
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http no buffered client request body recv %z",
+                           n);
+
+            if (n == NGX_AGAIN) {
+                break;
+            }
+
+            if (n == 0) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client prematurely closed connection");
+            }
+
+            if (n == 0 || n == NGX_ERROR) {
+                c->error = 1;
+                return NGX_HTTP_BAD_REQUEST;
+            }
+
+            if (rb->last) {
+                *rb->last_out = rb->last;
+                rb->last_out = &rb->last->next;
+                rb->last = NULL;
+            }
+
+            buf.start = rb->buf->last;
+            buf.pos = rb->buf->last;
+            buf.last = buf.start + n;
+            buf.end = buf.last;
+
+            rc = ngx_http_top_input_body_filter(r, &buf);
+            if (rc != NGX_OK) {
+                return rc;
+            }
+
+            rb->buf->last += n;
+            rb->rest -= n;
+            r->request_length += n;
+            rb->postpone_size += n;
+
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http no buffered client request body "
+                           "request_length: %O, rest: %uz, postpone_size: %O",
+                           r->request_length, rb->rest, rb->postpone_size);
+
+            if (rb->rest == 0) {
+                rb->buf->last_buf = 1;
+                goto read_ok;
+            }
+
+            if (rb->postpone_size >= (off_t) clcf->client_body_postpone_size) {
+
+                rb->flush = 1;
+
+                if (rb->buffered) {
+                    goto read_ok;
+                }
+
+                return NGX_DECLINED;
+            }
+        }
+
+        if (!c->read->ready) {
+            ngx_add_timer(c->read, clcf->client_body_timeout);
+
+            if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
+
+            return NGX_AGAIN;
+        }
+    }
+
+read_ok:
+
+    /*
+     * All the request body is read or the postpone_size is larger than the
+     * client_body_postpone_size, we should call the post_handler if this
+     * request is still buffered.
+     */
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+    r->read_event_handler = ngx_http_block_reading;
+
+    rb->buffered = 0;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_request_body_get_buf(ngx_http_request_t *r)
+{
+    ngx_chain_t               *cl;
+    ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    rb = r->request_body;
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (rb->free) {
+
+        cl = rb->free;
+        rb->free = rb->free->next;
+
+    } else {
+
+        if (rb->num >= clcf->client_body_buffers.num) {
+            rb->nomem = 1;
+            return NGX_DECLINED;
+        }
+
+        cl = ngx_alloc_chain_link(r->pool);
+        if (cl == NULL) {
+            return NGX_ERROR;
+        }
+
+        cl->buf = ngx_create_temp_buf(r->pool, clcf->client_body_buffers.size);
+        if (cl->buf == NULL) {
+            return NGX_ERROR;
+        }
+
+        cl->buf->tag = (ngx_buf_tag_t) &ngx_http_core_module;
+        cl->buf->recycled = 1;
+
+        rb->num++;
+    }
+
+    cl->next = NULL;
+
+    rb->buf = cl->buf;
+    rb->last = cl;
 
     return NGX_OK;
 }

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -31,8 +31,14 @@ static ngx_int_t ngx_http_upstream_reinit(ngx_http_request_t *r,
     ngx_http_upstream_t *u);
 static void ngx_http_upstream_send_request(ngx_http_request_t *r,
     ngx_http_upstream_t *u);
+static ngx_int_t ngx_http_upstream_output_filter_init(void *data);
+static ngx_int_t ngx_http_upstream_output_filter(void *data,
+    ngx_chain_t *in);
 static void ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
     ngx_http_upstream_t *u);
+static void ngx_http_upstream_send_non_buffered_request(ngx_http_request_t *r,
+    ngx_http_upstream_t *u);
+static void ngx_http_upstream_read_non_buffered_request(ngx_http_request_t *r);
 static void ngx_http_upstream_process_header(ngx_http_request_t *r,
     ngx_http_upstream_t *u);
 static ngx_int_t ngx_http_upstream_test_next(ngx_http_request_t *r,
@@ -503,6 +509,18 @@ ngx_http_upstream_init_request(ngx_http_request_t *r)
 
     if (r->request_body) {
         u->request_bufs = r->request_body->bufs;
+    }
+
+    if (!u->output_filter) {
+        u->output_filter_init = ngx_http_upstream_output_filter_init;
+        u->output_filter = ngx_http_upstream_output_filter;
+        u->output_filter_ctx = r;
+    }
+
+    if (u->output_filter_init && u->output_filter_init(u->output_filter_ctx)
+       != NGX_OK) {
+        ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return;
     }
 
     if (u->create_request(r) != NGX_OK) {
@@ -1199,6 +1217,17 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
     u->writer.limit = 0;
 
     if (u->request_sent) {
+
+        /*
+         * no buffering request can't reuse the request body when part of
+         * the body has been sent.
+         */
+        if (!r->request_buffering) {
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_BAD_GATEWAY);
+            return;
+        }
+
         if (ngx_http_upstream_reinit(r, u) != NGX_OK) {
             ngx_http_upstream_finalize_request(r, u,
                                                NGX_HTTP_INTERNAL_SERVER_ERROR);
@@ -1247,6 +1276,11 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
     }
 
 #endif
+
+    if (!r->request_buffering) {
+        ngx_http_upstream_send_non_buffered_request(r, u);
+        return;
+    }
 
     ngx_http_upstream_send_request(r, u);
 }
@@ -1310,6 +1344,11 @@ ngx_http_upstream_ssl_handshake(ngx_connection_t *c)
 
         c->write->handler = ngx_http_upstream_handler;
         c->read->handler = ngx_http_upstream_handler;
+
+        if (!r->request_buffering) {
+            ngx_http_upstream_send_non_buffered_request(r, u);
+            return;
+        }
 
         ngx_http_upstream_send_request(r, u);
 
@@ -1476,6 +1515,288 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u)
 }
 
 
+static ngx_int_t
+ngx_http_upstream_output_filter_init(void *data)
+{
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_output_filter(void *data, ngx_chain_t *in)
+{
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_upstream_send_non_buffered_request(ngx_http_request_t *r,
+    ngx_http_upstream_t *u)
+{
+    int                        tcp_nodelay;
+    ngx_int_t                  rc;
+    ngx_connection_t          *c;
+    ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    c = u->peer.connection;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http upstream read/send no buffered request");
+
+    if (!u->request_sent && ngx_http_upstream_test_connect(c) != NGX_OK) {
+        ngx_http_upstream_next(r, u, NGX_HTTP_UPSTREAM_FT_ERROR);
+        return;
+    }
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (clcf->tcp_nodelay && c->tcp_nodelay == NGX_TCP_NODELAY_UNSET) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "upstream tcp_nodelay");
+
+        tcp_nodelay = 1;
+
+        if (setsockopt(c->fd, IPPROTO_TCP, TCP_NODELAY,
+                           (const void *) &tcp_nodelay, sizeof(int)) == -1)
+        {
+            ngx_connection_error(c, ngx_socket_errno,
+                                 "setsockopt(TCP_NODELAY) failed");
+            ngx_http_upstream_finalize_request(r, u, 0);
+            return;
+        }
+
+        c->tcp_nodelay = NGX_TCP_NODELAY_SET;
+    }
+
+    rb = r->request_body;
+
+    for ( ;; ) {
+
+        if (rb == NULL) {
+
+            c->log->action = "sending no buffered request to upstream";
+
+            rc = ngx_output_chain(&u->output,
+                                  u->request_sent ? NULL : u->request_bufs);
+
+            goto send_done;
+        }
+
+        if (u->request_sent && rb->rest) {
+            c->log->action = "reading no buffered request body from client";
+
+            rc = ngx_http_do_read_non_buffered_client_request_body(r);
+
+            if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+                ngx_http_upstream_finalize_request(r, u, rc);
+                return;
+            }
+
+            if (!(rb->busy || rb->flush || rb->nomem || rb->rest == 0)) {
+
+                if (c->write->timer_set) {
+                    ngx_del_timer(c->write);
+                }
+
+                /*
+                 * the read timer has been added in the above
+                 * ngx_http_do_read_non_buffered_client_request_body()
+                 * function
+                 */
+
+                r->read_event_handler =
+                    ngx_http_upstream_read_non_buffered_request;
+
+                if (ngx_handle_read_event(r->connection->read, 0) != NGX_OK) {
+                    ngx_http_upstream_finalize_request(r, u,
+                                           NGX_HTTP_INTERNAL_SERVER_ERROR);
+                }
+
+                return;
+            }
+        }
+
+        c->log->action = "sending no buffered request to upstream";
+
+#if (NGX_DEBUG)
+        ngx_buf_t   *buf;
+        ngx_chain_t *cl;
+
+        for (cl = u->request_bufs; cl; cl = cl->next) {
+            buf = cl->buf;
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                          "http upstream before out bufs: p=%p, s=%d, size=%uO",
+                          buf, ngx_buf_special(buf), ngx_buf_size(buf));
+        }
+
+        for (cl = rb->bufs; cl; cl = cl->next) {
+            buf = cl->buf;
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                          "http upstream before rb->bufs: p=%p, s=%d, size=%uO",
+                          buf, ngx_buf_special(buf), ngx_buf_size(buf));
+        }
+
+#endif
+        if (u->output_filter(u->output_filter_ctx, rb->bufs) != NGX_OK) {
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+
+            return;
+        }
+
+#if (NGX_DEBUG)
+        for (cl = u->request_bufs; cl; cl = cl->next) {
+            buf = cl->buf;
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http upstream send out bufs: p=%p, s=%d, size=%uO",
+                           buf, ngx_buf_special(buf), ngx_buf_size(buf));
+        }
+#endif
+
+        rc = ngx_output_chain(&u->output, u->request_bufs);
+
+        /* Flush the buffer for sure. It may be stucked in the SSL buffer. */
+        if (rc == NGX_AGAIN && c->buffered) {
+            rc = ngx_output_chain(&u->output, NULL);
+        }
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "http upstream send no buffered request: rc=%i", rc);
+
+        ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &u->request_bufs,
+                               (ngx_buf_tag_t) &ngx_http_core_module);
+
+#if (NGX_DEBUG)
+        for (cl = rb->busy; cl; cl = cl->next) {
+            buf = cl->buf;
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http upstream send busy bufs: p=%p, s=%d, size=%uO",
+                           buf, ngx_buf_special(buf), ngx_buf_size(buf));
+        }
+
+        for (cl = rb->free; cl; cl = cl->next) {
+            buf = cl->buf;
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http upstream send free bufs: p=%p, s=%d, size=%uO",
+                           buf, ngx_buf_special(buf), ngx_buf_size(buf));
+        }
+#endif
+
+        rb->bufs = NULL;
+        rb->buf = NULL;
+        rb->last_out = &rb->bufs;
+        rb->postpone_size = 0;
+        rb->nomem = 0;
+        rb->flush = 0;
+        u->request_bufs = NULL;
+
+send_done:
+
+        u->request_sent = 1;
+
+        if (rc == NGX_ERROR) {
+
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+
+            return;
+        }
+
+        if (r->connection->read->timer_set) {
+            ngx_del_timer(r->connection->read);
+        }
+
+        if (c->write->timer_set) {
+            ngx_del_timer(c->write);
+        }
+
+        if (rc == NGX_AGAIN) {
+            ngx_add_timer(c->write, u->conf->send_timeout);
+
+            if (ngx_handle_write_event(c->write, u->conf->send_lowat)
+                != NGX_OK) {
+                ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            return;
+        }
+
+        /* rc == NGX_OK */
+
+        if (rb == NULL || rb->rest == 0) {
+            break;
+        }
+    }
+
+    /* send all the request body */
+
+    if (!u->store && !r->post_action && !u->conf->ignore_client_abort) {
+        r->read_event_handler = ngx_http_upstream_rd_check_broken_connection;
+    }
+
+    if (c->tcp_nopush == NGX_TCP_NOPUSH_SET) {
+        if (ngx_tcp_push(c->fd) == NGX_ERROR) {
+            ngx_log_error(NGX_LOG_CRIT, c->log, ngx_socket_errno,
+                          ngx_tcp_push_n " failed");
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        c->tcp_nopush = NGX_TCP_NOPUSH_UNSET;
+    }
+
+    ngx_add_timer(c->read, u->conf->read_timeout);
+
+#if 1
+    if (c->read->ready) {
+
+        /* post aio operation */
+
+        /*
+         * TODO comment
+         * although we can post aio operation just in the end
+         * of ngx_http_upstream_connect() CHECK IT !!!
+         * it's better to do here because we postpone header buffer allocation
+         */
+
+        ngx_http_upstream_process_header(r, u);
+        return;
+    }
+#endif
+
+    u->write_event_handler = ngx_http_upstream_dummy_handler;
+
+    if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
+        ngx_http_upstream_finalize_request(r, u,
+                                           NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return;
+    }
+}
+
+
+static void
+ngx_http_upstream_read_non_buffered_request(ngx_http_request_t *r)
+{
+    ngx_connection_t     *c;
+    ngx_http_upstream_t  *u;
+
+    c = r->connection;
+    u = r->upstream;
+
+    if (c->read->timedout) {
+        c->timedout = 1;
+        ngx_connection_error(c, NGX_ETIMEDOUT, "client timed out");
+        ngx_http_upstream_finalize_request(r, u, NGX_HTTP_REQUEST_TIME_OUT);
+        return;
+    }
+
+    ngx_http_upstream_send_non_buffered_request(r, u);
+}
+
+
 static void
 ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
     ngx_http_upstream_t *u)
@@ -1506,6 +1827,11 @@ ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
 
         (void) ngx_handle_write_event(c->write, 0);
 
+        return;
+    }
+
+    if (!r->request_buffering) {
+        ngx_http_upstream_send_non_buffered_request(r, u);
         return;
     }
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -157,6 +157,7 @@ typedef struct {
     ngx_uint_t                       ignore_headers;
     ngx_uint_t                       next_upstream;
     ngx_uint_t                       store_access;
+    ngx_flag_t                       request_buffering;
     ngx_flag_t                       buffering;
     ngx_flag_t                       pass_request_headers;
     ngx_flag_t                       pass_request_body;
@@ -298,6 +299,13 @@ struct ngx_http_upstream_s {
     ngx_chain_t                     *busy_bufs;
     ngx_chain_t                     *free_bufs;
 
+    /* Nginx => Upstream */
+    ngx_int_t                      (*output_filter_init)(void *data);
+    ngx_int_t                      (*output_filter)(void *data,
+                                         ngx_chain_t *in);
+    void                            *output_filter_ctx;
+
+    /* Upstream => Nginx */
     ngx_int_t                      (*input_filter_init)(void *data);
     ngx_int_t                      (*input_filter)(void *data, ssize_t bytes);
     void                            *input_filter_ctx;

--- a/tests/nginx-tests/cases/fastcgi_no_buffering.t
+++ b/tests/nginx-tests/cases/fastcgi_no_buffering.t
@@ -1,0 +1,477 @@
+#!/usr/bin/perl
+
+# Test for fastcgi backend.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval { require FCGI; };
+plan(skip_all => 'FCGI not installed') if $@;
+plan(skip_all => 'win32') if $^O eq 'MSWin32';
+
+my $t = Test::Nginx->new()->has(qw/http fastcgi/)->plan(53);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        client_max_body_size 200M;
+
+        location / {
+            fastcgi_request_buffering off;
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+
+        location /buffer {
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+    }
+}
+
+EOF
+
+$t->run_daemon(\&fastcgi_daemon);
+$t->run();
+
+###############################################################################
+
+like(http_get('/'), qr/SEE-THIS/, 'fastcgi request');
+like(http_get('/redir'), qr/302/, 'fastcgi redirect');
+like(http_get('/'), qr/^3$/m, 'fastcgi third request');
+
+unlike(http_head('/'), qr/SEE-THIS/, 'no data in HEAD');
+
+like(http_get('/stderr'), qr/SEE-THIS/, 'large stderr handled');
+
+sub http_post($;$;%) {
+    my ($url, $body, %extra) = @_;
+    my $len = length($body);
+
+    return http(<<EOF, %extra);
+POST $url HTTP/1.0
+Host: localhost
+Content-Length: $len
+Content-Type: application/x-www-form-urlencoded
+
+$body
+EOF
+}
+
+my $k1 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+my $body;
+
+$body= $k1;
+like(http_post('/upload', $body), qr/1024/, 'post 1k file');
+
+$body = $k1 x 10;
+like(http_post('/upload', $body), qr/10240/, 'post 10k file');
+
+$body = $k1 x 100;
+like(http_post('/upload', $body), qr/102400/, 'post 100k file');
+
+$body = $k1 x 1000;
+like(http_post('/upload', $body), qr/1024000/, 'post 1M file');
+
+$body = $k1;
+like(http_post('/buffer', $body), qr/1024/, 'post 1k file buffered');
+
+$body = $k1 x 10;
+like(http_post('/buffer', $body), qr/10240/, 'post 10k file buffered');
+
+$body = $k1 x 100;
+like(http_post('/buffer', $body), qr/102400/, 'post 100k file buffered');
+
+$body = $k1 x 1000;
+like(http_post('/buffer', $body), qr/1024000/, 'post 1M file buffered');
+
+###############################################################################
+
+$t->stop();
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        client_max_body_size 200M;
+        client_body_buffers 32 4k;
+
+        location / {
+            fastcgi_request_buffering off;
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+
+        location /buffer {
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+$body= $k1;
+like(http_post('/upload', $body), qr/1024/, 'post 1k file');
+
+$body = $k1 x 10;
+like(http_post('/upload', $body), qr/10240/, 'post 10k file');
+
+$body = $k1 x 100;
+like(http_post('/upload', $body), qr/102400/, 'post 100k file');
+
+$body = $k1 x 1000;
+like(http_post('/upload', $body), qr/1024000/, 'post 1M file');
+
+$body = $k1;
+like(http_post('/buffer', $body), qr/1024/, 'post 1k file buffered');
+
+$body = $k1 x 10;
+like(http_post('/buffer', $body), qr/10240/, 'post 10k file buffered');
+
+$body = $k1 x 100;
+like(http_post('/buffer', $body), qr/102400/, 'post 100k file buffered');
+
+$body = $k1 x 1000;
+like(http_post('/buffer', $body), qr/1024000/, 'post 1M file buffered');
+
+###############################################################################
+
+$t->stop();
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        client_max_body_size 200M;
+        client_body_postpone_size 1;
+
+        location / {
+            fastcgi_request_buffering off;
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+
+        location /buffer {
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+$body= $k1;
+like(http_post('/upload', $body), qr/1024/, 'post 1k file');
+
+$body = $k1 x 10;
+like(http_post('/upload', $body), qr/10240/, 'post 10k file');
+
+$body = $k1 x 100;
+like(http_post('/upload', $body), qr/102400/, 'post 100k file');
+
+$body = $k1 x 1000;
+like(http_post('/upload', $body), qr/1024000/, 'post 1M file');
+
+$body = $k1;
+like(http_post('/buffer', $body), qr/1024/, 'post 1k file buffered');
+
+$body = $k1 x 10;
+like(http_post('/buffer', $body), qr/10240/, 'post 10k file buffered');
+
+$body = $k1 x 100;
+like(http_post('/buffer', $body), qr/102400/, 'post 100k file buffered');
+
+$body = $k1 x 1000;
+like(http_post('/buffer', $body), qr/1024000/, 'post 1M file buffered');
+
+###############################################################################
+
+$t->stop();
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        client_max_body_size 200M;
+        client_body_postpone_size 4k;
+
+        location / {
+            fastcgi_request_buffering off;
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+
+        location /buffer {
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+$body= $k1;
+like(http_post('/upload', $body), qr/1024/, 'post 1k file');
+
+$body = $k1 x 10;
+like(http_post('/upload', $body), qr/10240/, 'post 10k file');
+
+$body = $k1 x 100;
+like(http_post('/upload', $body), qr/102400/, 'post 100k file');
+
+$body = $k1 x 1000;
+like(http_post('/upload', $body), qr/1024000/, 'post 1M file');
+
+$body = $k1;
+like(http_post('/buffer', $body), qr/1024/, 'post 1k file buffered');
+
+$body = $k1 x 10;
+like(http_post('/buffer', $body), qr/10240/, 'post 10k file buffered');
+
+$body = $k1 x 100;
+like(http_post('/buffer', $body), qr/102400/, 'post 100k file buffered');
+
+$body = $k1 x 1000;
+like(http_post('/buffer', $body), qr/1024000/, 'post 1M file buffered');
+
+###############################################################################
+
+$t->stop();
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        client_max_body_size 200M;
+        client_body_postpone_size 16k;
+
+        location / {
+            fastcgi_request_buffering off;
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+
+        location /buffer {
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+$body= $k1;
+like(http_post('/upload', $body), qr/1024/, 'post 1k file');
+
+$body = $k1 x 10;
+like(http_post('/upload', $body), qr/10240/, 'post 10k file');
+
+$body = $k1 x 100;
+like(http_post('/upload', $body), qr/102400/, 'post 100k file');
+
+$body = $k1 x 1000;
+like(http_post('/upload', $body), qr/1024000/, 'post 1M file');
+
+$body = $k1;
+like(http_post('/buffer', $body), qr/1024/, 'post 1k file buffered');
+
+$body = $k1 x 10;
+like(http_post('/buffer', $body), qr/10240/, 'post 10k file buffered');
+
+$body = $k1 x 100;
+like(http_post('/buffer', $body), qr/102400/, 'post 100k file buffered');
+
+$body = $k1 x 1000;
+like(http_post('/buffer', $body), qr/1024000/, 'post 1M file buffered');
+
+
+###############################################################################
+
+$t->stop();
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        client_max_body_size 200M;
+        client_body_postpone_size 2M;
+
+        location / {
+            fastcgi_request_buffering off;
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+
+        location /buffer {
+            fastcgi_pass 127.0.0.1:8081;
+            fastcgi_param REQUEST_URI $request_uri;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+$body= $k1;
+like(http_post('/upload', $body), qr/1024/, 'post 1k file');
+
+$body = $k1 x 10;
+like(http_post('/upload', $body), qr/10240/, 'post 10k file');
+
+$body = $k1 x 100;
+like(http_post('/upload', $body), qr/102400/, 'post 100k file');
+
+$body = $k1 x 1000;
+like(http_post('/upload', $body), qr/1024000/, 'post 1M file');
+
+$body = $k1;
+like(http_post('/buffer', $body), qr/1024/, 'post 1k file buffered');
+
+$body = $k1 x 10;
+like(http_post('/buffer', $body), qr/10240/, 'post 10k file buffered');
+
+$body = $k1 x 100;
+like(http_post('/buffer', $body), qr/102400/, 'post 100k file buffered');
+
+$body = $k1 x 1000;
+like(http_post('/buffer', $body), qr/1024000/, 'post 1M file buffered');
+
+
+###############################################################################
+
+sub fastcgi_daemon {
+	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
+		$socket);
+
+	my $count;
+	while( $request->Accept() >= 0 ) {
+		$count++;
+
+		if ($ENV{REQUEST_URI} eq '/stderr') {
+			warn "sample stderr text" x 512;
+		}
+
+		if ($ENV{REQUEST_URI} eq '/upload' or $ENV{REQUEST_URI} eq '/buffer') {
+            my $input = <STDIN>;
+            my $len = length($input);
+            #print $len;
+		print <<EOF;
+Content-Type: text/plain
+
+$len
+EOF
+            next;
+		}
+
+		print <<EOF;
+Location: http://127.0.0.1:8080/redirect
+Content-Type: text/html
+
+SEE-THIS
+$count
+EOF
+	}
+
+	FCGI::CloseSocket($socket);
+}
+
+###############################################################################

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
@@ -332,7 +332,7 @@ GET /
 --- config
     location / {
         set $test "/";
-        proxy_pass http://blog.163.com$test;
+        proxy_pass http://www.taobao.com$test;
     }
 
 --- request

--- a/tests/test-nginx/cases/proxy_no_buffering.t
+++ b/tests/test-nginx/cases/proxy_no_buffering.t
@@ -1,0 +1,731 @@
+# vi:filetype=perl
+
+use lib 'lib';
+use Test::Nginx::LWP;
+
+plan tests => repeat_each() * 2 * blocks();
+no_root_location();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: POST 1K
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+--- response_body: 1024
+
+=== TEST 2: POST 10K
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10
+--- response_body: 10240
+
+=== TEST 3: POST 100K
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 100
+--- response_body: 102400
+
+=== TEST 4: POST 1M
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 1000
+--- response_body: 1024000
+
+=== TEST 5: POST 10M
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10000
+--- response_body: 10240000
+
+=== TEST 6: POST 1K, 128k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 128k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+--- response_body: 1024
+
+=== TEST 7: POST 10K, 128k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 128k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10
+--- response_body: 10240
+
+=== TEST 8: POST 100K, 128k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 128k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 100
+--- response_body: 102400
+
+=== TEST 9: POST 1M, 128k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 128k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 1000
+--- response_body: 1024000
+
+=== TEST 10: POST 10M, 128k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 128k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10000
+--- response_body: 10240000
+
+=== TEST 11: POST 1K, 8k postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 8k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+--- response_body: 1024
+
+=== TEST 12: POST 10K, 8k 
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 8k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10
+--- response_body: 10240
+
+=== TEST 13: POST 100K, 8k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 8k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 100
+--- response_body: 102400
+
+=== TEST 14: POST 1M, 8k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 8k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 1000
+--- response_body: 1024000
+
+=== TEST 15: POST 10M, 8k
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 8k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10000
+--- response_body: 10240000
+
+=== TEST 16: POST 1K, 2M postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 2M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+--- response_body: 1024
+
+=== TEST 17: POST 10K, 2M postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 2M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10
+--- response_body: 10240
+
+=== TEST 18: POST 100K, 2M
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 2M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 100
+--- response_body: 102400
+
+=== TEST 18: POST 1M, 2M
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 2M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 1000
+--- response_body: 1024000
+
+=== TEST 19: POST 10M, 2M
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 2M;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10000
+--- response_body: 10240000
+
+=== TEST 20: POST 1K, buffer on
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+--- response_body: 1024
+
+=== TEST 21: POST 10K, buffer on
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10
+--- response_body: 10240
+
+=== TEST 22: POST 100K, buffer on
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 100
+--- response_body: 102400
+
+=== TEST 23: POST 1M, buffer on
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 1000
+--- response_body: 1024000
+
+=== TEST 24: POST 10M, buffer on
+--- config
+    location / {
+        client_max_body_size 200M;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10000
+--- response_body: 10240000
+
+=== TEST 25: POST 1K, buffers 128K
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_buffers 32 4k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+--- response_body: 1024
+
+=== TEST 26: POST 10K, buffers 128K
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_buffers 32 4k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10
+--- response_body: 10240
+
+=== TEST 27: POST 100K, buffers 128K
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_buffers 32 4k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 100
+--- response_body: 102400
+
+=== TEST 28: POST 1M, buffers 128K
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_buffers 32 4k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 1000
+--- response_body: 1024000
+
+=== TEST 29: POST 10M, buffers 128K
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_buffers 32 4k;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10000
+--- response_body: 10240000
+
+=== TEST 30: POST 1K, 1B postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 1;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+--- response_body: 1024
+
+=== TEST 31: POST 10K, 1B postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 1;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10
+--- response_body: 10240
+
+=== TEST 32: POST 100K, 1B postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 1;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 100
+--- response_body: 102400
+
+=== TEST 33: POST 1M, 1B postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 1;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 1000
+--- response_body: 1024000
+
+=== TEST 34: POST 10M, 1B postpone
+--- config
+    location / {
+        client_max_body_size 200M;
+        client_body_postpone_size 1;
+        proxy_request_buffering off;
+        proxy_pass http://127.0.0.1:1984/upload;
+    }
+
+    location /upload {
+        lua_need_request_body on;
+        client_max_body_size 200M;
+
+        content_by_lua 'ngx.print(ngx.req.get_headers()["Content-Length"])';
+    }
+
+--- request eval
+"POST /
+" . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" x 10000
+--- response_body: 10240000


### PR DESCRIPTION
Now the request body can be passed chunk by chunk to upstream, while
the whole body need be buffered before.
