### PR TITLE
tcp health check does not need keepalive

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -695,7 +695,7 @@ static ngx_check_conf_t  ngx_check_types[] = {
       NULL,
       NULL,
       0,
-      1 },
+      0 },
 
     { NGX_HTTP_CHECK_HTTP,
       ngx_string("http"),


### PR DESCRIPTION
making tcp health check be "keepalive" is buggy if backend server crashes quietly