### PR TITLE
Spdy bugfix for parsing http version and handling DATA frame length

### DIFF
--- a/src/http/ngx_http_spdy.c
+++ b/src/http/ngx_http_spdy.c
@@ -1133,7 +1133,6 @@ ngx_http_spdy_state_data(ngx_http_spdy_connection_t *sc, u_char *pos,
         complete = 1;
 
     } else {
-        sc->length -= size;
         complete = 0;
     }
 
@@ -1175,6 +1174,8 @@ ngx_http_spdy_state_data(ngx_http_spdy_connection_t *sc, u_char *pos,
                 goto error;
             }
         }
+
+        sc->length -= size;
 
         if (tf) {
             buf->start = pos;

--- a/src/http/ngx_http_spdy_v3.c
+++ b/src/http/ngx_http_spdy_v3.c
@@ -1419,7 +1419,6 @@ ngx_http_spdy_state_data(ngx_http_spdy_connection_t *sc, u_char *pos,
         complete = 1;
 
     } else {
-        sc->length -= size;
         complete = 0;
     }
 
@@ -1461,6 +1460,8 @@ ngx_http_spdy_state_data(ngx_http_spdy_connection_t *sc, u_char *pos,
                 goto error;
             }
         }
+
+        sc->length -= size;
 
         if (tf) {
             buf->start = pos;


### PR DESCRIPTION
- SPDY: fixed parsing of http version.
  There is an error while parsing multi-digit minor version numbers (e.g. "HTTP/1.10").
  
  nginx commit log: http://hg.nginx.org/nginx/rev/cff36d2d7fe6
- SPDY: fixed the DATA frame length handling in case of some errors.
  In our production, sometimes, the disk was full. In which case, the requests after the POST request
  were handled wrongly in one spdy connection.
  Because the input body (DATA frame) of POST request could not be written to disk, then
  ngx_http_spdy_state_read_data() tried to skip this DATA frame with wrong sc->length, which broke
  spdy stream.
  
  nginx commit log: http://hg.nginx.org/nginx/rev/d74889fbf06d
