### PR TITLE
SPDY: send output queue after processing of read event.

### DIFF
--- a/src/http/ngx_http_spdy.c
+++ b/src/http/ngx_http_spdy.c
@@ -381,6 +381,11 @@ ngx_http_spdy_read_handler(ngx_event_t *rev)
         return;
     }
 
+    if (sc->last_out && ngx_http_spdy_send_output_queue(sc) == NGX_ERROR) {
+        ngx_http_spdy_finalize_connection(sc, NGX_HTTP_CLIENT_CLOSED_REQUEST);
+        return;
+    }
+
     sc->blocked = 0;
 
     if (sc->processing) {

--- a/src/http/ngx_http_spdy_v3.c
+++ b/src/http/ngx_http_spdy_v3.c
@@ -547,6 +547,11 @@ ngx_http_spdy_read_handler(ngx_event_t *rev)
         return;
     }
 
+    if (sc->last_out && ngx_http_spdy_send_output_queue(sc) == NGX_ERROR) {
+        ngx_http_spdy_finalize_connection(sc, NGX_HTTP_CLIENT_CLOSED_REQUEST);
+        return;
+    }
+
     sc->blocked = 0;
 
     if (sc->processing) {


### PR DESCRIPTION
Some users reported that their spdy client could not receive the reply of PING frame in time.
Note that this problem has also been fixed in official nginx.
More details are available here: http://hg.nginx.org/nginx/rev/a336cbc3dd44.
