### PR TITLE
dynamic_resolve.t: skip cases without Net::DNS::Nameserver

### DIFF
--- a/tests/nginx-tests/cases/dynamic_resolve.t
+++ b/tests/nginx-tests/cases/dynamic_resolve.t
@@ -16,7 +16,8 @@ BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
 use Test::Nginx;
-use Net::DNS::Nameserver;
+eval { require Net::DNS::Nameserver; };
+plan(skip_all => 'Net::DNS::Nameserver not installed') if $@;
 
 ###############################################################################
 


### PR DESCRIPTION
If Net::DNS::Nameserver was not installed, we skip cases.
