### PR TITLE
Remove redundant conditional judgement in rbtree deletion

### DIFF
--- a/src/core/ngx_rbtree.c
+++ b/src/core/ngx_rbtree.c
@@ -176,12 +176,7 @@ ngx_rbtree_delete(ngx_thread_volatile ngx_rbtree_t *tree,
 
     } else {
         subst = ngx_rbtree_min(node->right, sentinel);
-
-        if (subst->left != sentinel) {
-            temp = subst->left;
-        } else {
-            temp = subst->right;
-        }
+        temp = subst->right;
     }
 
     if (subst == *root) {


### PR DESCRIPTION
In binary tree deletion, as its defination, first we need to find the
minimum node in its right sub-tree to replace the location of the node
to be deleted when it has both its left and right children. Then we
shall trace its sub-tree to find the minimum node by `ngx_rbtree_min`
function. Since the terminal condition of the tracing loop has already
been set as `node->left == sentinel`, there is no need to leave the
following if-condition judging whether the substitute node's left child
is the sentinel any more because the program will never run here. And the
code will be cleaner as well as may run even faster in some situations
after removing this redundant conditional branch.

In C++ SGI STL stl_tree.c source, we can see there is no if-condition
judgement in rbtree deletion:

https://github.com/dutor/stl/blob/master/sgi/stl_tree.h#L317

By the way, the current released Nginx source still has this issue but
I have no idea how to commit this patch to the upstream.

Signed-off-by: Leo Ma <begeekmyfriend@gmail.com>