### PR TITLE
fix bug described in issue 384, which is about persistent connection in ...

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -264,6 +264,7 @@ static void ngx_http_upstream_check_peek_handler(ngx_event_t *event);
 static void ngx_http_upstream_check_send_handler(ngx_event_t *event);
 static void ngx_http_upstream_check_recv_handler(ngx_event_t *event);
 
+static void ngx_http_upstream_check_discard_handler(ngx_event_t *event);
 static void ngx_http_upstream_check_dummy_handler(ngx_event_t *event);
 
 static ngx_int_t ngx_http_upstream_check_http_init(
@@ -540,7 +541,7 @@ static ngx_check_conf_t  ngx_check_types[] = {
 
     { NGX_HTTP_CHECK_HTTP,
       ngx_string("http"),
-      ngx_string("GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n"),
+      ngx_string("GET / HTTP/1.0\r\n\r\n"),
       NGX_CONF_BITMASK_SET | NGX_CHECK_HTTP_2XX | NGX_CHECK_HTTP_3XX,
       ngx_http_upstream_check_send_handler,
       ngx_http_upstream_check_recv_handler,
@@ -1072,6 +1073,56 @@ ngx_http_upstream_check_peek_handler(ngx_event_t *event)
     ngx_http_upstream_check_clean_event(peer);
 
     ngx_http_upstream_check_finish_handler(event);
+}
+
+
+static void
+ngx_http_upstream_check_discard_handler(ngx_event_t *event)
+{
+    u_char                          buf[4096];
+    ssize_t                         size;
+    ngx_connection_t               *c;
+    ngx_http_upstream_check_peer_t *peer;
+
+    c = event->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "upstream check discard handler");
+
+    if (ngx_http_upstream_check_need_exit()) {
+        return;
+    }
+
+    peer = c->data;
+
+    while (1) {
+        size = c->recv(c, buf, 4096);
+
+        if (size > 0) {
+            continue;
+
+        } else if (size == NGX_AGAIN) {
+            break;
+
+        } else {
+            if (size == 0) {
+                ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                               "peer closed its half side of the connection");
+            }
+
+            goto check_discard_fail;
+        }
+    }
+
+    if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+        goto check_discard_fail;
+    }
+
+    return;
+
+ check_discard_fail:
+    c->error = 1;
+    ngx_http_upstream_check_clean_event(peer);
 }
 
 
@@ -1856,7 +1907,7 @@ ngx_http_upstream_check_clean_event(ngx_http_upstream_check_peer_t *peer)
             (c->requests < ucscf->check_keepalive_requests))
         {
             c->write->handler = ngx_http_upstream_check_dummy_handler;
-            c->read->handler = ngx_http_upstream_check_dummy_handler;
+            c->read->handler = ngx_http_upstream_check_discard_handler;
         } else {
             ngx_close_connection(c);
             peer->pc.connection = NULL;
@@ -2802,7 +2853,7 @@ ngx_http_upstream_check_init_srv_conf(ngx_conf_t *cf, void *conf)
     }
 
     if (ucscf->check_keepalive_requests == NGX_CONF_UNSET_UINT) {
-        ucscf->check_keepalive_requests = 100;
+        ucscf->check_keepalive_requests = 1;
     }
 
     if (ucscf->check_type_conf == NGX_CONF_UNSET_PTR) {

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
@@ -16,7 +16,7 @@ __DATA__
     upstream test{
         server 127.0.0.1:1970;
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -45,7 +45,7 @@ GET /
         server 127.0.0.1:1971;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -54,7 +54,7 @@ GET /
         server www.taobao.com:81;
 
         check interval=3000 rise=1 fall=5 timeout=2000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -83,7 +83,7 @@ GET /
         server 127.0.0.1:1971;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET /foo HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET /foo HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -138,7 +138,7 @@ GET /
         server 127.0.0.1:1971;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -167,7 +167,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -197,7 +197,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -227,7 +227,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET /foo HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET /foo HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -284,7 +284,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -314,7 +314,7 @@ GET /
         ip_hash;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -346,7 +346,7 @@ GET /
         least_conn;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -376,7 +376,7 @@ GET /
         least_conn;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -406,7 +406,7 @@ GET /
         least_conn;
 
         check interval=3000 rise=1 fall=1 timeout=1000 type=http;
-        check_http_send "GET /foo HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET /foo HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -460,7 +460,7 @@ GET /
     upstream test{
         server 127.0.0.1:1970;
         check interval=2000 rise=1 fall=1 timeout=1000 type=http port=1971;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 
@@ -488,7 +488,7 @@ GET /
     upstream test{
         server 127.0.0.1:1971;
         check interval=3000 rise=1 fall=1 timeout=1000 type=http port=1970;
-        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_send "GET / HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
     }
 


### PR DESCRIPTION
1，默认check_keepalive_requests设置为1，即默认采用短连接，如果用户想采用长连接，需要将此值设置为大于1的数，并在自行设置的send内容中添加header，Connection: keep-alive。
2，采用一个discard handler，用于接收不需要的header及body数据，避免下次check时，读到上次响应的末段数据，导致解析出错。
3，test case修改。
