### PR TITLE
add soreuseport option of socket.

### DIFF
--- a/auto/os/linux
+++ b/auto/os/linux
@@ -148,6 +148,19 @@ ngx_feature_test="struct crypt_data  cd;
 . auto/feature
 
 
+# reuseport
+ngx_feature="SO_REUSEPORT"
+ngx_feature_name="NGX_HAVE_REUSEPORT"
+ngx_feature_run=no
+ngx_feature_incs="#include <sys/socket.h>
+                  #include <netinet/in.h>
+                  #include <netinet/tcp.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="setsockopt(0, SOL_SOCKET, SO_REUSEPORT, NULL, 0)"
+. auto/feature
+
+
 ngx_include="sys/vfs.h";     . auto/include
 
 

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -63,6 +63,10 @@ struct ngx_listening_s {
     unsigned            shared:1;    /* shared between threads or processes */
     unsigned            addr_ntop:1;
 
+#if (NGX_HAVE_REUSEPORT)
+    unsigned            reuse_port:1;
+#endif
+
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
     unsigned            ipv6only:1;
 #endif

--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -175,6 +175,17 @@ static ngx_command_t  ngx_event_core_commands[] = {
       0,
       NULL },
 
+#if (NGX_HAVE_REUSEPORT)
+
+    { ngx_string("reuse_port"),
+      NGX_EVENT_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      0,
+      offsetof(ngx_event_conf_t, reuse_port),
+      NULL },
+
+#endif        
+
       ngx_null_command
 };
 
@@ -605,7 +616,11 @@ ngx_event_process_init(ngx_cycle_t *cycle)
     ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx, ngx_core_module);
     ecf = ngx_event_get_conf(cycle->conf_ctx, ngx_event_core_module);
 
-    if (ccf->master && ccf->worker_processes > 1 && ecf->accept_mutex) {
+    if (ccf->master && ccf->worker_processes > 1 && ecf->accept_mutex
+#if (NGX_HAVE_REUSEPORT)
+        && !ecf->reuse_port
+#endif
+       ) {
         ngx_use_accept_mutex = 1;
         ngx_accept_mutex_held = 0;
         ngx_accept_mutex_delay = ecf->accept_mutex_delay;
@@ -1205,6 +1220,10 @@ ngx_event_core_create_conf(ngx_cycle_t *cycle)
     ecf->accept_mutex_delay = NGX_CONF_UNSET_MSEC;
     ecf->name = (void *) NGX_CONF_UNSET;
 
+#if (NGX_HAVE_REUSEPORT)
+    ecf->reuse_port = NGX_CONF_UNSET;
+#endif
+
 #if (NGX_DEBUG)
 
     if (ngx_array_init(&ecf->debug_connection, cycle->pool, 4,
@@ -1318,6 +1337,12 @@ ngx_event_core_init_conf(ngx_cycle_t *cycle, void *conf)
     ngx_conf_init_value(ecf->multi_accept, 0);
     ngx_conf_init_value(ecf->accept_mutex, 1);
     ngx_conf_init_msec_value(ecf->accept_mutex_delay, 100);
+
+#if (NGX_HAVE_REUSEPORT)
+
+    ngx_conf_init_value(ecf->reuse_port, 0);
+
+#endif
 
 
 #if (NGX_HAVE_RTSIG)

--- a/src/event/ngx_event.h
+++ b/src/event/ngx_event.h
@@ -475,6 +475,10 @@ typedef struct {
     ngx_flag_t    multi_accept;
     ngx_flag_t    accept_mutex;
 
+#if (NGX_HAVE_REUSEPORT)
+    ngx_flag_t    reuse_port;
+#endif
+
     ngx_msec_t    accept_mutex_delay;
 
     u_char       *name;


### PR DESCRIPTION
add soreuseport option of socket, this feature come from linux 3.9(http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=055dc21a1d1d219608cd4baac7d0683fb2cbbe8a).
you can set  "reuse_port on" in event block to open soreuseport option.
