### PR TITLE
fixed a compilation error when the '--without-dso' was specified

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -735,8 +735,9 @@ fi
 
 
 if [ $NGX_DSO = YES ] ; then
-
     have=NGX_DSO_ABI_COMPATIBILITY value="$NGX_DSO_ABI_COMPATIBILITY" . auto/define
+else
+    have=NGX_DSO_ABI_COMPATIBILITY value="0" . auto/define
 fi
 
 

--- a/src/core/ngx_dso_module.c
+++ b/src/core/ngx_dso_module.c
@@ -561,8 +561,7 @@ ngx_dso_load(ngx_conf_t *cf)
             return NGX_CONF_ERROR;
         }
 
-        if (dm[i].module->abi_compatibility != NGX_DSO_ABI_COMPATIBILITY)
-        {
+        if (dm[i].module->abi_compatibility != NGX_DSO_ABI_COMPATIBILITY) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "module \"%V\" is not compatible with this "
                                "ABI of tengine, you need recomplie module",


### PR DESCRIPTION
When the '--without-dso' configuration option was specified, Tengine couldn't compile.
