### PR TITLE
Feature: ssl_verify_client_exception directive

### DIFF
--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -41,6 +41,7 @@ static ngx_int_t ngx_http_ssl_variable(ngx_http_request_t *r,
 
 static ngx_int_t ngx_http_ssl_add_variables(ngx_conf_t *cf);
 static void *ngx_http_ssl_create_srv_conf(ngx_conf_t *cf);
+static void *ngx_http_ssl_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf,
     void *parent, void *child);
 
@@ -145,6 +146,13 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_ssl_srv_conf_t, verify),
       &ngx_http_ssl_verify },
+
+    { ngx_string("ssl_verify_client_exception"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_ssl_loc_conf_t, verify_exception),
+      NULL },
 
     { ngx_string("ssl_verify_depth"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
@@ -251,7 +259,7 @@ static ngx_http_module_t  ngx_http_ssl_module_ctx = {
     ngx_http_ssl_create_srv_conf,          /* create server configuration */
     ngx_http_ssl_merge_srv_conf,           /* merge server configuration */
 
-    NULL,                                  /* create location configuration */
+    ngx_http_ssl_create_loc_conf,          /* create location configuration */
     NULL                                   /* merge location configuration */
 };
 
@@ -531,6 +539,20 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
     return sscf;
 }
 
+static void *
+ngx_http_ssl_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_http_ssl_loc_conf_t *slcf;
+
+    slcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_ssl_loc_conf_t));
+    if (slcf == NULL) {
+        return NULL;
+    }
+
+    slcf->verify_exception = NGX_CONF_UNSET;
+
+    return slcf;
+}
 
 static char *
 ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -57,6 +57,10 @@ typedef struct {
     ngx_uint_t                      line;
 } ngx_http_ssl_srv_conf_t;
 
+typedef struct {
+    ngx_flag_t                      verify_exception;
+} ngx_http_ssl_loc_conf_t;
+
 
 extern ngx_module_t  ngx_http_ssl_module;
 

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1037,6 +1037,64 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
         return NGX_OK;
     }
 
+#if (NGX_HTTP_SSL)
+    ngx_connection_t  *c;
+    c = r->connection;
+
+    if (r->main == r && r->http_connection->ssl) {
+        long                      rc;
+        X509                     *cert;
+        ngx_http_ssl_srv_conf_t  *sscf;
+        ngx_http_ssl_loc_conf_t  *slcf;
+
+        if (c->ssl == NULL) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "client sent plain HTTP request to HTTPS port");
+            ngx_http_finalize_request(r, NGX_HTTP_TO_HTTPS);
+            return NGX_OK;
+        }
+
+        sscf = ngx_http_get_module_srv_conf(r, ngx_http_ssl_module);
+        slcf = ngx_http_get_module_loc_conf(r, ngx_http_ssl_module);
+
+        if (sscf->verify && slcf->verify_exception < 1) {
+            rc = SSL_get_verify_result(c->ssl->connection);
+
+            if (rc != X509_V_OK
+                && (sscf->verify != 3 || !ngx_ssl_verify_error_optional(rc)))
+            {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client SSL certificate verify error: (%l:%s)",
+                              rc, X509_verify_cert_error_string(rc));
+
+                ngx_ssl_remove_cached_session(sscf->ssl.ctx,
+                                       (SSL_get0_session(c->ssl->connection)));
+
+                ngx_http_finalize_request(r, NGX_HTTPS_CERT_ERROR);
+                return NGX_OK;
+            }
+
+            if (sscf->verify == 1) {
+                cert = SSL_get_peer_certificate(c->ssl->connection);
+
+                if (cert == NULL) {
+                    ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                  "client sent no required SSL certificate");
+
+                    ngx_ssl_remove_cached_session(sscf->ssl.ctx,
+                                       (SSL_get0_session(c->ssl->connection)));
+
+                    ngx_http_finalize_request(r, NGX_HTTPS_NO_CERT);
+                    return NGX_OK;
+                }
+
+                X509_free(cert);
+            }
+        }
+    }
+
+#endif
+
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
     if (!r->internal && clcf->internal) {


### PR DESCRIPTION
This directive is used to set some locations avoiding
client certificate verfication. If you turn on this
directive in one location, this location will not be
affected by the ssl_verify_client directive upper level.

Signed-off-by: Paul Yang <paulyang.inf@gmail.com>