### PR TITLE
Feature: the "gzip_clear_etag" directive.

### DIFF
--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -15,6 +15,7 @@
 typedef struct {
     ngx_flag_t           enable;
     ngx_flag_t           no_buffer;
+    ngx_flag_t           clear_etag;
 
     ngx_hash_t           types;
 
@@ -193,6 +194,13 @@ static ngx_command_t  ngx_http_gzip_filter_commands[] = {
       offsetof(ngx_http_gzip_conf_t, min_length),
       NULL },
 
+    { ngx_string("gzip_clear_etag"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_gzip_conf_t, clear_etag),
+      NULL },
+
       ngx_null_command
 };
 
@@ -306,7 +314,10 @@ ngx_http_gzip_header_filter(ngx_http_request_t *r)
 
     ngx_http_clear_content_length(r);
     ngx_http_clear_accept_ranges(r);
-    ngx_http_clear_etag(r);
+
+    if (conf->clear_etag) {
+        ngx_http_clear_etag(r);
+    }
 
     return ngx_http_next_header_filter(r);
 }
@@ -1123,6 +1134,7 @@ ngx_http_gzip_create_conf(ngx_conf_t *cf)
 
     conf->enable = NGX_CONF_UNSET;
     conf->no_buffer = NGX_CONF_UNSET;
+    conf->clear_etag = NGX_CONF_UNSET;
 
     conf->postpone_gzipping = NGX_CONF_UNSET_SIZE;
     conf->level = NGX_CONF_UNSET;
@@ -1142,6 +1154,7 @@ ngx_http_gzip_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->enable, prev->enable, 0);
     ngx_conf_merge_value(conf->no_buffer, prev->no_buffer, 0);
+    ngx_conf_merge_value(conf->clear_etag, prev->clear_etag, 1);
 
     ngx_conf_merge_bufs_value(conf->bufs, prev->bufs,
                               (128 * 1024) / ngx_pagesize, ngx_pagesize);

--- a/tests/nginx-tests/cases/gzip_clear_etag.t
+++ b/tests/nginx-tests/cases/gzip_clear_etag.t
@@ -1,0 +1,115 @@
+#!/usr/bin/perl
+
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use Socket qw/ CRLF /;
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->plan(8);
+
+##############################################################################
+# Test 1 ( gzip_clear_etag off )
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+%%TEST_GLOBALS_DSO%%
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    gzip on;
+    gzip_http_version 1.0;
+    gzip_clear_etag off;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /t {
+            proxy_pass http://127.0.0.1:8080/;
+        }
+    }
+
+}
+
+EOF
+
+$t->write_file('etag.html', 'test gzip clear etag');
+
+$t->run();
+
+###############################################################################
+
+like(http('GET /t/etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . 'Accept-Encoding:gzip' . CRLF . CRLF), qr#ETag#, 'gzip_clear_etag off, proxy, gzip');
+like(http('GET /t/etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . CRLF), qr#ETag#, 'gzip_clear_etag off, proxy, non-gzip');
+like(http('GET /etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . 'Accept-Encoding:gzip' . CRLF . CRLF), qr#ETag#, 'gzip_clear_etag off, non-proxy, gzip');
+like(http('GET /etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . CRLF), qr#ETag#, 'gzip_clear_etag off, non-proxy, non-gzip');
+
+$t->stop();
+
+##############################################################################
+# Test 2 (gzip_clear_etag on (default))
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon         off;
+
+%%TEST_GLOBALS_DSO%%
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    gzip on;
+    gzip_http_version 1.0;
+   #gzip_clear_etag on;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /t {
+            proxy_pass http://127.0.0.1:8080/;
+        }
+    }
+
+}
+
+EOF
+
+$t->write_file('etag.html', 'test gzip clear etag');
+
+$t->run();
+
+###############################################################################
+
+unlike(http('GET /t/etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . 'Accept-Encoding:gzip' . CRLF . CRLF), qr#ETag#, 'gzip_clear_etag on (default), proxy, gzip ');
+like(http('GET /t/etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . CRLF), qr#ETag#, 'gzip_clear_etag on (default), proxy, non-gzip');
+unlike(http('GET /etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . 'Accept-Encoding:gzip' . CRLF . CRLF), qr#ETag#, 'gzip_clear_etag on (default), non-proxy, gzip');
+like(http('GET /etag.html HTTP/1.1' . CRLF . 'Host: localhost' . CRLF . 'Connection:close'. CRLF . CRLF), qr#ETag#, 'gzip_clear_etag on (default), non-proxy, non-gzip');
+
+$t->stop();


### PR DESCRIPTION
Syntax: gzip_clear_etag on | off;
Default:    gzip_clear_etag on;
Context:    http, server, location

压缩的时候是否删除 reponse的etag头,  默认为on 删除.
