### PR TITLE
SPDY: disable "proxy_request_buffering off" for spdy request

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -657,6 +657,11 @@ ngx_http_fastcgi_handler(ngx_http_request_t *r)
     if (r->headers_in.content_length_n <= 0 && !r->headers_in.chunked) {
         r->request_buffering_off = 0;
     }
+#if (NGX_HTTP_SPDY)
+    if (r->spdy_stream) {
+        r->request_buffering_off = 0;
+    }
+#endif
 
     if (r->request_buffering_off) {
         u->output_filter_init = ngx_http_fastcgi_output_filter_init;

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -759,6 +759,11 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
     if (r->headers_in.content_length_n <= 0 && !r->headers_in.chunked) {
         r->request_buffering_off = 0;
     }
+#if (NGX_HTTP_SPDY)
+    if (r->spdy_stream) {
+        r->request_buffering_off = 0;
+    }
+#endif
 
     if (r->request_buffering_off) {
         u->output_filter_init = ngx_http_proxy_output_filter_init;


### PR DESCRIPTION
The spdy module handles request body (DATA frame) in memory or temporary
file always. In such case, it cannot work with "proxy_request_buffering off".

Thanks to Arlen Stalwick.

Fixed https://github.com/alibaba/tengine/issues/444.