### PR TITLE
Backport bug fix for SPDY from nginx

### DIFF
--- a/src/event/ngx_event_pipe.c
+++ b/src/event/ngx_event_pipe.c
@@ -439,7 +439,10 @@ ngx_event_pipe_read_upstream(ngx_event_pipe_t *p)
         }
     }
 
-    if (p->cacheable && p->in) {
+    if (p->cacheable && (p->in || p->buf_to_file)) {
+        ngx_log_debug0(NGX_LOG_DEBUG_EVENT, p->log, 0,
+                       "pipe write chain");
+
         if (ngx_event_pipe_write_chain_to_temp_file(p) == NGX_ABORT) {
             return NGX_ABORT;
         }
@@ -513,15 +516,6 @@ ngx_event_pipe_write_to_downstream(ngx_event_pipe_t *p)
                 }
 
                 p->in = NULL;
-            }
-
-            if (p->cacheable && p->buf_to_file) {
-                ngx_log_debug0(NGX_LOG_DEBUG_EVENT, p->log, 0,
-                               "pipe write chain");
-
-                if (ngx_event_pipe_write_chain_to_temp_file(p) == NGX_ABORT) {
-                    return NGX_ABORT;
-                }
             }
 
             ngx_log_debug0(NGX_LOG_DEBUG_EVENT, p->log, 0,

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2661,21 +2661,17 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     if (r->header_only) {
 
-        if (u->cacheable || u->store) {
-
-            if (ngx_shutdown_socket(c->fd, NGX_WRITE_SHUTDOWN) == -1) {
-                ngx_connection_error(c, ngx_socket_errno,
-                                     ngx_shutdown_socket_n " failed");
-            }
-
-            r->read_event_handler = ngx_http_request_empty_handler;
-            r->write_event_handler = ngx_http_request_empty_handler;
-            c->error = 1;
-
-        } else {
+        if (!u->buffering) {
             ngx_http_upstream_finalize_request(r, u, rc);
             return;
         }
+
+        if (!u->cacheable && !u->store) {
+            ngx_http_upstream_finalize_request(r, u, rc);
+            return;
+        }
+
+        u->pipe->downstream_error = 1;
     }
 
     if (r->request_body && r->request_body->temp_file) {


### PR DESCRIPTION
Related ticket in trac: http://trac.nginx.org/nginx/ticket/428
Releated changesets in trac: http://trac.nginx.org/nginx/changeset/35990c69b3ac3973ddb7844985b0a43fcdc17994/nginx

```
Upstream: p->downstream_error instead of closing connection.

Previously, nginx closed client connection in cases when a response body
from upstream was needed to be cached or stored but shouldn't be sent to
the client. While this is normal for HTTP, it is unacceptable for SPDY.
Fix is to use instead the p->downstream_error flag to prevent nginx from
sending anything downstream. To make this work, the event pipe code was
modified to properly cache empty responses with the flag set.
```