### PR TITLE
Shared keepalive v5

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -17,6 +17,7 @@ CORE_DEPS="src/core/nginx.h \
            src/core/ngx_hash.h \
            src/core/ngx_buf.h \
            src/core/ngx_queue.h \
+           src/core/ngx_lfstack.h \
            src/core/ngx_string.h \
            src/core/ngx_parse.h \
            src/core/ngx_inet.h \
@@ -49,6 +50,7 @@ CORE_SRCS="src/core/nginx.c \
            src/core/ngx_hash.c \
            src/core/ngx_buf.c \
            src/core/ngx_queue.c \
+           src/core/ngx_lfstack.c \
            src/core/ngx_output_chain.c \
            src/core/ngx_string.c \
            src/core/ngx_parse.c \

--- a/src/core/ngx_core.h
+++ b/src/core/ngx_core.h
@@ -33,6 +33,7 @@ typedef void (*ngx_connection_handler_pt)(ngx_connection_t *c);
 #define  NGX_DONE       -4
 #define  NGX_DECLINED   -5
 #define  NGX_ABORT      -6
+#define  NGX_YIELD      -7
 
 
 #include <ngx_errno.h>

--- a/src/core/ngx_core.h
+++ b/src/core/ngx_core.h
@@ -61,6 +61,7 @@ typedef void (*ngx_connection_handler_pt)(ngx_connection_t *c);
 #include <ngx_crc.h>
 #include <ngx_crc32.h>
 #include <ngx_murmurhash.h>
+#include <ngx_lfstack.h>
 #if (NGX_PCRE)
 #include <ngx_regex.h>
 #endif

--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -1408,6 +1408,7 @@ ngx_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size, void *tag)
     shm_zone->shm.size = size;
     shm_zone->shm.name = *name;
     shm_zone->shm.exists = 0;
+    shm_zone->shm.slab = 1;
     shm_zone->init = NULL;
     shm_zone->tag = tag;
 

--- a/src/core/ngx_lfstack.c
+++ b/src/core/ngx_lfstack.c
@@ -1,0 +1,149 @@
+
+/*
+ * Copyright (C) Yunkai Zhang
+ * Copyright (C) Alibaba Group Holding Limited
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+
+void
+ngx_lfstack_init(ngx_lfstack_t *l, size_t offset)
+{
+    l->head = 0;
+    l->offset = offset;
+}
+
+
+void
+ngx_lfstack_push(ngx_lfstack_t *l, void *item)
+{
+    ngx_int_t       rc;
+    ngx_atomic_t    prev, curr, addr, ver, *target;
+
+    target = ngx_offset_addr(item, l->offset);
+
+    do {
+        prev = l->head;
+
+        addr = ngx_ptr_addr_get(prev);
+        ver = ngx_ptr_ver_get(prev);
+
+        *target = addr;
+
+        curr = ngx_ptr_ver_set(item, ver);
+
+        rc = ngx_atomic_cmp_set(&l->head, prev, curr);
+    } while (rc == 0);
+
+    return;
+}
+
+
+void *
+ngx_lfstack_pop(ngx_lfstack_t *l)
+{
+    ngx_int_t       rc;
+    ngx_atomic_t    prev, next, addr, ver, *target;
+
+    do {
+        prev = l->head;
+
+        addr = ngx_ptr_addr_get(prev);
+
+        if (addr == 0) {
+            return NULL;
+        }
+
+        ver = ngx_ptr_ver_get(prev);
+
+        target = ngx_offset_addr(addr, l->offset);
+
+        next = ngx_ptr_ver_set(*target, ver + 1);
+
+        rc = ngx_atomic_cmp_set(&l->head, prev, next);
+    } while (rc == 0);
+
+    *target = 0;
+    return (void *) addr;
+}
+
+
+void *
+ngx_lfstack_popall(ngx_lfstack_t *l)
+{
+    ngx_int_t       rc;
+    ngx_atomic_t    prev, next, addr, ver;
+
+    do {
+        prev = l->head;
+
+        addr = ngx_ptr_addr_get(prev);
+
+        if (addr == 0) {
+            return NULL;
+        }
+
+        ver = ngx_ptr_addr_get(prev);
+
+        next = ngx_ptr_ver_set(0, ver + 1);
+
+        rc = ngx_atomic_cmp_set(&l->head, prev, next);
+    } while (rc == 0);
+
+    return (void *) addr;
+}
+
+
+void *
+ngx_lfstack_remove(ngx_lfstack_t *l, void *item)
+{
+    ngx_int_t       rc;
+    ngx_atomic_t    prev, next, addr, ver, *target, *target_next;
+
+retry:
+    prev = l->head;
+
+    addr = ngx_ptr_addr_get(prev);
+
+    target = ngx_offset_addr(item, l->offset);
+
+    while ((void *) addr == item) {
+        ver = ngx_ptr_ver_get(prev);
+
+        next = ngx_ptr_ver_set(*target, ver + 1);
+
+        rc = ngx_atomic_cmp_set(&l->head, prev, next);
+        if (rc) {
+            *target = 0;
+            return item;
+        }
+
+        prev = l->head;
+
+        addr = ngx_ptr_addr_get(prev);
+    }
+
+    next = addr;
+
+    while (next) {
+        target_next = ngx_offset_addr(next, l->offset);
+
+        next = *target_next;
+
+        if ((void *) next == item) {
+
+            rc = ngx_atomic_cmp_set(target_next, next, *target);
+            if (rc) {
+                *target = 0;
+                return item;
+            }
+
+            goto retry;
+        }
+    }
+
+    return NULL;
+}

--- a/src/core/ngx_lfstack.h
+++ b/src/core/ngx_lfstack.h
@@ -1,0 +1,57 @@
+
+/*
+ * Copyright (C) Yunkai Zhang
+ * Copyright (C) Alibaba Group Holding Limited
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+
+#ifndef _NGX_LFSTACK_H_INCLUDED_
+#define _NGX_LFSTACK_H_INCLUDED_
+
+
+/* TODO: Support 32bit system */
+
+/*
+ * In x86-64 architecture, linux virtual adderss
+ * comply with AMD Canonical form:
+ *
+ * *) Kernal virtual address space:
+ *    FFFF8000 00000000 - FFFFFFFF FFFFFFFF
+ *
+ * *) User virtual address space:
+ *    00007FFF FFFFFFFF - 00000000 00000000
+ *
+ * For more detail, please read this link:
+ * http://en.wikipedia.org/wiki/X86-64
+ */
+#define ngx_ptr_addr_get(ptr) \
+    (((uint64_t)(ptr) << 16) >> 16)
+
+#define ngx_ptr_ver_get(ptr) \
+    ((uint64_t)(ptr) >> 48)
+
+#define ngx_ptr_ver_set(ptr, ver) \
+    (((uint64_t)(ver) << 48) \
+     | ngx_ptr_addr_get(ptr))
+
+#define ngx_offset_addr(ptr, offset) \
+    (void *)((char *)(ptr) + (offset));
+
+typedef struct {
+    ngx_atomic_t    head;
+    size_t          offset;
+} ngx_lfstack_t;
+
+
+void ngx_lfstack_init(ngx_lfstack_t *l, size_t offset);
+void ngx_lfstack_push(ngx_lfstack_t *l, void *item);
+void *ngx_lfstack_pop(ngx_lfstack_t *l);
+void *ngx_lfstack_popall(ngx_lfstack_t *l);
+void *ngx_lfstack_remove(ngx_lfstack_t *l, void *item);
+
+
+#endif /* _NGX_LFSTACK_H_INCLUDED_ */

--- a/src/event/ngx_event_connect.h
+++ b/src/event/ngx_event_connect.h
@@ -62,6 +62,9 @@ struct ngx_peer_connection_s {
 
     ngx_log_t                       *log;
 
+    void                            *request;
+    void                            *upstream;
+
     unsigned                         cached:1;
 
                                      /* ngx_connection_log_error_e */
@@ -69,6 +72,8 @@ struct ngx_peer_connection_s {
 };
 
 
+ngx_int_t ngx_event_init_peer_socket(ngx_socket_t s, ngx_peer_connection_t *pc,
+    ngx_int_t rc);
 ngx_int_t ngx_event_connect_peer(ngx_peer_connection_t *pc);
 ngx_int_t ngx_event_get_peer(ngx_peer_connection_t *pc, void *data);
 

--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -8,11 +8,16 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+#include <ngx_channel.h>
 
 
 typedef struct {
     ngx_uint_t                         max_cached;
     ngx_msec_t                         keepalive_timeout;
+
+    ngx_uint_t                         per_server_pool:1;
+    ngx_uint_t                         shared:1;
+    void                              *shared_info;
 
     ngx_queue_t                        cache;
     ngx_queue_t                        free;
@@ -42,7 +47,7 @@ typedef struct {
 
 
 typedef struct {
-    ngx_http_upstream_keepalive_srv_conf_t  *conf;
+    ngx_http_upstream_keepalive_srv_conf_t  *conf; /* must be the top element */
 
     ngx_queue_t                        queue;
     ngx_connection_t                  *connection;
@@ -53,12 +58,60 @@ typedef struct {
 } ngx_http_upstream_keepalive_cache_t;
 
 
+typedef struct {
+    socklen_t                          socklen;
+    u_char                             sockaddr[NGX_SOCKADDRLEN];
+
+    ngx_lfstack_t                     *idle_list;
+    ngx_lfstack_t                     *free_list;
+} ngx_http_upstream_keepalive_shared_srv_t;
+
+
+typedef struct {
+    ngx_http_upstream_keepalive_srv_conf_t  *conf; /* must be the top element */
+
+    ngx_uint_t                         srv_index:16;
+    ngx_uint_t                         force_timeout:1;
+
+    ngx_pid_t                          pid;
+    ngx_uint_t                         slot;
+    ngx_socket_t                       fd;
+    ngx_connection_t                  *connection;
+
+    ngx_atomic_t                       next;
+} ngx_http_upstream_keepalive_shared_conn_t;
+
+
+typedef struct {
+    void                              *srv;
+    ngx_uint_t                         nsrv;
+    ngx_uint_t                         worker_processes;
+} ngx_http_upstream_keepalive_shared_info_t;
+
+
+typedef struct {
+    ngx_channel_t                      ch;
+    ngx_socket_t                       fd;
+    void                              *pc;
+    void                              *conn;
+} ngx_http_upstream_keepalive_channel_data_t;
+
+
 static ngx_int_t ngx_http_upstream_init_keepalive_peer(ngx_http_request_t *r,
     ngx_http_upstream_srv_conf_t *us);
 static ngx_int_t ngx_http_upstream_get_keepalive_peer(ngx_peer_connection_t *pc,
     void *data);
 static void ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc,
     void *data, ngx_uint_t state);
+static ngx_int_t ngx_http_upstream_get_shared_keepalive_peer(
+    ngx_peer_connection_t *pc, void *data);
+static void ngx_http_upstream_free_shared_keepalive_peer(
+    ngx_peer_connection_t *pc, void *data, ngx_uint_t state);
+
+static ngx_int_t ngx_http_upstream_keepalive_channel_send_fd(ngx_channel_t *ch,
+    void *data, ngx_log_t *log);
+static ngx_int_t ngx_http_upstream_keepalive_channel_recv_fd(ngx_channel_t *ch,
+    void *data, ngx_log_t *log);
 
 static void ngx_http_upstream_keepalive_dummy_handler(ngx_event_t *ev);
 static void ngx_http_upstream_keepalive_close_handler(ngx_event_t *ev);
@@ -82,7 +135,7 @@ static char *ngx_http_upstream_keepalive_timeout(ngx_conf_t *cf,
 static ngx_command_t  ngx_http_upstream_keepalive_commands[] = {
 
     { ngx_string("keepalive"),
-      NGX_HTTP_UPS_CONF|NGX_CONF_TAKE12,
+      NGX_HTTP_UPS_CONF|NGX_CONF_TAKE123,
       ngx_http_upstream_keepalive,
       0,
       0,
@@ -130,13 +183,127 @@ ngx_module_t  ngx_http_upstream_keepalive_module = {
 };
 
 
+static int ngx_libc_cdecl
+ngx_http_upstream_cmp_keepalive_shared_srv(const void *one, const void *two)
+{
+    ngx_http_upstream_keepalive_shared_srv_t  *first, *second;
+
+    first = (ngx_http_upstream_keepalive_shared_srv_t *) one;
+    second = (ngx_http_upstream_keepalive_shared_srv_t *) two;
+
+    return ngx_memn2cmp((u_char *) first->sockaddr,
+                        (u_char *) second->sockaddr,
+                        first->socklen, second->socklen);
+}
+
+
+static ngx_int_t
+ngx_http_upstream_init_keepalive_zone(ngx_shm_zone_t *shm_zone, void *data)
+{
+    ngx_shm_t                                   *shm;
+    ngx_cycle_t                                 *cycle;
+    ngx_core_conf_t                             *ccf;
+    ngx_http_upstream_server_t                  *usrv;
+    ngx_http_upstream_srv_conf_t                *us;
+    ngx_http_upstream_keepalive_srv_conf_t      *kcf;
+    ngx_http_upstream_keepalive_shared_info_t   *info;
+    ngx_http_upstream_keepalive_shared_conn_t   *conn;
+    ngx_http_upstream_keepalive_shared_srv_t    *srv;
+    ngx_uint_t                                   i, j;
+    size_t                                       si, sj, sk, offset;
+
+    us = shm_zone->data;
+    shm = &shm_zone->shm;
+
+    kcf = ngx_http_conf_upstream_srv_conf(us,
+                                          ngx_http_upstream_keepalive_module);
+
+    cycle = kcf->shared_info;
+    kcf->shared_info = NULL;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cycle->log, 0,
+                   "init keepalive zone");
+
+    ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx, ngx_core_module);
+
+    ngx_memzero(shm->addr, shm->size);
+
+    si = sizeof(ngx_http_upstream_keepalive_shared_info_t);
+
+    sj = sizeof(ngx_http_upstream_keepalive_shared_srv_t)
+       * us->servers->nelts;
+
+    sk = sizeof(ngx_lfstack_t) * (ccf->worker_processes + 1);
+
+    info = (void *) shm->addr;
+    info->srv = shm->addr + si;
+    info->nsrv = us->servers->nelts;
+    info->worker_processes = ccf->worker_processes;
+
+    kcf->shared_info = info;
+
+    offset = offsetof(ngx_http_upstream_keepalive_shared_conn_t, next);
+
+    srv = info->srv;
+    usrv = us->servers->elts;
+    for (i = 0; i < info->nsrv; i++) {
+        srv[i].socklen = usrv[i].addrs->socklen;
+
+        ngx_memcpy(srv[i].sockaddr, usrv[i].addrs->sockaddr,
+                   srv[i].socklen);
+
+        srv[i].idle_list = (ngx_lfstack_t *) ((char *) srv + sj + (sk * i));
+
+        for (j = 0; j < (info->worker_processes + 1); j++) {
+            ngx_lfstack_init(&srv[i].idle_list[j], offset);
+        }
+    }
+
+    ngx_qsort(srv, (size_t) info->nsrv, sizeof(*srv),
+              ngx_http_upstream_cmp_keepalive_shared_srv);
+
+    conn = (void *) (shm->addr + si + sj + (sk * info->nsrv));
+
+    if (kcf->per_server_pool == 0) {
+        for (i = 0; i < info->nsrv; i++) {
+            srv[i].free_list = &srv[0].idle_list[info->worker_processes];
+        }
+
+        for (i = 0; i < kcf->max_cached; i++) {
+            ngx_lfstack_push(srv[0].free_list, &conn[i]);
+        }
+
+        return NGX_OK;
+    }
+
+    for (i = 0; i < info->nsrv; i++) {
+        srv[i].free_list = &srv[i].idle_list[info->worker_processes];
+
+        for (j = 0; j < kcf->max_cached; j++) {
+            ngx_lfstack_push(srv[i].free_list, &conn[i * kcf->max_cached + j]);
+        }
+    }
+
+    return NGX_OK;
+}
+
+
 static ngx_int_t
 ngx_http_upstream_init_keepalive(ngx_conf_t *cf,
     ngx_http_upstream_srv_conf_t *us)
 {
-    ngx_uint_t                               i;
-    ngx_http_upstream_keepalive_srv_conf_t  *kcf;
-    ngx_http_upstream_keepalive_cache_t     *cached;
+    ngx_str_t                                    name;
+    ngx_uint_t                                   i;
+    ngx_shm_zone_t                              *shm_zone;
+    ngx_core_conf_t                             *ccf;
+    ngx_http_upstream_keepalive_srv_conf_t      *kcf;
+    ngx_http_upstream_keepalive_cache_t         *cached;
+
+    void      **ctx;
+    size_t      si, sj, sk, sl, size;
+
+    ctx = (void **) cf->cycle->conf_ctx;
+    ccf = (ngx_core_conf_t *) ngx_get_conf(ctx, ngx_core_module);
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cf->log, 0,
                    "init keepalive");
@@ -151,6 +318,40 @@ ngx_http_upstream_init_keepalive(ngx_conf_t *cf,
     kcf->original_init_peer = us->peer.init;
 
     us->peer.init = ngx_http_upstream_init_keepalive_peer;
+
+    if (kcf->shared) {
+        si = sizeof(ngx_http_upstream_keepalive_shared_info_t);
+
+        sj = sizeof(ngx_http_upstream_keepalive_shared_srv_t)
+           * us->servers->nelts;
+
+        sk = (sizeof(ngx_lfstack_t) * (ccf->worker_processes + 1))
+           * us->servers->nelts;
+
+        sl = sizeof(ngx_http_upstream_keepalive_shared_conn_t)
+           * kcf->max_cached;
+
+        if (kcf->per_server_pool) {
+            sl *= us->servers->nelts;
+        }
+
+        size = si + sj + sk + sl;
+
+        name.len = us->host.len;
+        name.data = us->host.data;
+
+        shm_zone = ngx_shared_memory_add(cf, &name, size,
+                                         (void *) ngx_current_msec);
+
+        /* shared memory won't be used by slab pool */
+        shm_zone->shm.slab = 0;
+        shm_zone->data = us;
+        shm_zone->init = ngx_http_upstream_init_keepalive_zone;
+
+        kcf->shared_info = cf->cycle;
+
+        return NGX_OK;
+    }
 
     /* allocate cache items and add to free queue */
 
@@ -201,8 +402,15 @@ ngx_http_upstream_init_keepalive_peer(ngx_http_request_t *r,
     kp->original_free_peer = r->upstream->peer.free;
 
     r->upstream->peer.data = kp;
-    r->upstream->peer.get = ngx_http_upstream_get_keepalive_peer;
-    r->upstream->peer.free = ngx_http_upstream_free_keepalive_peer;
+
+    if (kcf->shared) {
+        r->upstream->peer.get = ngx_http_upstream_get_shared_keepalive_peer;
+        r->upstream->peer.free = ngx_http_upstream_free_shared_keepalive_peer;
+
+    } else {
+        r->upstream->peer.get = ngx_http_upstream_get_keepalive_peer;
+        r->upstream->peer.free = ngx_http_upstream_free_keepalive_peer;
+    }
 
 #if (NGX_HTTP_SSL)
     kp->original_set_session = r->upstream->peer.set_session;
@@ -376,6 +584,256 @@ invalid:
 }
 
 
+static ngx_int_t
+ngx_http_upstream_get_shared_keepalive_peer(ngx_peer_connection_t *pc,
+    void *data)
+{
+    ngx_http_upstream_keepalive_peer_data_t     *kp = data;
+    ngx_http_upstream_keepalive_shared_srv_t    *srv, skey;
+    ngx_http_upstream_keepalive_shared_info_t   *info;
+    ngx_http_upstream_keepalive_shared_conn_t   *conn;
+    ngx_http_upstream_keepalive_channel_data_t   cd;
+
+    ngx_int_t          rc;
+    ngx_uint_t         i, j, n;
+    ngx_connection_t  *c;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "get keepalive peer");
+
+    /* ask balancer */
+
+    rc = kp->original_get_peer(pc, kp->data);
+
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /* check process status before accessing shared memory */
+    if (ngx_exiting || ngx_quit) {
+        return NGX_OK;
+    }
+
+    /* search shared cache for suitable connection */
+
+    info = kp->conf->shared_info;
+
+    ngx_memcpy(skey.sockaddr, pc->sockaddr, pc->socklen);
+    skey.socklen = pc->socklen;
+
+    srv = bsearch(&skey, info->srv, info->nsrv, sizeof(*srv),
+                  ngx_http_upstream_cmp_keepalive_shared_srv);
+
+    if (srv == NULL) {
+        ngx_log_error(NGX_LOG_ALERT, pc->log, 0,
+                      "bsearch failed!");
+        return NGX_OK;
+    }
+
+    /*
+     * try to pop local idle list firstly,
+     * if not found search for sibling idle lists
+     */
+    conn = NULL;
+    n = info->worker_processes;
+    for (j = 0; j < n; j++) {
+        i = (j + ngx_process_idx) % n;
+
+        conn = ngx_lfstack_pop(&srv->idle_list[i]);
+        if (conn != NULL) {
+            if (conn->pid == ngx_pid ||
+                conn->pid == ngx_processes[conn->slot].pid) {
+                break;
+            }
+
+            /*
+             * connection's owner process has been dead,
+             * let's reclaim it into free list.
+             */
+            ngx_lfstack_push(srv->free_list, conn);
+        }
+    }
+
+    if (conn == NULL) {
+        return NGX_OK;
+    }
+
+    if (conn->pid != ngx_pid) {
+        n = sizeof(ngx_http_upstream_keepalive_channel_data_t);
+        j = offsetof(ngx_http_upstream_keepalive_channel_data_t, fd);
+
+        cd.ch.command = NGX_CMD_RPC;
+        cd.ch.pid = ngx_pid;
+        cd.ch.slot = ngx_process_slot;
+        cd.ch.fd = -1;
+        cd.ch.rpc = ngx_http_upstream_keepalive_channel_send_fd;
+        cd.ch.len = n - j;
+
+        cd.fd = conn->fd;
+        cd.pc = pc;
+        cd.conn = conn;
+
+        /* ignore EAGAIN */
+        if (ngx_write_channel(ngx_processes[conn->slot].channel[0],
+                              &cd.ch, n, pc->log)
+            == NGX_OK)
+        {
+            return NGX_YIELD;
+        }
+
+        ngx_lfstack_push(&srv->idle_list[i], conn);
+        return NGX_OK;
+    }
+
+    c = conn->connection;
+
+    ngx_lfstack_push(srv->free_list, conn);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "get keepalive peer: using connection %p", c);
+
+    c->idle = 0;
+    c->log = pc->log;
+    c->read->log = pc->log;
+    c->write->log = pc->log;
+    c->pool->log = pc->log;
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+    pc->connection = c;
+    pc->cached = 1;
+
+    return NGX_DONE;
+}
+
+
+static void
+ngx_http_upstream_free_shared_keepalive_peer(ngx_peer_connection_t *pc,
+    void *data, ngx_uint_t state)
+{
+    ngx_http_upstream_keepalive_peer_data_t     *kp = data;
+    ngx_http_upstream_keepalive_shared_srv_t    *srv, skey;
+    ngx_http_upstream_keepalive_shared_info_t   *info;
+    ngx_http_upstream_keepalive_shared_conn_t   *conn;
+
+    ngx_uint_t            i;
+    ngx_connection_t     *c;
+    ngx_http_upstream_t  *u;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "free keepalive peer");
+
+    /* check process status before accessing shared memory */
+    if (ngx_exiting || ngx_quit) {
+        goto invalid;
+    }
+
+    /* cache valid connections */
+
+    u = kp->upstream;
+    c = pc->connection;
+    info = kp->conf->shared_info;
+
+    if (state & NGX_PEER_FAILED
+        || c == NULL
+        || c->read->eof
+        || c->read->error
+        || c->read->timedout
+        || c->write->error
+        || c->write->timedout)
+    {
+        goto invalid;
+    }
+
+    if (!u->keepalive) {
+        goto invalid;
+    }
+
+    if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+        goto invalid;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "free keepalive peer: saving connection %p", c);
+
+    conn = NULL;
+    if (kp->conf->per_server_pool == 0) {
+        srv = info->srv;
+        conn = ngx_lfstack_pop(srv[0].free_list);
+        if (conn == NULL) {
+            goto invalid;
+        }
+    }
+
+    ngx_memcpy(skey.sockaddr, pc->sockaddr, pc->socklen);
+    skey.socklen = pc->socklen;
+
+    srv = bsearch(&skey, info->srv, info->nsrv, sizeof(*srv),
+                  ngx_http_upstream_cmp_keepalive_shared_srv);
+
+    if (srv == NULL) {
+        ngx_log_error(NGX_LOG_ALERT, pc->log, 0,
+                      "bsearch failed!");
+        goto invalid;
+    }
+
+    if (kp->conf->per_server_pool) {
+        conn = ngx_lfstack_pop(srv->free_list);
+        if (conn == NULL) {
+            goto invalid;
+        }
+    }
+
+    conn->connection = c;
+    conn->conf = kp->conf;
+
+    conn->pid = ngx_pid;
+    conn->slot = ngx_process_slot;
+    conn->fd = c->fd;
+
+    pc->connection = NULL;
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+    if (c->write->timer_set) {
+        ngx_del_timer(c->write);
+    }
+
+    if (kp->conf->keepalive_timeout != NGX_CONF_UNSET_MSEC &&
+        kp->conf->keepalive_timeout != 0)
+    {
+        ngx_add_timer(c->read, kp->conf->keepalive_timeout);
+    }
+
+    c->write->handler = ngx_http_upstream_keepalive_dummy_handler;
+    c->read->handler = ngx_http_upstream_keepalive_close_handler;
+
+    c->data = conn;
+    c->idle = 1;
+    c->log = ngx_cycle->log;
+    c->read->log = ngx_cycle->log;
+    c->write->log = ngx_cycle->log;
+    c->pool->log = ngx_cycle->log;
+
+    i = srv - (ngx_http_upstream_keepalive_shared_srv_t *) info->srv;
+    conn->srv_index = i;
+    conn->force_timeout = 0;
+
+    ngx_lfstack_push(&srv->idle_list[ngx_process_idx], conn);
+
+    if (c->read->ready) {
+        ngx_http_upstream_keepalive_close_handler(c->read);
+    }
+
+invalid:
+
+    kp->original_free_peer(pc, kp->data, state);
+}
+
+
 static void
 ngx_http_upstream_keepalive_dummy_handler(ngx_event_t *ev)
 {
@@ -387,8 +845,11 @@ ngx_http_upstream_keepalive_dummy_handler(ngx_event_t *ev)
 static void
 ngx_http_upstream_keepalive_close_handler(ngx_event_t *ev)
 {
-    ngx_http_upstream_keepalive_srv_conf_t  *conf;
-    ngx_http_upstream_keepalive_cache_t     *item;
+    ngx_http_upstream_keepalive_srv_conf_t      *conf;
+    ngx_http_upstream_keepalive_cache_t         *item;
+    ngx_http_upstream_keepalive_shared_info_t   *info;
+    ngx_http_upstream_keepalive_shared_conn_t   *conn;
+    ngx_http_upstream_keepalive_shared_srv_t    *srv;
 
     int                n;
     char               buf[1];
@@ -423,13 +884,39 @@ ngx_http_upstream_keepalive_close_handler(ngx_event_t *ev)
 
 close:
 
-    item = c->data;
-    conf = item->conf;
+    /* check process status before accessing shared memory */
+    if (ngx_exiting || ngx_quit) {
+        ngx_http_upstream_keepalive_close(c);
+        return;
+    }
+
+    conf = *(void **) c->data;
+    if (conf->shared) {
+        conn = c->data;
+        n = conn->srv_index;
+
+        info = conf->shared_info;
+        srv = info->srv;
+
+        if (ngx_lfstack_remove(&srv[n].idle_list[ngx_process_idx], conn)
+            == NULL)
+        {
+            /* connection has been used by other worker */
+
+            if (conn->force_timeout == 0) {
+                return;
+            }
+
+        }
+        ngx_lfstack_push(srv[n].free_list, conn);
+
+    } else {
+        item = c->data;
+        ngx_queue_remove(&item->queue);
+        ngx_queue_insert_head(&conf->free, &item->queue);
+    }
 
     ngx_http_upstream_keepalive_close(c);
-
-    ngx_queue_remove(&item->queue);
-    ngx_queue_insert_head(&conf->free, &item->queue);
 }
 
 
@@ -493,6 +980,8 @@ ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf)
     /*
      * set by ngx_pcalloc():
      *
+     *     conf->per_server_pool = 0;
+     *     conf->shared = 0;
      *     conf->original_init_upstream = NULL;
      *     conf->original_init_peer = NULL;
      */
@@ -545,10 +1034,19 @@ ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     kcf->max_cached = n;
 
     for (i = 2; i < cf->args->nelts; i++) {
+        if (ngx_strcmp(value[i].data, "shared") == 0) {
+            kcf->shared = 1;
+            continue;
+        }
 
         if (ngx_strcmp(value[i].data, "single") == 0) {
             ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                                "the \"single\" parameter is deprecated");
+            continue;
+        }
+
+        if (ngx_strcmp(value[i].data, "per_server") == 0) {
+            kcf->per_server_pool = 1;
             continue;
         }
 
@@ -597,3 +1095,106 @@ ngx_http_upstream_keepalive_timeout(ngx_conf_t *cf, ngx_command_t *cmd,
     return NGX_CONF_OK;
 }
 
+
+static ngx_int_t
+ngx_http_upstream_keepalive_channel_send_fd(ngx_channel_t *ch, void *data,
+    ngx_log_t *log)
+{
+    ngx_http_upstream_keepalive_shared_srv_t    *srv;
+    ngx_http_upstream_keepalive_shared_info_t   *info;
+    ngx_http_upstream_keepalive_shared_conn_t   *conn;
+    ngx_http_upstream_keepalive_channel_data_t   cd;
+
+    ngx_uint_t              k, n, slot, rc;
+    ngx_socket_t            fd;
+    ngx_connection_t       *c;
+    ngx_peer_connection_t  *pc;
+
+    n = sizeof(ngx_http_upstream_keepalive_channel_data_t);
+    k = offsetof(ngx_http_upstream_keepalive_channel_data_t, fd);
+
+    slot = ch->slot;
+
+    ngx_memcpy(&cd.fd, data, ch->len);
+
+    fd = cd.fd;
+    pc = cd.pc;
+    conn = cd.conn;
+    info = conn->conf->shared_info;
+    srv = info->srv;
+
+    cd.ch.command = NGX_CMD_RPC;
+    cd.ch.pid = ngx_pid;
+    cd.ch.slot = ngx_process_slot;
+    cd.ch.fd = fd;
+    cd.ch.rpc = ngx_http_upstream_keepalive_channel_recv_fd;
+    cd.ch.len = n - k;
+
+    cd.fd = -1;
+    cd.pc = pc;
+    cd.conn = NULL;
+
+    rc = ngx_write_channel(ngx_processes[slot].channel[0], &cd.ch, n, log);
+    if (rc != NGX_OK) {
+        n = conn->srv_index;
+        ngx_lfstack_push(&srv[n].idle_list[ngx_process_idx], conn);
+        return rc;
+    }
+
+    c = conn->connection;
+
+    /*
+     * c->fd has been sent to other worker,
+     * close it at this side.
+     */
+
+    c->read->timedout = 1;
+    conn->force_timeout = 1;
+
+    /*
+     * The references of c->fd has been increased,
+     * we should delete it from epoll explicitly.
+     */
+    ngx_del_conn(c, 0);
+
+    ngx_http_upstream_keepalive_close_handler(c->read);
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_keepalive_channel_recv_fd(ngx_channel_t *ch, void *data,
+    ngx_log_t *log)
+{
+    ngx_http_upstream_keepalive_channel_data_t   cd;
+
+    ngx_int_t               n;
+    ngx_socket_t            fd;
+    ngx_peer_connection_t  *pc;
+
+    n = sizeof(ngx_http_upstream_keepalive_channel_data_t);
+
+    ngx_memcpy(&cd.fd, data, ch->len);
+
+    fd = ch->fd;
+    pc = cd.pc;
+
+    n = ngx_event_init_peer_socket(fd, pc, NGX_OK);
+
+#if NGX_DEBUG
+    ngx_connection_t *c = pc->connection;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "get keepalive peer: using connection %p", c);
+#endif
+
+    pc->cached = 1;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
+                   "http upstream connect: %i", fd);
+
+    ngx_http_upstream_connect_done(pc->request, pc->upstream, n);
+
+    return NGX_OK;
+}

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -413,6 +413,8 @@ ngx_int_t ngx_http_upstream_hide_headers_hash(ngx_conf_t *cf,
     ngx_http_upstream_conf_t *conf, ngx_http_upstream_conf_t *prev,
     ngx_str_t *default_hide_headers, ngx_hash_init_t *hash);
 
+void ngx_http_upstream_connect_done(ngx_http_request_t *r,
+    ngx_http_upstream_t *u, ngx_int_t rc);
 
 #define ngx_http_conf_upstream_srv_conf(uscf, module)                         \
     uscf->srv_conf[module.ctx_index]

--- a/src/os/unix/ngx_channel.c
+++ b/src/os/unix/ngx_channel.c
@@ -148,7 +148,7 @@ ngx_read_channel(ngx_socket_t s, ngx_channel_t *ch, size_t size, ngx_log_t *log)
 
 #if (NGX_HAVE_MSGHDR_MSG_CONTROL)
 
-    if (ch->command == NGX_CMD_OPEN_CHANNEL) {
+    if (ch->fd != -1) {
 
         if (cmsg.cm.cmsg_len < (socklen_t) CMSG_LEN(sizeof(int))) {
             ngx_log_error(NGX_LOG_ALERT, log, 0,
@@ -177,7 +177,7 @@ ngx_read_channel(ngx_socket_t s, ngx_channel_t *ch, size_t size, ngx_log_t *log)
 
 #else
 
-    if (ch->command == NGX_CMD_OPEN_CHANNEL) {
+    if (ch->fd != -1) {
         if (msg.msg_accrightslen != sizeof(int)) {
             ngx_log_error(NGX_LOG_ALERT, log, 0,
                           "recvmsg() returned no ancillary data");

--- a/src/os/unix/ngx_channel.h
+++ b/src/os/unix/ngx_channel.h
@@ -14,12 +14,19 @@
 #include <ngx_event.h>
 
 
-typedef struct {
-     ngx_uint_t  command;
-     ngx_pid_t   pid;
-     ngx_int_t   slot;
-     ngx_fd_t    fd;
-} ngx_channel_t;
+typedef struct ngx_channel_s  ngx_channel_t;
+
+typedef ngx_int_t (*ngx_channel_rpc_pt)(ngx_channel_t *ch, void *data,
+                                        ngx_log_t *log);
+
+struct ngx_channel_s {
+    ngx_uint_t           command;
+    ngx_pid_t            pid;
+    ngx_int_t            slot;
+    ngx_fd_t             fd;
+    ngx_channel_rpc_pt   rpc;
+    size_t               len;
+};
 
 
 ngx_int_t ngx_write_channel(ngx_socket_t s, ngx_channel_t *ch, size_t size,

--- a/src/os/unix/ngx_process.c
+++ b/src/os/unix/ngx_process.c
@@ -574,6 +574,10 @@ ngx_unlock_mutexes(ngx_pid_t pid)
             i = 0;
         }
 
+        if (shm_zone[i].shm.slab == 0) {
+            continue;
+        }
+
         sp = (ngx_slab_pool_t *) shm_zone[i].shm.addr;
 
         if (ngx_shmtx_force_unlock(&sp->mutex, pid)) {

--- a/src/os/unix/ngx_process.c
+++ b/src/os/unix/ngx_process.c
@@ -21,6 +21,7 @@ int              ngx_argc;
 char           **ngx_argv;
 char           **ngx_os_argv;
 
+ngx_int_t        ngx_process_idx;
 ngx_int_t        ngx_process_slot;
 ngx_socket_t     ngx_channel;
 ngx_int_t        ngx_last_process;
@@ -84,6 +85,7 @@ ngx_spawn_process(ngx_cycle_t *cycle, ngx_spawn_proc_pt proc, void *data,
 
     if (respawn >= 0) {
         s = respawn;
+        ngx_process_idx = ngx_processes[s].idx;
 
     } else {
         for (s = 0; s < ngx_last_process; s++) {
@@ -206,6 +208,7 @@ ngx_spawn_process(ngx_cycle_t *cycle, ngx_spawn_proc_pt proc, void *data,
     ngx_processes[s].data = data;
     ngx_processes[s].name = name;
     ngx_processes[s].exiting = 0;
+    ngx_processes[s].idx = ngx_process_idx;
 
     switch (respawn) {
 

--- a/src/os/unix/ngx_process.h
+++ b/src/os/unix/ngx_process.h
@@ -21,6 +21,7 @@ typedef void (*ngx_spawn_proc_pt) (ngx_cycle_t *cycle, void *data);
 
 typedef struct {
     ngx_pid_t           pid;
+    ngx_int_t           idx;
     int                 status;
     ngx_socket_t        channel[2];
 
@@ -88,6 +89,7 @@ extern char         **ngx_os_argv;
 
 extern ngx_pid_t      ngx_pid;
 extern ngx_socket_t   ngx_channel;
+extern ngx_int_t      ngx_process_idx;
 extern ngx_int_t      ngx_process_slot;
 extern ngx_int_t      ngx_last_process;
 extern ngx_process_t  ngx_processes[NGX_MAX_PROCESSES];

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -387,6 +387,7 @@ ngx_start_worker_processes(ngx_cycle_t *cycle, ngx_int_t n, ngx_int_t type)
 
     ch.command = NGX_CMD_OPEN_CHANNEL;
 
+    ngx_process_idx = 0;
     for (i = 0; i < n; i++) {
 
         ngx_spawn_process(cycle, ngx_worker_process_cycle,
@@ -397,6 +398,8 @@ ngx_start_worker_processes(ngx_cycle_t *cycle, ngx_int_t n, ngx_int_t type)
         ch.fd = ngx_processes[ngx_process_slot].channel[0];
 
         ngx_pass_open_channel(cycle, &ch);
+
+        ngx_process_idx++;
     }
 }
 

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -1302,6 +1302,7 @@ ngx_channel_handler(ngx_event_t *ev)
                     }
 
                     ngx_close_connection(c);
+                    ngx_free(data);
                     return;
                 }
             }
@@ -1319,6 +1320,7 @@ ngx_channel_handler(ngx_event_t *ev)
                     }
 
                     ngx_close_connection(c);
+                    ngx_free(data);
                     return;
                 }
 

--- a/src/os/unix/ngx_process_cycle.h
+++ b/src/os/unix/ngx_process_cycle.h
@@ -19,6 +19,7 @@
 #define NGX_CMD_TERMINATE      4
 #define NGX_CMD_REOPEN         5
 #define NGX_CMD_PIPE_BROKEN    6
+#define NGX_CMD_RPC            7
 
 
 #define NGX_PROCESS_SINGLE     0

--- a/src/os/unix/ngx_shmem.h
+++ b/src/os/unix/ngx_shmem.h
@@ -18,7 +18,8 @@ typedef struct {
     size_t       size;
     ngx_str_t    name;
     ngx_log_t   *log;
-    ngx_uint_t   exists;   /* unsigned  exists:1;  */
+    ngx_uint_t   exists:1;   /* unsigned  exists:1;  */
+    ngx_uint_t   slab:1;     /* used for slab pool, set by default */
 } ngx_shm_t;
 
 


### PR DESCRIPTION
To share keepalive connections across all workers

Changes in V5:
 - Use bsearch() to speed up the searching of upstream servers.
 - Add "per_server" option for upstream's "keepalive" directive.
 - Should use ngx_exiting/ngx_quit to check process status.

Changes in V4:
 - Fix bug about initializing srv->idle_list.
 - Check process status before accessing shared memory.
 - Continue to fix some coding style.
 - Use ngx_process_idx as index when access idle_list.
 - Reclaim connection into idle_list when send fd failed.

Changes in V3:
 - Adjust some coding style.
 - Remvoe zero array in keepalive_shared_srv_t.
 - Remove assert().
 - Fix ngx_channel_handler().
 - Ignore connections when its owner process is dead.
 - Delete old shared memory when relaod Tengine.