### PR TITLE
健康检查模块：修复对正常mysql检查偶尔失败

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -1815,6 +1815,9 @@ ngx_http_upstream_check_recv_handler(ngx_event_t *event)
 
     if (peer->state != NGX_HTTP_CHECK_SEND_DONE) {
 
+        if(ngx_http_upstream_check_peek_one_byte(c) != NGX_OK) {
+            goto check_recv_fail;
+        }
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
             goto check_recv_fail;
         }

--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -1786,6 +1786,14 @@ ngx_http_upstream_check_send_handler(ngx_event_t *event)
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http check send done.");
         peer->state = NGX_HTTP_CHECK_SEND_DONE;
         c->requests++;
+        
+        if(c->read->ready == 1) {
+            c->read->active = 0;
+            c->read->ready = 0;
+            if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+                goto check_send_fail;
+            }
+        }
     }
 
     return;


### PR DESCRIPTION
1.设备能通，但服务端口不通时，立即检测到失败，不用在等超时失败
2.mysql通过greeting信息检查，连接后read->handler可能早于write->handler，此时因为peer->state==NGX_HTTP_CHECK_CONNECT_DONE而read handler会不做事情，确保write handler后能再read
#625 
