### PR TITLE
tests: make dynamic_resolver.t support ipv6

### DIFF
--- a/tests/nginx-tests/cases/dynamic_resolve.t
+++ b/tests/nginx-tests/cases/dynamic_resolve.t
@@ -28,9 +28,9 @@ my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(6);
 my @server_addrs = ("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4");
 my @domain_addrs = ("127.0.0.2");
 
-#my $ipv6 = $t->has_module("ipv6") ? "ipv6=off" : "";
+my $ipv6 = $t->has_module("ipv6") ? "ipv6=off" : "";
 
-$t->write_file_expand('nginx.conf', <<'EOF');
+my $nginx_conf = <<'EOF';
 
 %%TEST_GLOBALS%%
 
@@ -43,7 +43,7 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    resolver 127.0.0.1:53530 valid=1s;
+    resolver 127.0.0.1:53530 valid=1s %%TEST_CONF_IPV6%%;
     resolver_timeout 1s;
 
     upstream backend {
@@ -117,6 +117,10 @@ http {
 }
 
 EOF
+
+$nginx_conf =~ s/%%TEST_CONF_IPV6%%/$ipv6/gmse;
+
+$t->write_file_expand('nginx.conf', $nginx_conf);
 
 foreach my $ip (@server_addrs) {
     $t->run_daemon(\&http_daemon, $ip);


### PR DESCRIPTION
Test cases have passed.
```
$ cat dtest.sh
nginx_src=$(pwd)
nginx_bin=$nginx_src/objs/nginx
nginx_test_lib=$nginx_src/tests/nginx-tests/nginx-tests/lib
nginx_case=tests/nginx-tests/nginx-tests

if [ "$1" != "" ]; then
  nginx_case=$1
fi

TEST_NGINX_BINARY="$nginx_bin" prove -I $nginx_test_lib $nginx_case -v

$ sh dtest.sh tests/nginx-tests/cases/dynamic_resolve.t
tests/nginx-tests/cases/dynamic_resolve.t ..
1..6
ok 1 - static resolved should be taobao' IP addr
;; HEADER SECTION
;;      id = 52828
;;      qr = 0  aa = 0  tc = 0  rd = 1  opcode = QUERY
;;      ra = 0  z  = 0  ad = 0  cd = 0  rcode  = NOERROR
;;      qdcount = 1     ancount = 0     nscount = 0     arcount = 0
;;      do = 0


;; QUESTION SECTION (1 record)
;; www.taobao.com.      IN      A

;; ANSWER SECTION (0 records)

;; AUTHORITY SECTION (0 records)

;; ADDITIONAL SECTION (0 records)
ok 2 - http server should be 127.0.0.2
ok 3 - http server should be 127.0.0.2 for /proxy_pass_var
ok 4 - stale http server should be www.taobao.com:8081, using initial result
ok 5 - shutdown connection if dns query is failed
ok 6 - next upstream should be 127.0.0.4
ok
All tests successful.
Files=1, Tests=6, 14 wallclock secs ( 0.03 usr  0.00 sys +  0.21 cusr  0.06 csys =  0.30 CPU)
Result: PASS
```