### PR TITLE
Limit req: don't truncate key value to 255 bytes.

### DIFF
--- a/src/http/modules/ngx_http_limit_req_module.c
+++ b/src/http/modules/ngx_http_limit_req_module.c
@@ -341,7 +341,7 @@ ngx_http_limit_req_handler(ngx_http_request_t *r)
             lr = (ngx_http_limit_req_node_t *) &node->color;
 
             node->key = hash;
-            lr->len = (u_char) total_len;
+            lr->len = (u_short) total_len;
 
             tp = ngx_timeofday();
             lr->last = (ngx_msec_t) (tp->sec * 1000 + tp->msec);


### PR DESCRIPTION
- While the module allows to use values up to 65535 bytes as a key, 
  that actually never worked properly. ( [official changeset](http://hg.nginx.org/nginx/rev/cda4fcb9294c) )
- This commit fixed https://github.com/alibaba/tengine/issues/491.
