### PR TITLE
added proxy_upstream_tries directive

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -486,6 +486,13 @@ static ngx_command_t  ngx_http_proxy_commands[] = {
       offsetof(ngx_http_proxy_loc_conf_t, upstream.next_upstream),
       &ngx_http_proxy_next_upstream_masks },
 
+    { ngx_string("proxy_upstream_tries"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_proxy_loc_conf_t, upstream.tries),
+      NULL },
+
     { ngx_string("proxy_pass_header"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_array_slot,
@@ -2725,6 +2732,8 @@ ngx_http_proxy_create_loc_conf(ngx_conf_t *cf)
     conf->redirect = NGX_CONF_UNSET;
     conf->upstream.change_buffering = 1;
 
+    conf->upstream.tries = NGX_CONF_UNSET_UINT;
+
     conf->cookie_domains = NGX_CONF_UNSET_PTR;
     conf->cookie_paths = NGX_CONF_UNSET_PTR;
 
@@ -2984,6 +2993,9 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->method.data[conf->method.len] = ' ';
         conf->method.len++;
     }
+
+    ngx_conf_merge_uint_value(conf->upstream.tries,
+                              prev->upstream.tries, NGX_CONF_UNSET_UINT);
 
     ngx_conf_merge_value(conf->upstream.pass_request_headers,
                               prev->upstream.pass_request_headers, 1);

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2448,6 +2448,8 @@ ngx_http_subrequest(ngx_http_request_t *r,
     c = r->connection;
     sr->connection = c;
 
+    sr->us_tries = 1;
+
     sr->ctx = ngx_pcalloc(r->pool, sizeof(void *) * ngx_http_max_module);
     if (sr->ctx == NULL) {
         return NGX_ERROR;

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -493,6 +493,8 @@ ngx_http_init_request(ngx_event_t *rev)
     r->main = r;
     r->count = 1;
 
+    r->us_tries = 1;
+
     if (clcf->request_time_cache) {
         tp = ngx_timeofday();
         r->start_sec = tp->sec;

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -439,6 +439,8 @@ struct ngx_http_request_s {
 
     ngx_uint_t                        err_status;
 
+    ngx_uint_t                        us_tries;
+
     ngx_http_connection_t            *http_connection;
 
     ngx_http_log_handler_pt           log_handler;

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -3242,6 +3242,13 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
     if (status) {
         u->state->status = status;
 
+        if (u->conf->tries != NGX_CONF_UNSET_UINT
+            && r->us_tries++ >= u->conf->tries)
+        {
+            ngx_http_upstream_finalize_request(r, u, status);
+            return;
+        }
+
         if (u->peer.tries == 0 || !(u->conf->next_upstream & ft_type)) {
 
 #if (NGX_HTTP_CACHE)

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -156,6 +156,7 @@ typedef struct {
 
     ngx_uint_t                       ignore_headers;
     ngx_uint_t                       next_upstream;
+    ngx_uint_t                       tries;
     ngx_uint_t                       store_access;
     ngx_flag_t                       request_buffering;
     ngx_flag_t                       buffering;


### PR DESCRIPTION
proxy_upstream_tries can limit proxy_next_upstream retry times. This directive can work in main/server/http/location config, and is disabled by default(default behavior is to try ALL upstreams). Partial code is
forked from patch: https://gist.github.com/shai-d/5446961.
