### PR TITLE
proxy_request_buffering_off: fixed unhandled read/write event

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1773,6 +1773,11 @@ ngx_http_upstream_send_non_buffered_request(ngx_http_request_t *r,
                                            NGX_HTTP_INTERNAL_SERVER_ERROR);
                 }
 
+                if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
+                    ngx_http_upstream_finalize_request(r, u,
+                                           NGX_HTTP_INTERNAL_SERVER_ERROR);
+                }
+
                 return;
             }
         }
@@ -1886,6 +1891,12 @@ send_done:
         if (rc == NGX_AGAIN) {
             ngx_add_timer(c->write, u->conf->send_timeout);
 
+            if (ngx_handle_read_event(r->connection->read, 0) != NGX_OK) {
+                ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
             if (ngx_handle_write_event(c->write, u->conf->send_lowat)
                 != NGX_OK) {
                 ngx_http_upstream_finalize_request(r, u,
@@ -1939,6 +1950,12 @@ send_done:
         return;
     }
 #endif
+
+    if (ngx_handle_read_event(r->connection->read, 0) != NGX_OK) {
+        ngx_http_upstream_finalize_request(r, u,
+                                           NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return;
+    }
 
     u->write_event_handler = ngx_http_upstream_dummy_handler;
 


### PR DESCRIPTION
This bug may cause CPU 100% if tengine uses LEVEL event module
(e.g. select, poll, /dev/poll).

While receiving write event from upstream connection, it tries to read
data from client and check whether there is enough data to send to upstream.
If there is not enough data, it just returns and waits next event. However,
there is a bug that it does not "handle" the write event. If it does not delete
the write event from /dev/poll, this write event will be reported to tengine again.
And then tengine has infinite loops.

For read event, the situation is similar to write event.

Thanks to Arne Jansen.