### PR TITLE
调整session_sticky模块的顺序

### DIFF
--- a/auto/options
+++ b/auto/options
@@ -112,7 +112,6 @@ NGX_ALL_MODULES="
     ngx_http_upstream_least_conn_module
     ngx_http_upstream_keepalive_module
     ngx_http_upstream_check_module
-    ngx_http_upstream_session_sticky_module
     ngx_http_upstream_consistent_hash_module
     ngx_http_stub_status_module
     ngx_http_write_filter_module
@@ -130,6 +129,7 @@ NGX_ALL_MODULES="
     ngx_http_userid_filter_module
     ngx_http_footer_filter_module
     ngx_http_trim_filter_module
+    ngx_http_upstream_session_sticky_module
     ngx_http_headers_filter_module
     ngx_http_copy_filter_module
     ngx_http_range_body_filter_module


### PR DESCRIPTION
修复session_sticky不能使用dso编译的问题
