### PR TITLE
Bugfix: the "[alert] zero size buf" error.

### DIFF
--- a/src/http/modules/ngx_http_trim_filter_module.c
+++ b/src/http/modules/ngx_http_trim_filter_module.c
@@ -339,6 +339,12 @@ ngx_http_trim_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 cl->buf->last_buf = 1;
 
                 *ll = cl;
+                ll = &cl->next;
+
+            }  else {
+                if (ln->next == NULL) {
+                    *ll = NULL;
+                }
             }
 
         } else {


### PR DESCRIPTION
当一个chain最后一个buffer是0字节并且不是last_buf时,会导致该0字节buffer输出而出错. 
