### PR TITLE
SPDY/3: drop the "delayed" flag when finalizing connection

### DIFF
--- a/src/http/ngx_http_spdy_v3.c
+++ b/src/http/ngx_http_spdy_v3.c
@@ -3252,7 +3252,9 @@ ngx_http_spdy_finalize_connection(ngx_http_spdy_connection_t *sc,
             if (stream->waiting) {
                 r->blocked -= stream->waiting;
                 stream->waiting = 0;
+
                 ev = fc->write;
+                ev->delayed = 0;
 
             } else {
                 ev = fc->read;


### PR DESCRIPTION
This problem has been fixed for SPDY/2.
More details are available here: 
- nginx hg commit: http://hg.nginx.org/nginx/rev/a279d2a33dbf
- tengine issue: https://github.com/alibaba/tengine/issues/488
