### PR TITLE
Replace tengine`s SO_REUSEPORT implementation with the official from nginx 1.9.1 [backport]

### DIFF
--- a/auto/os/linux
+++ b/auto/os/linux
@@ -179,20 +179,6 @@ ngx_feature_test="struct crypt_data  cd;
                   crypt_r(\"key\", \"salt\", &cd);"
 . auto/feature
 
-
-# reuseport
-ngx_feature="SO_REUSEPORT"
-ngx_feature_name="NGX_HAVE_REUSEPORT"
-ngx_feature_run=no
-ngx_feature_incs="#include <sys/socket.h>
-                  #include <netinet/in.h>
-                  #include <netinet/tcp.h>"
-ngx_feature_path=
-ngx_feature_libs=
-ngx_feature_test="setsockopt(0, SOL_SOCKET, SO_REUSEPORT, NULL, 0)"
-. auto/feature
-
-
 ngx_include="sys/vfs.h";     . auto/include
 
 

--- a/auto/unix
+++ b/auto/unix
@@ -344,7 +344,17 @@ ngx_feature_run=no
 ngx_feature_incs="#include <sys/socket.h>"
 ngx_feature_path=
 ngx_feature_libs=
-ngx_feature_test="setsockopt(0, SOL_SOCKET, SO_SETFIB, NULL, 4)"
+ngx_feature_test="setsockopt(0, SOL_SOCKET, SO_SETFIB, NULL, 0)"
+. auto/feature
+
+
+ngx_feature="SO_REUSEPORT"
+ngx_feature_name="NGX_HAVE_REUSEPORT"
+ngx_feature_run=no
+ngx_feature_incs="#include <sys/socket.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="setsockopt(0, SOL_SOCKET, SO_REUSEPORT, NULL, 0)"
 . auto/feature
 
 

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -83,15 +83,48 @@ ngx_create_listening(ngx_conf_t *cf, void *sockaddr, socklen_t socklen)
     ls->setfib = -1;
 #endif
 
-#if (NGX_HAVE_REUSEPORT)
-    ls->reuse_port = 0;
-#endif
-
 #if (NGX_HAVE_TCP_FASTOPEN)
     ls->fastopen = -1;
 #endif
 
     return ls;
+}
+
+
+ngx_int_t
+ngx_clone_listening(ngx_conf_t *cf, ngx_listening_t *ls)
+{
+#if (NGX_HAVE_REUSEPORT)
+
+    ngx_int_t         n;
+    ngx_core_conf_t  *ccf;
+    ngx_listening_t   ols;
+
+    if (!ls->reuseport) {
+        return NGX_OK;
+    }
+
+    ols = *ls;
+
+    ccf = (ngx_core_conf_t *) ngx_get_conf(cf->cycle->conf_ctx,
+                                           ngx_core_module);
+
+    for (n = 1; n < ccf->worker_processes; n++) {
+
+        /* create a socket for each worker process */
+
+        ls = ngx_array_push(&cf->cycle->listening);
+        if (ls == NULL) {
+            return NGX_ERROR;
+        }
+
+        *ls = ols;
+        ls->worker = n;
+    }
+
+#endif
+
+    return NGX_OK;
 }
 
 
@@ -110,6 +143,9 @@ ngx_set_inherited_sockets(ngx_cycle_t *cycle)
 #endif
 #if (NGX_HAVE_DEFERRED_ACCEPT && defined TCP_DEFER_ACCEPT)
     int                        timeout;
+#endif
+#if (NGX_HAVE_REUSEPORT)
+    int                        reuseport;
 #endif
 
     ls = cycle->listening.elts;
@@ -218,6 +254,25 @@ ngx_set_inherited_sockets(ngx_cycle_t *cycle)
         }
 
 #endif
+#endif
+
+#if (NGX_HAVE_REUSEPORT)
+
+        reuseport = 0;
+        olen = sizeof(int);
+
+        if (getsockopt(ls[i].fd, SOL_SOCKET, SO_REUSEPORT,
+                       (void *) &reuseport, &olen)
+            == -1)
+        {
+            ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_socket_errno,
+                          "getsockopt(SO_REUSEPORT) %V failed, ignored",
+                          &ls[i].addr_text);
+
+        } else {
+            ls[i].reuseport = reuseport ? 1 : 0;
+        }
+
 #endif
 
 #if (NGX_HAVE_TCP_FASTOPEN)
@@ -337,6 +392,31 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                 continue;
             }
 
+#if (NGX_HAVE_REUSEPORT)
+
+            if (ls[i].add_reuseport) {
+
+                /*
+                 * to allow transition from a socket without SO_REUSEPORT
+                 * to multiple sockets with SO_REUSEPORT, we have to set
+                 * SO_REUSEPORT on the old socket before opening new ones
+                 */
+
+                int  reuseport = 1;
+
+                if (setsockopt(ls[i].fd, SOL_SOCKET, SO_REUSEPORT,
+                               (const void *) &reuseport, sizeof(int))
+                    == -1)
+                {
+                    ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_socket_errno,
+                                  "setsockopt(SO_REUSEPORT) %V failed, ignored",
+                                  &ls[i].addr_text);
+                }
+
+                ls[i].add_reuseport = 0;
+            }
+#endif
+
             if (ls[i].fd != (ngx_socket_t) -1) {
                 continue;
             }
@@ -377,42 +457,27 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
 
 #if (NGX_HAVE_REUSEPORT)
 
-            u_char              *onfly;
-            ngx_event_conf_t    *ecf;
+            if (ls[i].reuseport) {
+                int  reuseport;
 
-            ecf = ngx_event_get_conf(cycle->conf_ctx, ngx_event_core_module);
+                reuseport = 1;
 
-            if (ecf->reuse_port) {
-
-                onfly = (u_char *) getenv(NGINX_VAR);
-
-                if (ngx_process == NGX_PROCESS_SIGNALLER
-                    || (cycle->old_cycle != NULL && !ngx_is_init_cycle(cycle->old_cycle))
-                    || ls[i].reuse_port
-                    || onfly != NULL
-                    || ngx_test_config)
+                if (setsockopt(s, SOL_SOCKET, SO_REUSEPORT,
+                               (const void *) &reuseport, sizeof(int))
+                    == -1)
                 {
+                    ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
+                                  "setsockopt(SO_REUSEPORT) %V failed, ignored",
+                                  &ls[i].addr_text);
 
-                    if(setsockopt(s, SOL_SOCKET, SO_REUSEPORT,
-                                  (const void *) &reuse, sizeof(int))
-                       == -1)
-                    {
+                    if (ngx_close_socket(s) == -1) {
                         ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
-                            "setsockopt(SO_REUSEPORT) %V failed",
-                                     &ls[i].addr_text);
-
-                        if (ngx_close_socket(s) == -1) {
-                            ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
-                                ngx_close_socket_n " %V failed",
-                                         &ls[i].addr_text);
-                        }
-
-                        return NGX_ERROR;
+                                      ngx_close_socket_n " %V failed",
+                                      &ls[i].addr_text);
                     }
 
-                    ls[i].reuse_port = 1;
+                    return NGX_ERROR;
                 }
-
             }
 #endif
 
@@ -517,21 +582,6 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
 
                 return NGX_ERROR;
             }
-
-#if (NGX_HAVE_REUSEPORT)
-
-            if (ecf->reuse_port && !ls[i].reuse_port) {
-                if (ngx_close_socket(s) == -1) {
-                    ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
-                                  ngx_close_socket_n " %V failed",
-                                  &ls[i].addr_text);
-                }
-
-                failed = 1;
-                ls[i].reuse_port = 1;
-                continue;
-            }
-#endif
 
             ls[i].listen = 1;
 

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -51,6 +51,8 @@ struct ngx_listening_s {
     ngx_listening_t    *previous;
     ngx_connection_t   *connection;
 
+    ngx_uint_t          worker;
+
     unsigned            open:1;
     unsigned            remain:1;
     unsigned            ignore:1;
@@ -63,12 +65,12 @@ struct ngx_listening_s {
     unsigned            shared:1;    /* shared between threads or processes */
     unsigned            addr_ntop:1;
 
-#if (NGX_HAVE_REUSEPORT)
-    unsigned            reuse_port:1;
-#endif
-
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
     unsigned            ipv6only:1;
+#endif
+#if (NGX_HAVE_REUSEPORT)
+    unsigned            reuseport:1;
+    unsigned            add_reuseport:1;
 #endif
     unsigned            keepalive:2;
 
@@ -199,6 +201,7 @@ struct ngx_connection_s {
 
 ngx_listening_t *ngx_create_listening(ngx_conf_t *cf, void *sockaddr,
     socklen_t socklen);
+ngx_int_t ngx_clone_listening(ngx_conf_t *cf, ngx_listening_t *ls);
 ngx_int_t ngx_set_inherited_sockets(ngx_cycle_t *cycle);
 ngx_int_t ngx_open_listening_sockets(ngx_cycle_t *cycle);
 void ngx_configure_listening_sockets(ngx_cycle_t *cycle);

--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -596,6 +596,10 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
                 if (ls[i].ignore) {
                     continue;
                 }
+				
+                if (ls[i].remain) {
+                    continue;
+                }
 
                 if (ngx_cmp_sockaddr(nls[n].sockaddr, nls[n].socklen,
                                      ls[i].sockaddr, ls[i].socklen, 1)
@@ -644,6 +648,14 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
                         nls[n].add_deferred = 1;
                     }
 #endif
+
+#if (NGX_HAVE_REUSEPORT)
+                    if (nls[n].reuseport && !ls[i].reuseport) {
+                        nls[n].add_reuseport = 1;
+                    }
+#endif
+
+
                     break;
                 }
             }

--- a/src/event/ngx_event.h
+++ b/src/event/ngx_event.h
@@ -78,6 +78,14 @@ struct ngx_event_s {
     unsigned         posted_ready:1;
 #endif
 
+    unsigned         closed:1;
+
+    /* to test on worker exit */
+    unsigned         channel:1;
+    unsigned         resolver:1;
+	
+    unsigned         cancelable:1;
+
 #if (NGX_WIN32)
     /* setsockopt(SO_UPDATE_ACCEPT_CONTEXT) was successful */
     unsigned         accept_context_updated:1;
@@ -128,12 +136,6 @@ struct ngx_event_s {
     ngx_log_t       *log;
 
     ngx_rbtree_node_t   timer;
-
-    unsigned         closed:1;
-
-    /* to test on worker exit */
-    unsigned         channel:1;
-    unsigned         resolver:1;
 
 #if (NGX_THREADS)
 
@@ -475,10 +477,6 @@ typedef struct {
 
     ngx_flag_t    multi_accept;
     ngx_flag_t    accept_mutex;
-
-#if (NGX_HAVE_REUSEPORT)
-    ngx_flag_t    reuse_port;
-#endif
 
     ngx_msec_t    accept_mutex_delay;
 

--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -11,7 +11,7 @@
 
 
 static ngx_int_t ngx_enable_accept_events(ngx_cycle_t *cycle);
-static ngx_int_t ngx_disable_accept_events(ngx_cycle_t *cycle);
+static ngx_int_t ngx_disable_accept_events(ngx_cycle_t *cycle, ngx_uint_t all);
 
 
 void
@@ -112,7 +112,7 @@ ngx_event_accept(ngx_event_t *ev)
             }
 
             if (err == NGX_EMFILE || err == NGX_ENFILE) {
-                if (ngx_disable_accept_events((ngx_cycle_t *) ngx_cycle)
+                if (ngx_disable_accept_events((ngx_cycle_t *) ngx_cycle, 1)
                     != NGX_OK)
                 {
                     return;
@@ -413,7 +413,7 @@ ngx_trylock_accept_mutex(ngx_cycle_t *cycle)
                    "accept mutex lock failed: %ui", ngx_accept_mutex_held);
 
     if (ngx_accept_mutex_held) {
-        if (ngx_disable_accept_events(cycle) == NGX_ERROR) {
+        if (ngx_disable_accept_events(cycle, 0) == NGX_ERROR) {
             return NGX_ERROR;
         }
 
@@ -436,7 +436,7 @@ ngx_enable_accept_events(ngx_cycle_t *cycle)
 
         c = ls[i].connection;
 
-        if (c->read->active) {
+        if (c == NULL || c->read->active) { 
             continue;
         }
 
@@ -458,7 +458,7 @@ ngx_enable_accept_events(ngx_cycle_t *cycle)
 
 
 static ngx_int_t
-ngx_disable_accept_events(ngx_cycle_t *cycle)
+ngx_disable_accept_events(ngx_cycle_t *cycle, ngx_uint_t all)
 {
     ngx_uint_t         i;
     ngx_listening_t   *ls;
@@ -469,9 +469,22 @@ ngx_disable_accept_events(ngx_cycle_t *cycle)
 
         c = ls[i].connection;
 
-        if (!c->read->active) {
+        if (c == NULL || !c->read->active) {
             continue;
         }
+
+#if (NGX_HAVE_REUSEPORT)
+
+		/* 
+		 * do not disable accept on worker's own sockets 
+		 * when disabling accept events due to accept mutex 
+		 */ 
+ 
+		if (ls[i].reuseport && !all) { 
+			continue; 
+		} 
+ 
+#endif
 
         if (ngx_event_flags & NGX_USE_RTSIG_EVENT) {
             if (ngx_del_conn(c, NGX_DISABLE_EVENT) == NGX_ERROR) {

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -1728,13 +1728,7 @@ ngx_http_init_listening(ngx_conf_t *cf, ngx_http_conf_port_t *port)
 
         ls->servers = hport;
 
-        if (i == last - 1) {
-            hport->naddrs = last;
-
-        } else {
-            hport->naddrs = 1;
-            i = 0;
-        }
+        hport->naddrs = i + 1;
 
         switch (ls->sockaddr->sa_family) {
 
@@ -1750,6 +1744,10 @@ ngx_http_init_listening(ngx_conf_t *cf, ngx_http_conf_port_t *port)
                 return NGX_ERROR;
             }
             break;
+        }
+
+        if (ngx_clone_listening(cf, ls) != NGX_OK) {
+            return NGX_ERROR;
         }
 
         addr++;
@@ -1828,6 +1826,10 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
 
 #if (NGX_HAVE_TCP_FASTOPEN)
     ls->fastopen = addr->opt.fastopen;
+#endif
+
+#if (NGX_HAVE_REUSEPORT)
+    ls->reuseport = addr->opt.reuseport;
 #endif
 
     return ls;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4524,6 +4524,19 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 #endif
         }
 
+        if (ngx_strcmp(value[n].data, "reuseport") == 0) {
+#if (NGX_HAVE_REUSEPORT)
+            lsopt.reuseport = 1;
+            lsopt.set = 1;
+            lsopt.bind = 1;
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "reuseport is not supported "
+                               "on this platform, ignored");
+#endif
+            continue;
+        }
+
         if (ngx_strcmp(value[n].data, "ssl") == 0) {
 #if (NGX_HTTP_SSL)
             lsopt.ssl = 1;

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -87,6 +87,9 @@ typedef struct {
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
     unsigned                   ipv6only:1;
 #endif
+#if (NGX_HAVE_REUSEPORT)
+    unsigned                   reuseport:1;
+#endif
     unsigned                   so_keepalive:2;
     unsigned                   proxy_protocol:1;
 

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -36,6 +36,7 @@ static void ngx_cache_loader_process_handler(ngx_event_t *ev);
 
 
 ngx_uint_t    ngx_process;
+ngx_uint_t    ngx_worker;
 ngx_pid_t     ngx_pid;
 ngx_uint_t    ngx_threaded;
 
@@ -390,20 +391,6 @@ ngx_start_worker_processes(ngx_cycle_t *cycle, ngx_int_t n, ngx_int_t type)
 
     ch.command = NGX_CMD_OPEN_CHANNEL;
 
-#if (NGX_HAVE_REUSEPORT)
-
-    ngx_uint_t           listen_nelt;
-    ngx_event_conf_t    *ecf;
-
-    ecf = ngx_event_get_conf(cycle->conf_ctx, ngx_event_core_module);
-    if (ecf->reuse_port) {
-        listen_nelt = cycle->listening.nelts;
-        ngx_close_listening_sockets(cycle);
-        cycle->listening.nelts = listen_nelt;
-    }
-
-#endif
-
     for (i = 0; i < n; i++) {
 
         ngx_spawn_process(cycle, ngx_worker_process_cycle,
@@ -619,23 +606,6 @@ ngx_reap_children(ngx_cycle_t *cycle)
 
     live = 0;
 
-#if (NGX_HAVE_REUSEPORT)
-
-    ngx_event_conf_t    *ecf;
-
-    ecf = ngx_event_get_conf(cycle->conf_ctx, ngx_event_core_module);
-
-    if (!ngx_terminate
-        && !ngx_quit
-        && ecf->reuse_port)
-    {
-        if (ngx_open_listening_sockets(cycle) != NGX_OK) {
-            return live;
-        }
-    }
-
-#endif
-
     for (i = 0; i < ngx_last_process; i++) {
 
         ngx_log_debug7(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
@@ -749,21 +719,6 @@ ngx_reap_children(ngx_cycle_t *cycle)
         }
     }
 
-#if (NGX_HAVE_REUSEPORT)
-
-    ngx_uint_t           listen_nelt;
-
-    if (!ngx_terminate
-        && !ngx_quit
-        && ecf->reuse_port)
-    {
-        listen_nelt = cycle->listening.nelts;
-        ngx_close_listening_sockets(cycle);
-        cycle->listening.nelts = listen_nelt;
-    }
-
-#endif
-
     return live;
 }
 
@@ -830,6 +785,7 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
     ngx_connection_t  *c;
 
     ngx_process = NGX_PROCESS_WORKER;
+    ngx_worker = worker; 
 
     ngx_worker_process_init(cycle, worker);
 
@@ -999,22 +955,6 @@ ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker)
                           ccf->rlimit_sigpending);
         }
     }
-#endif
-
-#if (NGX_HAVE_REUSEPORT)
-
-    ngx_event_conf_t    *ecf;
-
-    ecf = ngx_event_get_conf(cycle->conf_ctx, ngx_event_core_module);
-    if (ecf->reuse_port) {
-        if (ngx_open_listening_sockets(cycle) != NGX_OK) {
-            /* fatal */
-            exit(2);
-        }
-
-        ngx_configure_listening_sockets(cycle);
-    }
-
 #endif
 
     if (geteuid() == 0) {

--- a/src/os/unix/ngx_process_cycle.h
+++ b/src/os/unix/ngx_process_cycle.h
@@ -41,6 +41,7 @@ void ngx_single_process_cycle(ngx_cycle_t *cycle);
 
 
 extern ngx_uint_t      ngx_process;
+extern ngx_uint_t      ngx_worker;
 extern ngx_pid_t       ngx_pid;
 extern ngx_pid_t       ngx_new_binary;
 extern ngx_uint_t      ngx_inherited;


### PR DESCRIPTION
In nginx 1.9.1 reuseport socket option was introduced. I think better to replace tengine`s implementation with this.

Related commits:
http://trac.nginx.org/nginx/changeset/b4cc553aafeb4b7e19b63e6846490e2835d7e853/nginx/
http://trac.nginx.org/nginx/changeset/4f6efabcb09b693ac5461f2b1d05a526f9710137/nginx/
http://trac.nginx.org/nginx/changeset/193bbc006d5e0ddf71322ceb1114b81e3c661c65/nginx/

I am not sure does it needed for reuseport, so i've just also backported http://trac.nginx.org/nginx/changeset/3c344ea7d88bb839ef2814164342c635aaad816f/nginx/
And this just by the way (may be reverted) http://trac.nginx.org/nginx/changeset/b19350b896bb390a639a7e4cf099781b73cb4fa7/nginx/