### PR TITLE
Fixed: compile warning about upstream_check's uninitialized variable

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -4306,6 +4306,7 @@ ngx_http_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
 
     opeers_shm = NULL;
     peers_shm = NULL;
+    ngx_str_set(&oshm_name, "");
 
     same = 0;
     peers = check_peers_ctx;


### PR DESCRIPTION
https://github.com/alibaba/tengine/commit/9210e49b043fbcb7ff17a7d9e17fc3787f0138e1#commitcomment-12357437