### PR TITLE
Striped the last linefeed in the resolver file

### DIFF
--- a/tests/nginx-tests/cases/resolver.t
+++ b/tests/nginx-tests/cases/resolver.t
@@ -10,7 +10,7 @@ use warnings;
 use strict;
 
 use Test::More;
-use File::Copy; 
+use File::Copy;
 
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
@@ -32,7 +32,7 @@ EOF
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->plan(2)
+my $t = Test::Nginx->new()->plan(5)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -105,6 +105,132 @@ $t->write_file('resolv.conf', 'nameserver 8.8.8.8');
 $t->run();
 
 like(http_get_host("/", "www.taobao.com"), qr/HTTP\/1.1 200 OK/, 'resolver_file to resolv.conf');
+
+$t->stop();
+###############################################################################
+###############################################################################
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+master_process off;
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+    access_log    off;
+
+    resolver_file %%TESTDIR%%/resolv2.conf;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            proxy_pass http://$http_host;
+        }
+
+    }
+}
+
+EOF
+
+$t->write_file('resolv2.conf', '   nameserver     8.8.8.8   ');
+
+$t->run();
+
+like(http_get_host("/", "www.taobao.com"), qr/HTTP\/1.1 200 OK/, 'resolver_file to resolv2.conf');
+
+$t->stop();
+###############################################################################
+###############################################################################
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+master_process off;
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+    access_log    off;
+
+    resolver_file %%TESTDIR%%/resolv3.conf;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            proxy_pass http://$http_host;
+        }
+
+    }
+}
+
+EOF
+
+$t->write_file_expand('resolv3.conf', <<'EOF');
+nameserver 8.8.8.8
+nameserver 114.114.114.114
+EOF
+
+$t->run();
+
+like(http_get_host("/", "www.taobao.com"), qr/HTTP\/1.1 200 OK/, 'resolver_file to resolv3.conf');
+
+$t->stop();
+###############################################################################
+###############################################################################
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+master_process off;
+daemon         off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+    access_log    off;
+
+    resolver_file %%TESTDIR%%/resolv4.conf;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            proxy_pass http://$http_host;
+        }
+
+    }
+}
+
+EOF
+
+$t->write_file_expand('resolv4.conf', <<'EOF');
+
+  nameserver 8.8.8.8  
+  nameserver    8.8.8.8  
+  nameserver  114.114.114.114  
+
+EOF
+
+$t->run();
+
+like(http_get_host("/", "www.taobao.com"), qr/HTTP\/1.1 200 OK/, 'resolver_file to resolv4.conf');
 
 $t->stop();
 ###############################################################################


### PR DESCRIPTION
In CentOS 6.4, the interface gethostbyname can't parse the
nameserver string with extra linefeed.
