### PR TITLE
fix Merge the duplicate peer; if always ignore merging peer, too many…

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -3758,6 +3758,23 @@ ngx_http_upstream_check_http_send(ngx_conf_t *cf, ngx_command_t *cmd,
 
     ucscf = ngx_http_conf_get_module_srv_conf(cf,
                                               ngx_http_upstream_check_module);
+    if (ucscf->check_type_conf == NGX_CONF_UNSET_PTR)
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid check_http_send should set [check] first");
+        return NGX_CONF_ERROR;
+    }
+
+    if (value[1].len
+        && (ucscf->check_type_conf->name.len != 4
+            || ngx_strncmp(ucscf->check_type_conf->name.data,
+                           "http", 4) != 0))
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid check_http_send for type \"%V\"",
+                           &ucscf->check_type_conf->name);
+        return NGX_CONF_ERROR;
+    }
 
     ucscf->send = value[1];
 

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
@@ -538,3 +538,59 @@ GET /
 --- request
 GET /
 --- response_body_like: ^<(.*)>$
+
+=== TEST 19: the http_check with type!=http and check_http_send configured
+--- http_config
+    upstream test{
+        server 127.0.0.1:1970;
+        check_keepalive_requests 10;
+        check interval=3000 rise=1 fall=1 timeout=1000 type=tcp;
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- nginx config test
+nginx -t
+--- response_body_like: nginx: [emerg] invalid check_http_send for type "tcp" in <(.*)>$
+
+=== TEST 20: the http_check with check_http_send configured before check
+--- http_config
+    upstream test{
+        server 127.0.0.1:1970;
+        check_keepalive_requests 10;
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check interval=3000 rise=1 fall=1 timeout=1000 type=http;
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- nginx config test
+nginx -t
+--- response_body_like: nginx: [emerg] invalid check_http_send should set [check] first in <(.*)>$


### PR DESCRIPTION
… check health timers(1+num of workprogresses) will be added after calling dyups. if always merge peer , when two or more upstreams have same server-port but diffrent check configration, the result of health check will be disturbed. so we need to check before merge.
我们的项目在使用tengine的时候遇到问题如下：
1、在之前有merge peer的时候；当多个upstream中有相同的server+port的时候，而每个upstream的health check配置了不同的检测uri（send的内容不同）。在执行dyups更新upstream后，healthcheck模块返回的status是错乱的。
2、在取消merge peer的操作后；当执行dyup更新upstream操作后，healthcheck的检测次数明显上升，检测频率=（1+worker线程数）* 配置的频率。

针对对这个问题做的commit：
在peer_shm中记录send的内容的ngx_murmur_hash2值以及check_type_conf，在判断merge的时候如果type=http类型，检查send内容ngx_murmur_hash2值，相同才merge。因为fastcgi我们healthcheck没有用到所以没有加入fastcgi_params的验证，直接merge。如果type是其他类型，因为没有可配置参数，所以在有相同的server+port时检查结果应该是一样的，所以也merge。

希望尽快可以得到你们的答复，谢谢。