### PR TITLE
Spdy bugfix for CVE-2014-0133 and CVE-2014-0088

### DIFF
--- a/src/http/ngx_http_spdy.c
+++ b/src/http/ngx_http_spdy.c
@@ -1490,7 +1490,7 @@ static u_char *
 ngx_http_spdy_state_save(ngx_http_spdy_connection_t *sc,
     u_char *pos, u_char *end, ngx_http_spdy_handler_pt handler)
 {
-#if (NGX_DEBUG)
+#if 1
     if (end - pos > NGX_SPDY_STATE_BUFFER_SIZE) {
         ngx_log_error(NGX_LOG_ALERT, sc->connection->log, 0,
                       "spdy state buffer overflow: "

--- a/src/http/ngx_http_spdy_v3.c
+++ b/src/http/ngx_http_spdy_v3.c
@@ -1775,7 +1775,7 @@ static u_char *
 ngx_http_spdy_state_save(ngx_http_spdy_connection_t *sc,
     u_char *pos, u_char *end, ngx_http_spdy_handler_pt handler)
 {
-#if (NGX_DEBUG)
+#if 1
     if (end - pos > NGX_SPDY_STATE_BUFFER_SIZE) {
         ngx_log_error(NGX_LOG_ALERT, sc->connection->log, 0,
                       "spdy state buffer overflow: "


### PR DESCRIPTION
- SPDY: memory corruption (bugfix for CVE-2014-0088)
  More details from nginx announcement are available here:
  http://mailman.nginx.org/pipermail/nginx-announce/2014/000132.html
- SPDY: heap buffer overflow (bugfix for CVE-2014-0133)
  More details from nginx announcement are available here:
  http://mailman.nginx.org/pipermail/nginx-announce/2014/000135.html
