### PR TITLE
SSL: fix compilation error: 'SSL_OP_MSIE_SSLV2_RSA_PADDING' undeclared 

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -196,8 +196,10 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_options(ssl->ctx, SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG);
     SSL_CTX_set_options(ssl->ctx, SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER);
 
+#ifdef SSL_OP_MSIE_SSLV2_RSA_PADDING
     /* this option allow a potential SSL 2.0 rollback (CAN-2005-2969) */
     SSL_CTX_set_options(ssl->ctx, SSL_OP_MSIE_SSLV2_RSA_PADDING);
+#endif
 
     SSL_CTX_set_options(ssl->ctx, SSL_OP_SSLEAY_080_CLIENT_DH_BUG);
     SSL_CTX_set_options(ssl->ctx, SSL_OP_TLS_D5_BUG);


### PR DESCRIPTION
`SSL_OP_MSIE_SSLV2_RSA_PADDING` had no effect since 0.9.7h / 0.9.8b and it was removed in recent OpenSSL.

More details are available here: http://hg.nginx.org/nginx/rev/a73678f5f96f.

This patch tries to fix https://github.com/alibaba/tengine/issues/458.
