### PR TITLE
backtrace module: fix compiling error

### DIFF
--- a/src/misc/ngx_backtrace_module.c
+++ b/src/misc/ngx_backtrace_module.c
@@ -13,6 +13,14 @@
 #define NGX_BACKTRACE_DEFAULT_STACK_MAX_SIZE 30
 
 
+typedef struct {
+    int     signo;
+    char   *signame;
+    char   *name;
+    void  (*handler)(int signo);
+} ngx_signal_t;
+
+
 static char *ngx_backtrace_files(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static void ngx_error_signal_handler(int signo);


### PR DESCRIPTION
fix following compiling error:
```
$ make
make -f objs/Makefile
make[1]: Entering directory `/home/xiaochen.wxc/work/github/tengine-xiaochen'
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g   -I src/core -I src/event -I src/event/modules -I src/os/unix -I src/proc -I objs -I src/http -I src/http/modules -I src/mail \
                -o objs/src/misc/ngx_backtrace_module.o \
                src/misc/ngx_backtrace_module.c
src/misc/ngx_backtrace_module.c:29: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘ngx_backtrace_signals’
src/misc/ngx_backtrace_module.c: In function ‘ngx_init_error_signals’:
src/misc/ngx_backtrace_module.c:94: error: ‘ngx_signal_t’ undeclared (first use in this function)
src/misc/ngx_backtrace_module.c:94: error: (Each undeclared identifier is reported only once
src/misc/ngx_backtrace_module.c:94: error: for each function it appears in.)
src/misc/ngx_backtrace_module.c:94: error: ‘sig’ undeclared (first use in this function)
src/misc/ngx_backtrace_module.c:97: error: ‘ngx_backtrace_signals’ undeclared (first use in this function)
src/misc/ngx_backtrace_module.c: In function ‘ngx_error_signal_handler’:
src/misc/ngx_backtrace_module.c:118: error: ‘ngx_signal_t’ undeclared (first use in this function)
src/misc/ngx_backtrace_module.c:118: error: ‘sig’ undeclared (first use in this function)
src/misc/ngx_backtrace_module.c:122: error: ‘ngx_backtrace_signals’ undeclared (first use in this function)
make[1]: *** [objs/src/misc/ngx_backtrace_module.o] Error 1
make[1]: Leaving directory `/home/xiaochen.wxc/work/github/tengine-xiaochen'
make: *** [build] Error 2
```

This bug is introduced by #634.