### PR TITLE
在DragonFlyBSD 3.6下编译时发生错误

### DIFF
--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -1384,7 +1384,7 @@ ngx_http_variable_ascii(ngx_http_request_t *r,
     len = name->len - (sizeof("ascii_") - 1);
     p = name->data + sizeof("ascii_") - 1;
 
-    if (ngx_strncasecmp(p, (u_char *)"0x", 2) == 0) {
+    if (ngx_strncasecmp(p, (u_char *) "0x", 2) == 0) {
 
         p = p + 2;
         len = len - 2;


### PR DESCRIPTION
在DragonFlyBSD 3.6下编译时发生错误，是函数参数类型不一致所导致
