### PR TITLE
Auto read nameserver: fix invalid filename length

### DIFF
--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -190,8 +190,7 @@ ngx_resolver_read_resolv_file(ngx_conf_t *cf, ngx_str_t *filename, ngx_str_t **n
 
     ngx_memzero(&file, sizeof(ngx_file_t));
 
-    file.name.data = filename->data;
-    file.name.len = filename->len;
+    file.name = *filename;
     file.log = cf->log;
 
     file.fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY,


### PR DESCRIPTION
In ngx_resolver_read_resolv_file(), `sizeof(NGX_RESOLVER_FILE) - 1` is assigned to file.name.len wrongly.
