### PR TITLE
non buffered request: rename r->request_buffering to r->request_buffering_off

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -653,12 +653,12 @@ ngx_http_fastcgi_handler(ngx_http_request_t *r)
     u->finalize_request = ngx_http_fastcgi_finalize_request;
     r->state = 0;
 
-    r->request_buffering = flcf->upstream.request_buffering;
+    r->request_buffering_off = !flcf->upstream.request_buffering;
     if (r->headers_in.content_length_n <= 0 && !r->headers_in.chunked) {
-        r->request_buffering = 1;
+        r->request_buffering_off = 0;
     }
 
-    if (!r->request_buffering) {
+    if (r->request_buffering_off) {
         u->output_filter_init = ngx_http_fastcgi_output_filter_init;
         u->output_filter = ngx_http_fastcgi_output_filter;
     }
@@ -1105,7 +1105,7 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
      * Don't send the last FASTCGI_STDIN record, It will be sent in the
      * output filter
      */
-    if (r->request_buffering) {
+    if (!r->request_buffering_off) {
         h = (ngx_http_fastcgi_header_t *) b->last;
         b->last += sizeof(ngx_http_fastcgi_header_t);
     }
@@ -1215,7 +1215,7 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
         r->upstream->request_bufs = cl;
     }
 
-    if (r->request_buffering) {
+    if (!r->request_buffering_off) {
         ngx_http_fastcgi_last_record(h);
     }
 

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -709,8 +709,6 @@ ngx_http_create_request(ngx_connection_t *c)
     r->method = NGX_HTTP_UNKNOWN;
     r->http_version = NGX_HTTP_VERSION_10;
 
-    r->request_buffering = 1;
-
     r->headers_in.content_length_n = -1;
     r->headers_in.keep_alive_n = -1;
     r->headers_out.content_length_n = -1;

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -489,7 +489,7 @@ struct ngx_http_request_s {
     unsigned                          uri_changed:1;
     unsigned                          uri_changes:4;
 
-    unsigned                          request_buffering:1;
+    unsigned                          request_buffering_off:1;
     unsigned                          request_body_in_single_buf:1;
     unsigned                          request_body_in_file_only:1;
     unsigned                          request_body_in_persistent_file:1;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -98,7 +98,7 @@ ngx_http_read_client_request_body(ngx_http_request_t *r,
         return NGX_OK;
     }
 
-    if (!r->request_buffering) {
+    if (r->request_buffering_off) {
         return ngx_http_read_non_buffered_client_request_body(r, post_handler);
     }
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1276,7 +1276,7 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     r->connection->log->action = "connecting to upstream";
 
-    if (u->request_sent && !r->request_buffering) {
+    if (u->request_sent && r->request_buffering_off) {
 
         /*
          * no buffering request can't reuse the request body when part of
@@ -1424,7 +1424,7 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
 #endif
 
-    if (!r->request_buffering) {
+    if (r->request_buffering_off) {
         ngx_http_upstream_send_non_buffered_request(r, u);
         return;
     }
@@ -1497,7 +1497,7 @@ ngx_http_upstream_ssl_handshake(ngx_connection_t *c)
         c->write->handler = ngx_http_upstream_handler;
         c->read->handler = ngx_http_upstream_handler;
 
-        if (!r->request_buffering) {
+        if (r->request_buffering_off) {
             ngx_http_upstream_send_non_buffered_request(r, u);
             return;
         }
@@ -2003,7 +2003,7 @@ ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
         return;
     }
 
-    if (!r->request_buffering) {
+    if (r->request_buffering_off) {
         ngx_http_upstream_send_non_buffered_request(r, u);
         return;
     }


### PR DESCRIPTION
- Directives proxy_request_buffering and fastcgi_request_buffering are enabled
  by default, in which case r->request_buffering should be 1.
  
  If r->request_buffering is 1 by default, we should patch all subrequest
  creating functions to set this field of sub request structure(ngx_http_request_t).
- This commit also fixes segfault if sub requset has input body.
  If uri '/lua' is requested, tengine will segfault with following configure:
  
  ```
    location /memc {
        set $memc_key $echo_request_uri;
        set $memc_exptime 600;
        memc_pass 127.0.0.1:11211;
    }
  
    location /lua {
        content_by_lua '
            res = ngx.location.capture("/memc",
                { method = ngx.HTTP_PUT, body = "hello" });
        ';
    }
  ```
