### PR TITLE
upstream rbtree bugfix(issue #530)

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5421,8 +5421,12 @@ not_found:
 
 #if (NGX_HTTP_UPSTREAM_RBTREE)
 
+            uscf = uscfp[i];
+
             ngx_rbtree_insert(&umcf->rbtree, &uscfp[i]->node);
             ngx_list_delete(&umcf->implicit_upstreams, &uscfp[i]);
+
+            return uscf;
 
 #endif
         }


### PR DESCRIPTION
ngx_list_delete 之后, uscfp[i]指向的数据已经改变, 导致返回错误的 uscf.
