### PR TITLE
修复session sticky加上option=indirect选项导致http 变量乱掉的bug

### DIFF
--- a/src/http/modules/ngx_http_upstream_session_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_session_sticky_module.c
@@ -122,7 +122,7 @@ static ngx_http_output_header_filter_pt ngx_http_ss_next_header_filter;
 static ngx_command_t ngx_http_session_sticky_commands[] = {
 
     { ngx_string("session_sticky"),
-      NGX_HTTP_UPS_CONF|NGX_CONF_ANY,
+      NGX_HTTP_UPS_CONF|NGX_CONF_ANY|NGX_CONF_1MORE,
       ngx_http_upstream_session_sticky,
       NGX_HTTP_SRV_CONF_OFFSET,
       0,
@@ -513,10 +513,8 @@ finish:
     {
         cookie->len -= (end - st);
         if (cookie->len == 0) {
-            rc = ngx_list_delete(&r->headers_in.headers, cookies[i]);
-            if (rc != NGX_OK) {
-                return NGX_ERROR;
-            }
+            cookies[i]->hash = 0;
+            return NGX_OK;
         }
 
         while (end < last) {

--- a/tests/nginx-tests/cases/session_sticky.t
+++ b/tests/nginx-tests/cases/session_sticky.t
@@ -35,7 +35,9 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    upstream insert_indirect {
+	proxy_set_header Host $http_host;
+
+	upstream insert_indirect {
         session_sticky cookie=test domain=.taobao.com path=/ maxage=120 maxidle=40 maxlife=60 mode=insert option=indirect fallback=on;
 
         server          127.0.0.1:9000;
@@ -127,9 +129,9 @@ http {
     }
 
     upstream nothing {
-        session_sticky cookie=test;
-        server         127.0.0.1:9002;
-        server         127.0.0.1:9003;
+        session_sticky cookie=test maxidle=3600 option=indirect;
+        server         127.0.0.1:9000;
+        server         127.0.0.1:9001;
     }
 
     upstream insert_nocookie {
@@ -196,7 +198,7 @@ http {
     }
 
     server {
-        listen      127.0.0.1:8080;
+        listen      8080;
         server_name localhost;
 
         location /test_insert_indirect {
@@ -302,9 +304,17 @@ http {
         }
 
         location /test_nothing {
+            session_sticky_hide_cookie upstream=nothing;
             proxy_pass http://nothing/;
         }
     }
+
+	server {
+		listen 8080 default;
+
+		location /no_location {
+		}
+	}
 }
 
 EOF
@@ -467,9 +477,10 @@ sub my_http_get
     my ($url, $cookie) = @_;
     my $r = http(<<EOF);
 GET $url HTTP/1.1
-Host: localhost
 Connection: close
 Cookie: test=$cookie
+Host: localhost
+User-Agent:chrome
 
 EOF
 }


### PR DESCRIPTION
option=indirect，该选项打开之后，session sticky 会通过内存移动的方式删除cookie，但memmove后，没有重置request 其他域的指针，从而导致指针错乱；

触发条件：
1. cookies在host之前，并且host之后还有其它head；
2. cookie行中，只有1个cookie-SLB添加的server id；
