### PR TITLE
update ngx_dyups_init_upstream function for memzero 'cf' variable

### DIFF
--- a/src/http/modules/ngx_http_dyups_module.c
+++ b/src/http/modules/ngx_http_dyups_module.c
@@ -1558,7 +1558,7 @@ ngx_dyups_init_upstream(ngx_http_dyups_srv_conf_t *duscf, ngx_str_t *name,
     duscf->dynamic = 1;
     duscf->upstream = uscf;
     
-    ngx_memzero(&cf, sizeof (ngx_conf_t));
+    ngx_memzero(&cf, sizeof(ngx_conf_t));
     cf.module_type = NGX_HTTP_MODULE;
     cf.cmd_type = NGX_HTTP_MAIN_CONF;
     cf.pool = duscf->pool;

--- a/src/http/modules/ngx_http_dyups_module.c
+++ b/src/http/modules/ngx_http_dyups_module.c
@@ -1557,7 +1557,8 @@ ngx_dyups_init_upstream(ngx_http_dyups_srv_conf_t *duscf, ngx_str_t *name,
 
     duscf->dynamic = 1;
     duscf->upstream = uscf;
-
+    
+    ngx_memzero(&cf, sizeof (ngx_conf_t));
     cf.module_type = NGX_HTTP_MODULE;
     cf.cmd_type = NGX_HTTP_MAIN_CONF;
     cf.pool = duscf->pool;


### PR DESCRIPTION
hi @yzprofile 
I found the function `ngx_dyups_init_upstream`  'cf' variable is not memzero and maybe it's cause some bugs.
Plz review and Thx.
  

