### PR TITLE
Update README.md

### DIFF
--- a/packages/debian/README.md
+++ b/packages/debian/README.md
@@ -1,14 +1,26 @@
 Installation
 ===
+
 ##  build the deb package   
 1. install some basic packages
-> aptitude install  build-essential debhelper make autoconf automake patch dpkg-dev  fakeroot pbuilder gnupg dh-make libssl-dev libpcre3-dev      
+
+```
+aptitude install build-essential debhelper make autoconf automake patch \
+ dpkg-dev fakeroot pbuilder gnupg dh-make libssl-dev libpcre3-dev      
+```
 
 2. build package     
-change to source directory         
-> mv packages/debian/ .     
-> export DEB_BUILD_OPTIONS=nocheck; dpkg-buildpackage -rfakeroot -uc -b     
+change to source directory
 
-## install the deb package   
-> sudo  dpkg -i tengine_2.0.2-1_amd64.deb    
+```
+mv packages/debian .
+DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -rfakeroot -uc -b
+```
+
+## install the deb package 
+replace the deb name with the current version
+
+```
+sudo dpkg -i tengine_2.0.2-1_amd64.deb
+```
 


### PR DESCRIPTION
- break long dependency line
- defining `DEB_BUILD_OPTIONS` is like export
- `tengine_2.0.2-1_amd64.deb` is just an example
