### PR TITLE
ngx lua module compile warning

### DIFF
--- a/src/http/modules/lua/ngx_http_lua_util.c
+++ b/src/http/modules/lua/ngx_http_lua_util.c
@@ -968,7 +968,7 @@ ngx_http_lua_request_cleanup(void *data)
  */
 ngx_int_t
 ngx_http_lua_run_thread(lua_State *L, ngx_http_request_t *r,
-    ngx_http_lua_ctx_t *ctx, int nret)
+    ngx_http_lua_ctx_t *ctx, const int nret)
 {
     ngx_http_lua_co_ctx_t   *next_coctx, *parent_coctx, *orig_coctx;
     int                      rv, nrets, success = 1;


### PR DESCRIPTION
compile warning:argument 'nret' might be clobbered by 'longjmp' or
'vfork'[-Werror=clobbered]
