### PR TITLE
SSL: avoid calling SSL_shutdown() during handshake

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1766,6 +1766,21 @@ ngx_ssl_shutdown(ngx_connection_t *c)
     int        n, sslerr, mode;
     ngx_err_t  err;
 
+    //OpenSSL 1.0.2f+ bug fix: https://trac.nginx.org/nginx/changeset/062c189fee20c18fae5ac3716a7379143d64150e/nginx
+    if (!c->ssl->handshaked) {
+        /*
+         * OpenSSL 1.0.2f complains if SSL_shutdown() is called during
+         * an SSL handshake, while previous versions always return 0.
+         * Avoid calling SSL_shutdown() if handshake wasn't completed.
+         */
+
+        SSL_free(c->ssl->connection);
+        c->ssl = NULL;
+
+        return NGX_OK;
+    }
+
+
     if (c->timedout) {
         mode = SSL_RECEIVED_SHUTDOWN|SSL_SENT_SHUTDOWN;
         SSL_set_quiet_shutdown(c->ssl->connection, 1);


### PR DESCRIPTION
This fixes "called a function you should not call" and
"shutdown while in init" errors as observed with OpenSSL 1.0.2f
due to changes in how OpenSSL handles SSL_shutdown() during
SSL handshakes.

via: https://trac.nginx.org/nginx/changeset/062c189fee20c18fae5ac3716a7379143d64150e/nginx