### PR TITLE
bugfix: upstream check for dynamic

### DIFF
--- a/auto/options
+++ b/auto/options
@@ -567,7 +567,7 @@ do
         --with-http_reqstat_module=shared)         HTTP_REQ_STATUS=NO
                                                    HTTP_REQ_STATUS_SHARED=YES        ;;
 
-        --with-http_dyups_module)        HTTP_NODYNAMIC_UPSTREAM=YES  ;;
+        --with-http_dyups_module)        HTTP_DYNAMIC_UPSTREAM=YES  ;;
         --with-http_dyups_lua_api)       HTTP_DYNAMIC_UPSTREAM_LUA=YES  ;;
 
         --without-http_charset_module)   HTTP_CHARSET=NO

--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -1171,6 +1171,7 @@ ngx_http_upstream_check_add_dynamic_peer_shm(ngx_pool_t *pool,
 
     ngx_shmtx_lock(&shpool->mutex);
 
+#if 0
     for (i = 0; i < peers_shm->number; i++) {
 
         /* TODO: lock the peer mutex */
@@ -1188,6 +1189,7 @@ ngx_http_upstream_check_add_dynamic_peer_shm(ngx_pool_t *pool,
             return i;
         }
     }
+#endif
 
     for (i = 0; i < peers_shm->number; i++) {
 


### PR DESCRIPTION
#641

bug原因:
当动态更新的upstream存在相同的server时, 新增加的server将和原来老的server共用存储空间.
如果配置的check url或者规则不一样, 将会出问题.