### PR TITLE
Fix Set-Cookie on session_sticky_module

### DIFF
--- a/src/http/modules/ngx_http_upstream_session_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_session_sticky_module.c
@@ -975,9 +975,9 @@ ngx_http_session_sticky_insert(ngx_http_request_t *r)
     set_cookie->value.len = ctx->sscf->cookie.len
                           + sizeof("=") - 1
                           + ctx->sid.len
-                          + sizeof(";Domain=") - 1
+                          + sizeof("; Domain=") - 1
                           + ctx->sscf->domain.len
-                          + sizeof(";Path=") - 1
+                          + sizeof("; Path=") - 1
                           + ctx->sscf->path.len;
 
     if (ctx->sscf->maxidle != NGX_CONF_UNSET) {
@@ -987,7 +987,7 @@ ngx_http_session_sticky_insert(ngx_http_request_t *r)
                               + 2; /* '|' and '|' */
     } else {
         set_cookie->value.len = set_cookie->value.len
-                              + sizeof(";Max-Age=") - 1
+                              + sizeof("; Max-Age=") - 1
                               + ctx->sscf->maxage.len;
     }
 
@@ -1008,15 +1008,15 @@ ngx_http_session_sticky_insert(ngx_http_request_t *r)
         p = ngx_cpymem(p, ctx->s_firstseen.data, ctx->s_firstseen.len);
     }
     if (ctx->sscf->domain.len) {
-        p = ngx_cpymem(p, ";Domain=", sizeof(";Domain=") - 1);
+        p = ngx_cpymem(p, "; Domain=", sizeof("; Domain=") - 1);
         p = ngx_cpymem(p, ctx->sscf->domain.data, ctx->sscf->domain.len);
     }
     if (ctx->sscf->path.len) {
-        p = ngx_cpymem(p, ";Path=", sizeof(";Path=") - 1);
+        p = ngx_cpymem(p, "; Path=", sizeof("; Path=") - 1);
         p = ngx_cpymem(p, ctx->sscf->path.data, ctx->sscf->path.len);
     }
     if (ctx->sscf->maxidle == NGX_CONF_UNSET && ctx->sscf->maxage.len) {
-        p = ngx_cpymem(p, ";Max-Age=", sizeof(";Max-Age=") - 1);
+        p = ngx_cpymem(p, "; Max-Age=", sizeof("; Max-Age=") - 1);
         p = ngx_cpymem(p, ctx->sscf->maxage.data, ctx->sscf->maxage.len);
     }
 

--- a/src/http/modules/ngx_http_upstream_session_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_session_sticky_module.c
@@ -988,7 +988,9 @@ ngx_http_session_sticky_insert(ngx_http_request_t *r)
     } else {
         set_cookie->value.len = set_cookie->value.len
                               + sizeof("; Max-Age=") - 1
-                              + ctx->sscf->maxage.len;
+                              + ctx->sscf->maxage.len
+                              + sizeof("; Expires=") - 1
+                              + sizeof("Xxx, 00-Xxx-00 00:00:00 GMT") - 1;
     }
 
     p = ngx_pnalloc(r->pool, set_cookie->value.len);
@@ -1018,6 +1020,10 @@ ngx_http_session_sticky_insert(ngx_http_request_t *r)
     if (ctx->sscf->maxidle == NGX_CONF_UNSET && ctx->sscf->maxage.len) {
         p = ngx_cpymem(p, "; Max-Age=", sizeof("; Max-Age=") - 1);
         p = ngx_cpymem(p, ctx->sscf->maxage.data, ctx->sscf->maxage.len);
+        p = ngx_cpymem(p, "; Expires=", sizeof("; Expires=") - 1);
+        ngx_uint_t maxage = ngx_atoi(ctx->sscf->maxage.data,
+                                      ctx->sscf->maxage.len);
+        p = ngx_http_cookie_time(p, ngx_time() + maxage);
     }
 
     set_cookie->value.len = p - set_cookie->value.data;


### PR DESCRIPTION
1. set-cookie-string require a space after semicolon, refer [RFC6265](https://tools.ietf.org/html/rfc6265#page-9).
2. Max-Age is only supported since HTTP/1.1, add the Expires filed to fix HTTP/1.0 and some fucking browsers such as IE6/7/8.