### PR TITLE
Disable SSLv3 from the default HTTP SSL bitmask

### DIFF
--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -567,8 +567,8 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                          prev->prefer_server_ciphers, 0);
 
     ngx_conf_merge_bitmask_value(conf->protocols, prev->protocols,
-                         (NGX_CONF_BITMASK_SET|NGX_SSL_SSLv3|NGX_SSL_TLSv1
-                          |NGX_SSL_TLSv1_1|NGX_SSL_TLSv1_2));
+                         (NGX_CONF_BITMASK_SET|NGX_SSL_TLSv1|NGX_SSL_TLSv1_1
+                          |NGX_SSL_TLSv1_2));
 
     ngx_conf_merge_size_value(conf->buffer_size, prev->buffer_size,
                          NGX_SSL_BUFSIZE);


### PR DESCRIPTION
At this stage, there are few user agents in the wild which do not support
anything better than SSLv3. Even in China, the usual place cited for wide
deployments of Windows XP and Internet Explorer 6, the number of SSLv3-only
clients is rapidly diminishing since Windows XP is no longer receiving updates
and web designers around the world are now actively desupporting Internet
Explorer 6.

In light of the POODLE attack, and its recommended mitigation of RC4 for
client/server pairs which do not support TLS_FALLBACK_SCSV, it feels somewhat
irresponsible for a web server to default to known-vulnerable behavior. This
is especially true when enabling SSLv3 is as simple as specifying it in the
server's config file.

Besides Internet Explorer 6, embedded and mobile devices are generally the
only widely-deployed user agents which will be affected by the disabling of
SSLv3 from the default suite. In the case of embedded and mobile use, the
status quo seems to be that developers and administrators are explicit about
which options they set so that future changes in behavior will not affect
their deployments. However, it may be worth a documentation note.

Originally reported by Thomas Ward in nginx ticket 653:
http://trac.nginx.org/nginx/ticket/653

This patch has been tested against OpenSSL 0.9.7l 28 Sep 2006 as well as
OpenSSL 0.9.7d 17 Mar 2004 (+ security patches to 2006-09-29). These versions
will only speak TLSv1 (not 1.1 or 1.2) with this change. I do not have any
older OpenSSL versions available to me readily, and newer OpenSSL is
unlikely to have any issues whatsoever with disabling SSLv3.

Only the HTTP module has had its bitmask altered. While SSLv3 is historic
and should be disabled by default for everything, there are no known attacks
against the other modules at this time. Therefore, those changes are out of
scope for this issue.