### PR TITLE
Patch for CVE-2016-4450

### DIFF
--- a/src/os/unix/ngx_files.c
+++ b/src/os/unix/ngx_files.c
@@ -292,6 +292,12 @@ ngx_write_chain_to_file(ngx_file_t *file, ngx_chain_t *cl, off_t offset,
         /* create the iovec and coalesce the neighbouring bufs */
 
         while (cl && vec.nelts < IOV_MAX) {
+
+            if (ngx_buf_special(cl->buf)) {
+                cl = cl->next;
+                continue;
+            }
+
             if (prev == cl->buf->pos) {
                 iov->iov_len += cl->buf->last - cl->buf->pos;
 


### PR DESCRIPTION
This pull request for CVE-2016-4450 :  
 A specially crafted request might result in worker process crash due to a NULL pointer dereference while writing client request body to a temporary file (CVE-2016-4450).

http://mailman.nginx.org/pipermail/nginx-announce/2016/000179.html
https://bugs.launchpad.net/ubuntu/+source/nginx/+bug/1587577