### PR TITLE
Introduce a built-in variable: $normalized_request

### DIFF
--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -9,6 +9,7 @@
 #include <ngx_http.h>
 #include <nginx.h>
 #include <ngx_md5.h>
+#include <ctype.h>
 
 
 static ngx_int_t ngx_http_variable_request(ngx_http_request_t *r,
@@ -75,6 +76,8 @@ static ngx_int_t ngx_http_variable_scheme(ngx_http_request_t *r,
 static ngx_int_t ngx_http_variable_https(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_full_request(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_normalized_request(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_is_args(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
@@ -237,6 +240,9 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
     { ngx_string("https"), NULL, ngx_http_variable_https, 0, 0, 0 },
 
     { ngx_string("full_request"), NULL, ngx_http_variable_full_request,
+      0, 0, 0 },
+
+    { ngx_string("normalized_request"), NULL, ngx_http_variable_normalized_request,
       0, 0, 0 },
 
     { ngx_string("request_uri"), NULL, ngx_http_variable_request,
@@ -1841,6 +1847,156 @@ ngx_http_variable_full_request(ngx_http_request_t *r,
     }
 
     last = ngx_cpymem(last, r->unparsed_uri.data, r->unparsed_uri.len);
+
+    v->len = size;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    return NGX_OK;
+
+failed:
+
+    v->len = 0;
+    v->data = NULL;
+    v->valid = 0;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_normalized_request(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    size_t                     size;
+    u_char                    *s, *last;
+    ngx_str_t                 *host, scheme, port;
+    ngx_uint_t                 p, len;
+    struct sockaddr_in        *sin;
+#if (NGX_HAVE_INET6)
+    struct sockaddr_in6       *sin6;
+#endif
+    ngx_http_core_srv_conf_t  *cscf;
+    enum {
+        s_usual = 0,
+        s_first,
+        s_second
+    } state;
+
+    cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+    ngx_str_null(&scheme);
+
+#if (NGX_HTTP_SSL)
+
+    if (r->connection->ssl) {
+        ngx_str_set(&scheme, "https://");
+    }
+
+#endif
+
+    if (scheme.len == 0) {
+        ngx_str_set(&scheme, "http://");
+    }
+
+    if (r->headers_in.server.len) {
+        host = &r->headers_in.server;
+
+    } else {
+        host = &cscf->server_name;
+    }
+
+    if (ngx_connection_local_sockaddr(r->connection, NULL, 0) != NGX_OK) {
+        goto failed;
+    }
+
+    ngx_str_null(&port);
+
+    switch (r->connection->local_sockaddr->sa_family) {
+
+#if (NGX_HAVE_INET6)
+    case AF_INET6:
+        sin6 = (struct sockaddr_in6 *) r->connection->local_sockaddr;
+        p = ntohs(sin6->sin6_port);
+        break;
+#endif
+
+    default:
+        sin = (struct sockaddr_in *) r->connection->local_sockaddr;
+        p = ntohs(sin->sin_port);
+        break;
+    }
+
+    if (p > 0 && p < 65536 && ((p != 80 && scheme.len == 7)
+                               || (p != 443 && scheme.len == 8)))
+    {
+        port.data = ngx_pnalloc(r->pool, sizeof(":65535") - 1);
+        if (port.data == NULL) {
+            goto failed;
+        }
+
+        port.len = ngx_sprintf(port.data, ":%ui", p) - port.data;
+    }
+
+    len = r->unparsed_uri.len;
+
+    /* exclude #<fragment> part from URL */
+    s = ngx_strlchr(r->unparsed_uri.data,
+                    r->unparsed_uri.data + len, '#');
+    if (s != NULL) {
+        len = s - r->unparsed_uri.data;
+    }
+
+    size = scheme.len + host->len + port.len + len;
+
+    v->data = ngx_pnalloc(r->pool, size);
+    if (v->data == NULL) {
+        goto failed;
+    }
+
+    last = v->data;
+
+    last = ngx_cpymem(last, scheme.data, scheme.len);
+
+    last = ngx_cpymem(last, host->data, host->len);
+
+    if (port.len) {
+        last = ngx_cpymem(last, port.data, port.len);
+    }
+
+    last = ngx_cpymem(last, r->unparsed_uri.data, len);
+
+    /* convert all escape characters in unparsed_uri to upper-case */
+    state = s_usual;
+    s = last - len;
+    while (s < last) {
+        switch (state) {
+        case s_usual:
+            if (s[0] == '%') {
+                state = s_first;
+            }
+            s++;
+            break;
+        case s_first:
+            if (isxdigit(s[0])) {
+                s++;
+                state = s_second;
+
+            } else {
+                state = s_usual;
+            }
+            break;
+        case s_second:
+            if (isxdigit(s[0])) {
+                s[-1] = ngx_toupper(s[-1]);
+                s[0] = ngx_toupper(s[0]);
+                s++;
+            }
+            state = s_usual;
+            break;
+        }
+    }
 
     v->len = size;
     v->valid = 1;


### PR DESCRIPTION
When working with key-value store, such as memcached, we usually use URL
to generate unique key for each object.

But unfortunately, each URL may have several forms, for example:

1) http://abc.com/search?text=Hello+G%C3%BCnter#h1
2) http://ABC.COM/search?text=Hello+G%c3%bcnter#h1
3) HTTP://abc.com/search?text=Hello+G%C3%BCnter#h3

All above froms are refer to the same object. So we have to normalize URL
before generating object key.

As we known, URL syntax looks like:

```
<scheme>://<user>:<password>@<host>:<port>/<path>;<params>?<query>#<frag>
```

The $normalized_request variable is the normalized form of URL, which will:
- exclude `#<frag>` part from URL.
- convert `<scheme>` and `<host>` to lower-case.
- convert all escape characters(%nn) in `<path>` to upper-case.

Signed-off-by: Yunkai Zhang qiushu.zyk@taobao.com
