### PR TITLE
core: fixed valgrind warning in ngx_http_core_merge_loc_conf()

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4050,10 +4050,11 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                prev->error_pages != NGX_CONF_UNSET_PTR)
     {
         ep = prev->error_pages->elts;
-        ec = conf->error_pages->elts;
 
         for (i = 0; i < prev->error_pages->nelts; i++) {
             found = 0;
+
+            ec = conf->error_pages->elts;
 
             for (j = 0; j < conf->error_pages->nelts; j++) {
                 if (ep[i].status == ec[j].status) {


### PR DESCRIPTION
ngx_array_push() will modify conf->error_pages->elts.
So it should get conf->error_pages->elts again before traversing its elements.

Valgrind warning is as following:
```
==18957== Invalid read of size 2
==18957==    at 0x48A630: ngx_http_core_merge_loc_conf (ngx_http_core_module.c:4028)
==18957==    by 0x487E5B: ngx_http_block (ngx_http.c:610)
==18957==    by 0x461DD5: ngx_conf_parse (ngx_conf_file.c:395)
==18957==    by 0x45F29C: ngx_init_cycle (ngx_cycle.c:278)
==18957==    by 0x4506A8: main (nginx.c:347)
==18957==  Address 0x1293e978 is not stack'd, malloc'd or (recently) free'd
```