### PR TITLE
use configurable persistent connection in upstream health check

### DIFF
--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/check_interface.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/check_interface.t
@@ -22,7 +22,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -61,7 +61,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -101,7 +101,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -141,7 +141,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -180,7 +180,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -219,7 +219,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -258,7 +258,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -297,7 +297,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -336,7 +336,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -375,7 +375,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -414,7 +414,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=2000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -453,7 +453,7 @@ upstream backend {
     server 127.0.0.1:1975;
 
     check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-    check_http_send "GET / HTTP/1.0\r\n\r\n";
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
     check_http_expect_alive http_2xx http_3xx;
 }
 
@@ -477,6 +477,46 @@ server {
 
 --- request
 GET /status?format=html&status=foo
+--- response_headers
+Content-Type: text/html
+--- response_body_like: ^.*Check upstream server number: 6.*$
+
+=== TEST 13: the http_check interface, with check_keepalive_requests configured
+--- http_config
+upstream backend {
+    server 127.0.0.1:1971;
+    server 127.0.0.1:1972;
+    server 127.0.0.1:1973;
+    server 127.0.0.1:1970;
+    server 127.0.0.1:1974;
+    server 127.0.0.1:1975;
+
+    check_keepalive_requests 10;
+    check interval=3000 rise=1 fall=1 timeout=1000 type=http;
+    check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+    check_http_expect_alive http_2xx http_3xx;
+}
+
+server {
+    listen 1970;
+
+    location / {
+        root   html;
+        index  index.html index.htm;
+    }
+}
+
+--- config
+    location / {
+        proxy_pass http://backend;
+    }
+
+    location /status {
+        check_status;
+    }
+
+--- request
+GET /status
 --- response_headers
 Content-Type: text/html
 --- response_body_like: ^.*Check upstream server number: 6.*$

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
@@ -16,7 +16,7 @@ __DATA__
     upstream test{
         server 127.0.0.1:1970;
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -45,7 +45,7 @@ GET /
         server 127.0.0.1:1971;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -54,7 +54,7 @@ GET /
         server www.taobao.com:81;
 
         check interval=3000 rise=1 fall=5 timeout=2000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -83,7 +83,7 @@ GET /
         server 127.0.0.1:1971;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET /foo HTTP/1.0\r\n\r\n";
+        check_http_send "GET /foo HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -138,7 +138,7 @@ GET /
         server 127.0.0.1:1971;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -167,7 +167,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -197,7 +197,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -227,7 +227,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET /foo HTTP/1.0\r\n\r\n";
+        check_http_send "GET /foo HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -284,7 +284,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -314,7 +314,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -346,7 +346,7 @@ GET /
         least_conn;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -376,7 +376,7 @@ GET /
         least_conn;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -406,7 +406,7 @@ GET /
         least_conn;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET /foo HTTP/1.0\r\n\r\n";
+        check_http_send "GET /foo HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -460,7 +460,7 @@ GET /
     upstream test{
         server 127.0.0.1:1970;
         check interval=2000 rise=1 fall=1 timeout=1000 type=http port=1971;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -488,7 +488,7 @@ GET /
     upstream test{
         server 127.0.0.1:1971;
         check interval=3000 rise=1 fall=1 timeout=1000 type=http port=1970;
-        check_http_send "GET / HTTP/1.0\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -511,3 +511,30 @@ GET /
 --- error_code: 502
 --- response_body_like: ^.*$
 
+=== TEST 18: the http_check with check_keepalive_requests configured
+--- http_config
+    upstream test{
+        server 127.0.0.1:1970;
+        check_keepalive_requests 10;
+        check interval=3000 rise=1 fall=1 timeout=1000 type=http;
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- request
+GET /
+--- response_body_like: ^<(.*)>$

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/tcp_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/tcp_check.t
@@ -180,3 +180,29 @@ GET /
 --- error_code: 502
 --- response_body_like: ^.*$
 
+=== TEST 5: the tcp_check test with check_keepalive_requests configured
+--- http_config
+    upstream test{
+        server 127.0.0.1:1970;
+
+        check_keepalive_requests 10;
+        check interval=2000 rise=1 fall=1 timeout=1000 type=tcp;
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+    }
+
+--- config
+    location / { 
+        proxy_pass http://test;
+    }
+
+--- request
+GET /
+--- response_body_like: ^<(.*)>$


### PR DESCRIPTION
1) add directive "check_keepalive_requests" which controls the request number of a persistent connection its default value is 100.
2) for ssl, mysql and ajp protocol, persistent connection is not used, in this case, directive "check_keepalive_requests" does not work.
3) for http protocol, if the status code is 4xx or 5xx, persistent connection will be closed.
4) The health checking request must contain header “Connection: keep-alive” to announce using persistent connection, or else the upstream server will close the connection.
