### PR TITLE
Feature: rt support in sysguard module

### DIFF
--- a/src/http/modules/ngx_http_sysguard_module.c
+++ b/src/http/modules/ngx_http_sysguard_module.c
@@ -8,17 +8,44 @@
 #include <ngx_http.h>
 
 
-typedef struct {
-    ngx_flag_t  enable;
-    ngx_int_t   load;
-    ngx_str_t   load_action;
-    ngx_int_t   swap;
-    ngx_str_t   swap_action;
-    size_t      free;
-    ngx_str_t   free_action;
-    time_t      interval;
+#define NGX_HTTP_SYSGUARD_MODE_OR  0
+#define NGX_HTTP_SYSGUARD_MODE_AND 1
 
-    ngx_uint_t  log_level;
+
+typedef struct {
+    time_t           stamp;
+    ngx_uint_t       requests;
+    time_t           sec;
+    ngx_msec_int_t   msec;
+} ngx_http_sysguard_rt_node_t;
+
+typedef struct {
+    ngx_http_sysguard_rt_node_t  *slots;
+    ngx_int_t                     nr_slots;
+    ngx_int_t                     current;
+
+    time_t                        cached_rt_exptime;
+    ngx_int_t                     cached_rt;
+} ngx_http_sysguard_rt_ring_t;
+
+typedef struct {
+    ngx_flag_t                    enable;
+
+    ngx_int_t                     load;
+    ngx_str_t                     load_action;
+    ngx_int_t                     swap;
+    ngx_str_t                     swap_action;
+    size_t                        free;
+    ngx_str_t                     free_action;
+    ngx_int_t                     rt;
+    ngx_int_t                     rt_period;
+    ngx_str_t                     rt_action;
+    time_t                        interval;
+
+    ngx_uint_t                    log_level;
+    ngx_uint_t                    mode;
+
+    ngx_http_sysguard_rt_ring_t  *rt_ring;
 } ngx_http_sysguard_conf_t;
 
 
@@ -29,6 +56,8 @@ static char *ngx_http_sysguard_load(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_sysguard_mem(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+static char *ngx_http_sysguard_rt(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
 static ngx_int_t ngx_http_sysguard_init(ngx_conf_t *cf);
 
 
@@ -37,6 +66,12 @@ static ngx_conf_enum_t  ngx_http_sysguard_log_levels[] = {
     { ngx_string("notice"), NGX_LOG_NOTICE },
     { ngx_string("warn"), NGX_LOG_WARN },
     { ngx_string("error"), NGX_LOG_ERR },
+    { ngx_null_string, 0 }
+};
+
+static ngx_conf_enum_t  ngx_http_sysguard_modes[] = {
+    { ngx_string("or"), NGX_HTTP_SYSGUARD_MODE_OR },
+    { ngx_string("and"), NGX_HTTP_SYSGUARD_MODE_AND },
     { ngx_null_string, 0 }
 };
 
@@ -50,6 +85,13 @@ static ngx_command_t  ngx_http_sysguard_commands[] = {
       offsetof(ngx_http_sysguard_conf_t, enable),
       NULL },
 
+    { ngx_string("sysguard_mode"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_enum_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_sysguard_conf_t, mode),
+      &ngx_http_sysguard_modes },
+
     { ngx_string("sysguard_load"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE12,
       ngx_http_sysguard_load,
@@ -60,6 +102,13 @@ static ngx_command_t  ngx_http_sysguard_commands[] = {
     { ngx_string("sysguard_mem"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE12,
       ngx_http_sysguard_mem,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("sysguard_rt"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE123,
+      ngx_http_sysguard_rt,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       NULL },
@@ -167,6 +216,137 @@ ngx_http_sysguard_update_mem(ngx_http_request_t *r, time_t exptime)
 
 
 static ngx_int_t
+ngx_http_sysguard_update_rt(ngx_http_request_t *r, time_t exptime)
+{
+    ngx_uint_t                    rt = 0, rt_sec = 0,
+                                  rt_requests = 0;
+    ngx_int_t                     i, head, processed = 0;
+    ngx_msec_int_t                rt_msec = 0;
+    ngx_http_sysguard_conf_t     *glcf;
+    ngx_http_sysguard_rt_ring_t  *ring;
+    ngx_http_sysguard_rt_node_t  *node, *cur_node;
+
+    glcf = ngx_http_get_module_loc_conf(r, ngx_http_sysguard_module);
+
+    ring = glcf->rt_ring;
+
+    ring->cached_rt_exptime = ngx_time() + exptime;
+
+    i = ring->current;
+
+    head = (ring->current + 1) % ring->nr_slots;
+
+    cur_node = &ring->slots[ring->current];
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "sysguard update rt: i: %i, c:%i h: %i",
+                   i, ring->current, head);
+
+    for ( ; (i != head) && (processed < glcf->rt_period); i--, processed++) {
+
+        node = &ring->slots[i];
+
+        ngx_log_debug5(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "node in loop: i: %i, p:%i, sec: %T, msec: %i, r: %ui",
+                       i, processed, node->sec, node->msec, node->requests);
+
+        if (node->stamp == 0
+            || (cur_node->stamp - node->stamp) != processed)
+        {
+
+            ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "continue: i: %i, p:%i, node tamp: %T, "
+                           "cur stamp: %T",
+                           i, processed, node->stamp, cur_node->stamp);
+
+           goto cont;
+        }
+
+        rt_sec += node->sec;
+        rt_msec += node->msec;
+        rt_requests += node->requests;
+
+cont:
+        /* wrap back to beginning */
+        if (i == 0) {
+            i = ring->nr_slots;
+        }
+    }
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "rt sec: %ui, rt msec:%i, rc requests: %ui",
+                   rt_sec, rt_msec, rt_requests);
+
+    rt_msec += (ngx_msec_int_t) (rt_sec * 1000);
+    rt_msec = ngx_max(rt_msec, 0);
+
+    if (rt_requests != 0 && rt_msec > 0) {
+
+        rt_msec = rt_msec / rt_requests;
+
+        rt = rt_msec / 1000 * 1000 + rt_msec % 1000;
+    }
+
+    ring->cached_rt = rt;
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_sysguard_update_rt_node(ngx_http_request_t *r)
+{
+    ngx_http_sysguard_rt_ring_t    *ring;
+    ngx_http_sysguard_rt_node_t    *node;
+    time_t                          cur_sec, off;
+    ngx_uint_t                      cur_msec;
+    ngx_http_sysguard_conf_t       *glcf;
+
+    glcf = ngx_http_get_module_loc_conf(r, ngx_http_sysguard_module);
+
+    if (!glcf->enable) {
+        return;
+    }
+
+    if (glcf->rt == NGX_CONF_UNSET) {
+        return;
+    }
+
+    cur_sec = ngx_cached_time->sec;
+    cur_msec = ngx_cached_time->msec;
+
+    ring = glcf->rt_ring;
+
+    node = &ring->slots[ring->current];
+
+    off = cur_sec - node->stamp;
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "sysguard update rt node: off: %T, stamp:%T, cur time: %T",
+                   off, node->stamp, cur_sec);
+
+    if (off) {
+
+        ring->current = (ring->current + off) % ring->nr_slots;
+
+        node = &ring->slots[ring->current];
+
+        memset(node, 0, sizeof(ngx_http_sysguard_rt_node_t));
+
+        node->stamp = cur_sec;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "sysguard update rt node: new current: %i",
+                   ring->current);
+
+    node->sec += cur_sec - r->start_sec;
+    node->msec += cur_msec - r->start_msec;
+    node->requests++;
+}
+
+
+static ngx_int_t
 ngx_http_sysguard_do_redirect(ngx_http_request_t *r, ngx_str_t *path)
 {
     if (path->len == 0) {
@@ -187,6 +367,9 @@ static ngx_int_t
 ngx_http_sysguard_handler(ngx_http_request_t *r)
 {
     ngx_http_sysguard_conf_t  *glcf;
+    ngx_int_t                  load_log = 0, swap_log = 0,
+                               free_log = 0, rt_log = 0;
+    ngx_str_t                 *action = NULL;
 
     if (r->main->sysguard_set) {
         return NGX_DECLINED;
@@ -217,12 +400,22 @@ ngx_http_sysguard_handler(ngx_http_request_t *r)
 
         if (ngx_http_sysguard_cached_load > glcf->load) {
 
-            ngx_log_error(glcf->log_level, r->connection->log, 0,
-                          "sysguard load limited, current:%1.3f conf:%1.3f",
-                          ngx_http_sysguard_cached_load * 1.0 / 1000,
-                          glcf->load * 1.0 / 1000);
+            if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_OR) {
 
-            return ngx_http_sysguard_do_redirect(r, &glcf->load_action);
+                ngx_log_error(glcf->log_level, r->connection->log, 0,
+                              "sysguard load limited, current:%1.3f conf:%1.3f",
+                              ngx_http_sysguard_cached_load * 1.0 / 1000,
+                              glcf->load * 1.0 / 1000);
+
+                return ngx_http_sysguard_do_redirect(r, &glcf->load_action);
+            } else {
+                action = &glcf->load_action;
+                load_log = 1;
+            }
+        } else {
+            if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_AND) {
+                goto out;
+            }
         }
     }
 
@@ -243,12 +436,22 @@ ngx_http_sysguard_handler(ngx_http_request_t *r)
 
         if (ngx_http_sysguard_cached_swapstat > glcf->swap) {
 
-            ngx_log_error(glcf->log_level, r->connection->log, 0,
-                          "sysguard swap limited, current:%i conf:%i",
-                          ngx_http_sysguard_cached_swapstat,
-                          glcf->swap);
+            if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_OR) {
 
-            return ngx_http_sysguard_do_redirect(r, &glcf->swap_action);
+                ngx_log_error(glcf->log_level, r->connection->log, 0,
+                              "sysguard swap limited, current:%i conf:%i",
+                              ngx_http_sysguard_cached_swapstat,
+                              glcf->swap);
+
+                return ngx_http_sysguard_do_redirect(r, &glcf->swap_action);
+            } else {
+                action = &glcf->swap_action;
+                swap_log = 1;
+            }
+        } else {
+            if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_AND) {
+                goto out;
+            }
         }
     }
 
@@ -271,17 +474,95 @@ ngx_http_sysguard_handler(ngx_http_request_t *r)
 
             if (ngx_http_sysguard_cached_free < glcf->free) {
 
-                ngx_log_error(glcf->log_level, r->connection->log, 0,
-                              "sysguard free limited, current:%uzM conf:%uzM",
-                              ngx_http_sysguard_cached_free / 1024 / 1024,
-                              glcf->free / 1024 / 1024);
+                if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_OR) {
 
-                return ngx_http_sysguard_do_redirect(r, &glcf->free_action);
+                    ngx_log_error(glcf->log_level, r->connection->log, 0,
+                                  "sysguard free limited, "
+                                  "current:%uzM conf:%uzM",
+                                  ngx_http_sysguard_cached_free / 1024 / 1024,
+                                  glcf->free / 1024 / 1024);
+
+                    return ngx_http_sysguard_do_redirect(r, &glcf->free_action);
+                } else {
+                    action = &glcf->free_action;
+                    free_log = 1;
+                }
+            } else {
+                if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_AND) {
+                    goto out;
+                }
             }
         }
-
     }
 
+    /* response time */
+
+    if (glcf->rt != NGX_CONF_UNSET) {
+
+        if (glcf->rt_ring->cached_rt_exptime < ngx_time()) {
+            ngx_http_sysguard_update_rt(r, glcf->interval);
+        }
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http sysguard handler rt: %1.3f %1.3f",
+                       glcf->rt_ring->cached_rt * 1.0 / 1000,
+                       glcf->rt * 1.0 / 1000);
+
+        if (glcf->rt_ring->cached_rt > glcf->rt) {
+
+            if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_OR) {
+
+                ngx_log_error(glcf->log_level, r->connection->log, 0,
+                              "sysguard rt limited, current:%1.3f conf:%1.3f",
+                              glcf->rt_ring->cached_rt * 1.0 / 1000,
+                              glcf->rt * 1.0 / 1000);
+
+                return ngx_http_sysguard_do_redirect(r, &glcf->rt_action);
+            } else {
+                action = &glcf->rt_action;
+                rt_log = 1;
+            }
+        } else {
+            if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_AND) {
+                goto out;
+            }
+        }
+    }
+
+    if (glcf->mode == NGX_HTTP_SYSGUARD_MODE_AND && action) {
+
+        if (load_log) {
+            ngx_log_error(glcf->log_level, r->connection->log, 0,
+                          "sysguard load limited, current:%1.3f conf:%1.3f",
+                          ngx_http_sysguard_cached_load * 1.0 / 1000,
+                          glcf->load * 1.0 / 1000);
+        }
+
+        if (swap_log) {
+            ngx_log_error(glcf->log_level, r->connection->log, 0,
+                          "sysguard swap limited, current:%i conf:%i",
+                          ngx_http_sysguard_cached_swapstat,
+                          glcf->swap);
+        }
+
+        if (free_log) {
+            ngx_log_error(glcf->log_level, r->connection->log, 0,
+                          "sysguard free limited, current:%uzM conf:%uzM",
+                          ngx_http_sysguard_cached_free / 1024 / 1024,
+                          glcf->free / 1024 / 1024);
+        }
+
+        if (rt_log) {
+            ngx_log_error(glcf->log_level, r->connection->log, 0,
+                          "sysguard rt limited, current:%1.3f conf:%1.3f",
+                          glcf->rt_ring->cached_rt * 1.0 / 1000,
+                          glcf->rt * 1.0 / 1000);
+        }
+
+        return ngx_http_sysguard_do_redirect(r, action);
+    }
+
+out:
     return NGX_DECLINED;
 }
 
@@ -301,14 +582,19 @@ ngx_http_sysguard_create_conf(ngx_conf_t *cf)
      *
      *     conf->load_action = {0, NULL};
      *     conf->swap_action = {0, NULL};
+     *     conf->rt_action = {0, NULL};
+     *     conf->ring = NULL;
      */
 
     conf->enable = NGX_CONF_UNSET;
     conf->load = NGX_CONF_UNSET;
     conf->swap = NGX_CONF_UNSET;
     conf->free = NGX_CONF_UNSET_SIZE;
+    conf->rt = NGX_CONF_UNSET;
+    conf->rt_period = NGX_CONF_UNSET;
     conf->interval = NGX_CONF_UNSET;
     conf->log_level = NGX_CONF_UNSET_UINT;
+    conf->mode = NGX_CONF_UNSET_UINT;
 
     return conf;
 }
@@ -324,14 +610,40 @@ ngx_http_sysguard_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_str_value(conf->load_action, prev->load_action, "");
     ngx_conf_merge_str_value(conf->swap_action, prev->swap_action, "");
     ngx_conf_merge_str_value(conf->free_action, prev->free_action, "");
+    ngx_conf_merge_str_value(conf->rt_action, prev->rt_action, "");
     ngx_conf_merge_value(conf->load, prev->load, NGX_CONF_UNSET);
     ngx_conf_merge_value(conf->swap, prev->swap, NGX_CONF_UNSET);
     ngx_conf_merge_size_value(conf->free, prev->free, NGX_CONF_UNSET_SIZE);
+    ngx_conf_merge_value(conf->rt, prev->rt, NGX_CONF_UNSET);
+    ngx_conf_merge_value(conf->rt_period, prev->rt_period, 1);
     ngx_conf_merge_value(conf->interval, prev->interval, 1);
     ngx_conf_merge_uint_value(conf->log_level, prev->log_level, NGX_LOG_ERR);
+    ngx_conf_merge_uint_value(conf->mode, prev->mode,
+                              NGX_HTTP_SYSGUARD_MODE_OR);
+
+
+    if (conf->rt != NGX_CONF_UNSET) {
+        /* init glcf->ring */
+        conf->rt_ring = ngx_pcalloc(cf->pool,
+                                    sizeof(ngx_http_sysguard_rt_ring_t));
+        if (conf->rt_ring == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        conf->rt_ring->slots = ngx_pcalloc(cf->pool,
+                         sizeof(ngx_http_sysguard_rt_node_t) * conf->rt_period);
+        if (conf->rt_ring->slots == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        conf->rt_ring->nr_slots = conf->rt_period;
+        conf->rt_ring->current = 0;
+        conf->rt_ring->slots[0].stamp = ngx_time();
+    }
 
     return NGX_CONF_OK;
 }
+
 
 static char *
 ngx_http_sysguard_load(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
@@ -500,6 +812,81 @@ invalid:
 }
 
 
+static char *
+ngx_http_sysguard_rt(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_sysguard_conf_t  *glcf = conf;
+
+    ngx_str_t  *value, ss;
+    ngx_uint_t  i;
+
+    value = cf->args->elts;
+
+    for (i = 1; i < cf->args->nelts; i++) {
+        if (ngx_strncmp(value[i].data, "rt=", 3) == 0) {
+
+            if (glcf->rt != NGX_CONF_UNSET) {
+                return "is duplicate";
+            }
+
+            glcf->rt = ngx_atofp(value[i].data + 3, value[i].len - 3, 3);
+            if (glcf->rt == NGX_ERROR) {
+                goto invalid;
+            }
+
+            continue;
+        }
+
+        if (ngx_strncmp(value[i].data, "period=", 7) == 0) {
+
+            ss.data = value[i].data + 7;
+            ss.len = value[i].len - 7;
+
+            glcf->rt_period = ngx_parse_time(&ss, 1);
+            if (glcf->rt_period == NGX_ERROR) {
+                goto invalid;
+            }
+
+            continue;
+        }
+
+        if (ngx_strncmp(value[i].data, "action=", 7) == 0) {
+
+            if (value[i].len == 7) {
+                goto invalid;
+            }
+
+            if (value[i].data[7] != '/' && value[i].data[7] != '@') {
+                goto invalid;
+            }
+
+            glcf->rt_action.data = value[i].data + 7;
+            glcf->rt_action.len = value[i].len - 7;
+
+            continue;
+        }
+    }
+
+    return NGX_CONF_OK;
+
+invalid:
+
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                       "invalid parameter \"%V\"", &value[i]);
+
+    return NGX_CONF_ERROR;
+}
+
+
+static ngx_int_t
+ngx_http_sysguard_log_handler(ngx_http_request_t *r)
+{
+    ngx_http_sysguard_update_rt_node(r);
+
+    return NGX_OK;
+}
+
+
 static ngx_int_t
 ngx_http_sysguard_init(ngx_conf_t *cf)
 {
@@ -514,6 +901,13 @@ ngx_http_sysguard_init(ngx_conf_t *cf)
     }
 
     *h = ngx_http_sysguard_handler;
+
+    h = ngx_array_push(&cmcf->phases[NGX_HTTP_LOG_PHASE].handlers);
+    if (h == NULL) {
+        return NGX_ERROR;
+    }
+
+    *h = ngx_http_sysguard_log_handler;
 
     return NGX_OK;
 }

--- a/tests/nginx-tests/cases/sysguard.t
+++ b/tests/nginx-tests/cases/sysguard.t
@@ -24,7 +24,7 @@ my $can_use_threads = eval 'use threads; 1';
 plan(skip_all => 'perl does not support threads') if (!$can_use_threads || threads->VERSION < 1.86);
 plan(skip_all => 'unsupported os') if (!(-e "/usr/bin/uptime" || -e "/usr/bin/free"));
 
-my $t = Test::Nginx->new()->has(qw/http sysguard/)->plan(8);
+my $t = Test::Nginx->new()->has(qw/http sysguard/)->plan(19);
 
 $t->set_dso("ngx_http_fastcgi_module", "ngx_http_fastcgi_module.so");
 $t->set_dso("ngx_http_uwsgi_module", "ngx_http_uwsgi_module.so");
@@ -96,6 +96,80 @@ http {
             sysguard_mem free=%%free1%%k action=/limit;
         }
 
+        location /rt_limit {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_rt rt=0.001 period=2s action=/limit;
+        }
+
+        location /load_and_rt_limit {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode and;
+            sysguard_load load=%%load1%% action=/limit;
+            sysguard_rt rt=0.001 period=2s action=/limit;
+        }
+
+        location /load_or_rt_limit {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode or;
+            sysguard_load load=%%load2%% action=/limit;
+            sysguard_rt rt=0.001 period=2s actoin=/limit;
+        }
+
+        location /load_or_rt_limit1 {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode or;
+            sysguard_load load=%%load1%% action=/limit;
+            sysguard_rt rt=0.001 period=2s actoin=/limit;
+        }
+
+        location /load_or_rt_limit2 {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode or;
+            sysguard_load load=%%load1%% action=/limit;
+            sysguard_rt rt=10.000 period=2s actoin=/limit;
+        }
+
+        location /rt_unlimit {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_rt rt=10.000 period=1s action=/limit;
+        }
+
+        location /load_and_rt_unlimit {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode and;
+            sysguard_load load=%%load2%% action=/limit;
+            sysguard_rt rt=10.000 period=1s action=/limit;
+        }
+
+        location /load_and_rt_unlimit1 {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode and;
+            sysguard_load load=%%load1%% action=/limit;
+            sysguard_rt rt=10.000 period=1s action=/limit;
+        }
+
+        location /load_and_rt_unlimit2 {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode and;
+            sysguard_load load=%%load2%% action=/limit;
+            sysguard_rt rt=0.001 period=1s action=/limit;
+        }
+
+        location /load_or_rt_unlimit {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode or;
+            sysguard_load load=%%load2%% action=/limit;
+            sysguard_rt rt=10.000 period=1s action=/limit;
+        }
+
+        location /load_and_mem_and_rt_limit {
+            proxy_pass http://127.0.0.1:8081;
+            sysguard_mode and;
+            sysguard_load load=%%load1%% action=/limit;
+            sysguard_rt rt=0.001 period=2s action=/limit;
+            sysguard_mem free=%%free2%%k action=/limit;
+        }
+
         location /limit {
             return 503;
         }
@@ -126,6 +200,7 @@ $content =~ s/%%free2%%/$free_up/gmse;
 
 $t->write_file_expand('nginx.conf', $content);
 
+$t->run_daemon(\&http_daemon);
 $t->run();
 
 ###############################################################################
@@ -140,6 +215,38 @@ like(http_get("/mem_load_limit"), qr/503/, 'mem_load_limit');
 like(http_get("/mem_load_limit1"), qr/503/, 'mem_load_limit1');
 like(http_get("/mem_load_limit2"), qr/503/, 'mem_load_limit2');
 like(http_get("/mem_load_limit3"), qr/404/, 'mem_load_limit3');
+
+
+http_get("/rt_limit");
+# To expire cache (sysguard interval)
+sleep 1;
+
+like(http_get("/rt_limit"), qr/503/, 'rt_limit');
+
+http_get("/load_and_rt_limit");
+sleep 1;
+like(http_get("/load_and_rt_limit"), qr/503/, 'load_and_rt_limit');
+http_get("/load_or_rt_limit");
+sleep 1;
+like(http_get("/load_or_rt_limit"), qr/503/, 'load_or_rt_limit');
+like(http_get("/load_or_rt_limit1"), qr/503/, 'load_or_rt_limit1');
+like(http_get("/load_or_rt_limit2"), qr/503/, 'load_or_rt_limit2');
+
+sleep 1;
+http_get("/rt_unlimit");
+like(http_get("/rt_unlimit"), qr/404/, 'rt_unlimit');
+
+like(http_get("/load_and_rt_unlimit"), qr/404/, 'load_and_rt_unlimit');
+like(http_get("/load_and_rt_unlimit1"), qr/404/, 'load_and_rt_unlimit1');
+like(http_get("/load_and_rt_unlimit2"), qr/404/, 'load_and_rt_unlimit2');
+like(http_get("/load_or_rt_unlimit"), qr/404/, 'load_or_rt_unlimit');
+
+sleep 1;
+http_get("/load_and_mem_and_rt_limit");
+sleep 1;
+like(http_get("/load_and_mem_and_rt_limit"), qr/503/,
+     'load_and_mem_and_rt_limit');
+
 
 sub getload
 {
@@ -184,5 +291,53 @@ sub runload
     sleep(10);
     for ($i = 0; $i<=8; $i++) {
         $ths[$i]->kill('KILL')->detach();
+    }
+}
+
+sub http_daemon {
+    my $server = IO::Socket::INET->new(
+        Proto => 'tcp',
+        LocalHost => '127.0.0.1:8081',
+        Listen => 5,
+        Reuse => 1
+    )
+    or die "Can't create listening socket: $!\n";
+
+    local $SIG{PIPE} = 'IGNORE';
+
+    while (my $client = $server->accept()) {
+        $client->autoflush(1);
+
+        my $headers = '';
+        my $uri = '';
+
+        while (<$client>) {
+            $headers .= $_;
+            last if (/^\x0d?\x0a?$/);
+        }
+
+        $uri = $1 if $headers =~ /^\S+\s+([^ ]+)\s+HTTP/i;
+
+        if ($uri =~ /^.*_limit$/) {
+            sleep 1;
+            print $client <<'EOF';
+HTTP/1.1 200 OK
+Connection: close
+
+EOF
+            print $client "TEST-OK-IF-YOU-SEE-THIS"
+            unless $headers =~ /^HEAD/i;
+
+        } else {
+
+            print $client <<"EOF";
+HTTP/1.1 404 Not Found
+Connection: close
+
+Oops, '$uri' not found
+EOF
+        }
+
+        close $client;
     }
 }


### PR DESCRIPTION
Two new directives are introduced:
*) sysguard_mode and/or
*) sysguard_rt rt=time period=time action=some_location

This feature introduces the ability to limit requests based on "rt".
Also, all the measurements can be considered in an "and" or "or"
relationship due to the new "sysguard_mode" directive.

Test cases are included.

Signed-off-by: Paul Yang(InfoHunter) paulyang.inf@gmail.com
