### PR TITLE
test (kqueue)connection completely in ngx_http_upstream_test_connect()

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2166,7 +2166,7 @@ ngx_http_upstream_test_connect(ngx_connection_t *c)
             return NGX_ERROR;
         }
 
-    } else
+    }
 #endif
     {
         err = 0;


### PR DESCRIPTION
With NGX_HAVE_KQUEUE option, ngx_http_upstream_test_connect() may return NGX_OK although the connection isnt established.

Reproduce the problem in os x 10.8.4, let backend server down, then
tengine upstream tries to connect and send request to it:

<pre><code>ngx_http_upstream_init_request()
'-> ngx_http_upstream_connect()
    '-> ngx_event_connect_peer() returns NGX_AGAIN             ---- cannot connect
    '-> ..
    '-> ngx_http_upstream_send_request()
        '-> ngx_http_upstream_test_connect() returns NGX_OK   ---- wrong value
    '-> ngx_output_chain() returns NGX_AGAIN
</code></pre>


With this patch, ngx_http_upstream_test_connect() will call getsockopt to test connection after it thinks kqueue connection is ok.

Without this patch, tengine can work well because c->recv() will return NGX_ERROR when read event timedout expires.

Note that nginx has the same problem.

简单说来就是 让 ngx_http_upstream_test_connect()在认为kqueue连接是正常时，再跑一遍常规测试(getsockopt)
