### PR TITLE
Cleaning up #ifdefs that break statements

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -3282,6 +3282,7 @@ ngx_http_core_location(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy)
     ngx_http_module_t         *module;
     ngx_http_conf_ctx_t       *ctx, *pctx;
     ngx_http_core_loc_conf_t  *clcf, *pclcf;
+    int is_error;
 
     ctx = ngx_pcalloc(cf->pool, sizeof(ngx_http_conf_ctx_t));
     if (ctx == NULL) {
@@ -3435,12 +3436,12 @@ ngx_http_core_location(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy)
         len = pclcf->name.len;
 
 #if (NGX_PCRE)
-        if (clcf->regex == NULL
-            && ngx_filename_cmp(clcf->name.data, pclcf->name.data, len) != 0)
+        is_error = (clcf->regex == NULL
+            && ngx_filename_cmp(clcf->name.data, pclcf->name.data, len) != 0);
 #else
-        if (ngx_filename_cmp(clcf->name.data, pclcf->name.data, len) != 0)
+        is_error = (ngx_filename_cmp(clcf->name.data, pclcf->name.data, len) != 0);
 #endif
-        {
+        if (is_error) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "location \"%V\" is outside location \"%V\"",
                                &clcf->name, &pclcf->name);


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.
- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.
