### PR TITLE
add english document of consistent_hash module

### DIFF
--- a/docs/modules/ngx_http_upstream_consistent_hash_module.md
+++ b/docs/modules/ngx_http_upstream_consistent_hash_module.md
@@ -1,0 +1,72 @@
+Name
+====
+
+*  consistent hash module
+
+Description
+===========
+
+* This module provides consistent hashing algorithm for upstream load-balancing.
+
+* If one of backend servers is down, the request of this client will be transferred to another server.
+
+* `server` *id* field: Id field can be used as server flag. If id field is not set, ip address and port are used to identify server. You can use id field to set server flag mannually. In that case, although ip address or port of a server is changed, id can still identify the server. BTW, it can reduce remapping keys effectively to use id field.
+
+* `server` *weight* field: server weight, the number of virtual peers
+
+* Algorithm: It supposes that 1 server is mapped to m virtual peers, so n servers correspond to n*m virtual peers. All these peers will be mapped to hash ring on average. Every time request comes, it calculates a hash key via configuration parameter, and finds a peer on the hash ring nearest to the location specified by the hash key.
+
+* It can dispatch requests to backend servers on average according to nginx configuration parameter.
+
+    `consistent_hash $remote_addr`: mapping via client ip address
+
+    `consistent_hash $request_uri`: mapping via request-uri
+
+    `consistent_hash $args`: mapping via url query string
+
+
+Example
+===========
+
+    worker_processes  1;
+
+    http {
+        upstream test {
+            consistent_hash $request_uri;
+
+            server 127.0.0.1:9001 id=1001 weight=3;
+            server 127.0.0.1:9002 id=1002 weight=10;
+            server 127.0.0.1:9003 id=1003 weight=20;
+        }
+    }
+
+
+Directives
+==========
+
+consistent_hash
+------------------------
+
+**Syntax**: *consistent_hash variable_name*
+
+**Default**: *none*
+
+**Context**: *upstream*
+
+This directive causes requests to be distributed between upstreams based on consistent hashing alogrithm. And it uses nginx variables, specified by variable_name, as input data of hash function.
+
+
+Installation
+===========
+
+* This module is built by default, it can be disabled with the `--without-http_upstream_consistent_hash_module` configuration parameter.
+
+    $ ./configure
+
+* compile
+
+    $ make
+
+* install
+
+    $ make install

--- a/docs/modules/ngx_http_upstream_consistent_hash_module_cn.md
+++ b/docs/modules/ngx_http_upstream_consistent_hash_module_cn.md
@@ -20,9 +20,11 @@
 
 * `server` *wegiht* 字段，作为server权重，对应虚拟节点数目
 
-* 具体算法，将每个server虚拟成n个节点，均匀分布到hash环上，每次请求，根据配置的参数计算出一个hash值，在hash环
+* 具体算法，假设每个server对应n个虚拟节点，那m个server就对应n×m个虚拟节点，这些节点被均匀分布到hash环上。
 
-    上查找离这个hash最近的虚拟节点，对应的server作为该次请求的后端机器。
+    每次请求进入时，模块根据配置的参数计算出一个hash值，在hash环上查找离这个hash值最近的虚拟节点，并将此
+
+    节点对应的server作为该次请求的后端机器。
 
 * 该模块可以根据配置参数采取不同的方式将请求均匀映射到后端机器，比如：
 
@@ -37,7 +39,7 @@
 ===========
 
     worker_processes  1;
-    
+
     http {
         upstream test {
             consistent_hash $request_uri;
@@ -52,7 +54,7 @@
 指令
 ==========
 
-consistent_hash 
+consistent_hash
 ------------------------
 
 **Syntax**: *consistent_hash variable_name*
@@ -61,20 +63,19 @@ consistent_hash
 
 **Context**: *upstream*
 
-配置upstream采用一致性hash作为负载均衡算法，并使用配置的变量名作为hash输入。
-
+配置upstream采用一致性hash作为负载均衡算法，variable_name作为hash输入，可以使用nginx变量。
 
 编译安装
 ===========
 
-* 在configure的时候打开一致性hash模块，关闭使用选项`--without-http_upstream_consistent_hash_module`。
+* configure默认打开一致性hash模块，若要关闭请使用选项`--without-http_upstream_consistent_hash_module`。
 
       $ ./configure
-      
+
 * 编译
 
     $ make
-    
+
 * 安装模块
 
     $ make install


### PR DESCRIPTION
修正一致性哈希中文文档，使其语句更加通顺(方便翻译)
同时增加了一致性哈希的英文文档

update chinese document for consistent_hash module
add english document for consisitent_hash module

For human-readable markdown, see https://github.com/chobits/tengine/blob/consistent_hash_doc/docs/modules/ngx_http_upstream_consistent_hash_module.md
