### PR TITLE
dynamic_resolver: fix segfault when using variable in proxy_pass

### DIFF
--- a/src/http/modules/ngx_http_upstream_dynamic_module.c
+++ b/src/http/modules/ngx_http_upstream_dynamic_module.c
@@ -222,16 +222,14 @@ ngx_http_upstream_dynamic_handler(ngx_resolver_ctx_t *ctx)
     u_char                 *p;
 
     size_t                                 len;
-    ngx_http_upstream_srv_conf_t          *us;
     ngx_http_upstream_dynamic_srv_conf_t  *dscf;
+    ngx_http_upstream_dynamic_peer_data_t *bp;
 
-    r = ctx->data;
-
+    bp = ctx->data;
+    r = bp->request;
     u = r->upstream;
-    us = u->conf->upstream;
     pc = &u->peer;
-
-    dscf = ngx_http_conf_upstream_srv_conf(us, ngx_http_upstream_dynamic_module);
+    dscf = bp->conf;
 
     if (ctx->state) {
 
@@ -436,7 +434,7 @@ ngx_http_upstream_get_dynamic_peer(ngx_peer_connection_t *pc, void *data)
     // ctx->type = NGX_RESOLVE_A;
     /* END */
     ctx->handler = ngx_http_upstream_dynamic_handler;
-    ctx->data = r;
+    ctx->data = bp;
     ctx->timeout = clcf->resolver_timeout;
 
     u->dyn_resolve_ctx = ctx;

--- a/tests/nginx-tests/cases/dynamic_resolve.t
+++ b/tests/nginx-tests/cases/dynamic_resolve.t
@@ -24,13 +24,13 @@ plan(skip_all => 'Net::DNS::Nameserver not installed') if $@;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(5);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(6);
 my @server_addrs = ("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4");
 my @domain_addrs = ("127.0.0.2");
 
 #my $ipv6 = $t->has_module("ipv6") ? "ipv6=off" : "";
 
-$t->write_file_expand('nginx.conf', <<"EOF");
+$t->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
 
@@ -97,6 +97,11 @@ http {
             proxy_pass http://backend1;
         }
 
+        location /proxy_pass_var {
+            set $up backend1;
+            proxy_pass http://$up;
+        }
+
         location /stale {
             proxy_pass http://backend2;
         }
@@ -128,6 +133,10 @@ like(http_get('/static'), qr/501/,
     'static resolved should be taobao\' IP addr');
 like(http_get('/'), qr/127\.0\.0\.2/,
     'http server should be 127.0.0.2');
+
+# test variable in proxy_pass argument
+like(http_get('/proxy_pass_var'), qr/127\.0\.0\.2/,
+    'http server should be 127.0.0.2 for /proxy_pass_var');
 
 # kill dns daemon
 kill $^O eq 'MSWin32' ? 9 : 'TERM', $dns_pid;
@@ -183,6 +192,7 @@ sub http_daemon {
         $uri = $1 if $headers =~ /^\S+\s+([^ ]+)\s+HTTP/i;
 
         if ($uri eq '/'
+            or $uri eq '/proxy_pass_var'
             or $uri eq '/static'
             or $uri eq '/next'
             or $uri eq '/stale'


### PR DESCRIPTION
* add a new test case (all test cases have passed)
* `r->upstream->conf->upstream` will be NULL if using variable in proxy_pass directive
* try to fix https://github.com/alibaba/tengine/issues/729#issuecomment-216793045