### PR TITLE
rollback: undo this commit "test (kqueue)connection completely in ngx_ht...

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2191,7 +2191,7 @@ ngx_http_upstream_test_connect(ngx_connection_t *c)
             return NGX_ERROR;
         }
 
-    }
+    } else
 #endif
     {
         err = 0;


### PR DESCRIPTION
Sorry for this commit rollback. Please undo commit 422086fb7df6daef082fcaf7459b9ce72f84eaf4. (pull request for this commit: https://github.com/alibaba/tengine/pull/296)

Maxim Dounin's reply for this patch is as following:

On Fri, Aug 16, 2013 at 10:19:00AM +0800, Xiaochen Wang wrote:

> Without this patch, nginx can work well because c->recv() will return
> NGX_ERROR when read event timedout expires.

Note well that the purpose of ngx_http_upstream_test_connect()
call before writing to an upstream is to properly report source of
the error if it happens.  It's bad idea to do getsockopt() in all
cases for performance reasons
