### PR TITLE
Add Dynamic TLS Record Sizing for Tengine

### DIFF
--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -36,11 +36,18 @@
 #define ngx_ssl_session_t       SSL_SESSION
 #define ngx_ssl_conn_t          SSL
 
+typedef struct {
+    ngx_msec_t                  timeout;
+    ngx_uint_t                  threshold;
+    size_t                      size_lo;
+    size_t                      size_hi;
+} ngx_ssl_dyn_rec_t;
 
 typedef struct {
     SSL_CTX                    *ctx;
     ngx_log_t                  *log;
     size_t                      buffer_size;
+    ngx_ssl_dyn_rec_t           dyn_rec;
 } ngx_ssl_t;
 
 
@@ -63,6 +70,10 @@ typedef struct {
     unsigned                    no_wait_shutdown:1;
     unsigned                    no_send_shutdown:1;
     unsigned                    handshake_buffer_set:1;
+
+    ngx_ssl_dyn_rec_t           dyn_rec;
+    ngx_msec_t                  dyn_rec_last_write;
+    ngx_uint_t                  dyn_rec_records_sent;
 } ngx_ssl_connection_t;
 
 typedef struct {
@@ -78,7 +89,8 @@ typedef struct {
 #define NGX_SSL_DFLT_BUILTIN_SCACHE  -5
 
 
-#define NGX_SSL_MAX_SESSION_SIZE  4096
+/*#define NGX_SSL_MAX_SESSION_SIZE   16*1024 */
+#define NGX_SSL_MAX_SESSION_SIZE  16384
 
 typedef struct ngx_ssl_sess_id_s  ngx_ssl_sess_id_t;
 
@@ -226,4 +238,4 @@ extern int  ngx_ssl_stapling_index;
     PEM_read_bio_X509(b, x, cb, arg)
 #endif
 
-#endif /* _NGX_EVENT_OPENSSL_H_INCLUDED_ */
+#endif /*_NGX_EVENT_OPENSSL_H_INCLUDED_ */

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -57,6 +57,12 @@ typedef struct {
 
     u_char                         *file;
     ngx_uint_t                      line;
+
+    ngx_flag_t                      dyn_rec_enable;
+    ngx_msec_t                      dyn_rec_timeout;
+    size_t                          dyn_rec_size_lo;
+    size_t                          dyn_rec_size_hi;
+    ngx_uint_t                      dyn_rec_threshold;
 } ngx_http_ssl_srv_conf_t;
 
 typedef struct {


### PR DESCRIPTION
Hi, this pull request is a patch for NGX SSL module which added dynamic TLS record sizing feature.

As we known, TLS working over TCP with record  protocol, it's divides the data being transmitted into records of a fixed (maximum: 16 KB in Nginx ) size and then hands those records to TCP for transmission.  then TCP promptly divides those records up into segments which are then transmitted. In some case, record size can can touch off HoL.[1]

That is to say, we can reduce latency by tuning TLS record size. In a nutshell, static record size introduces an inherent tradeoff between latency and throughput – smaller records are good for latency, but hurt server throughput by adding bytes and CPU overhead. So,the scheme for dynamic record sizing in this patch is : 

- for echo connect start with records of size `ssl_dyn_rec_size_lo`  which can fit into one tcp segment (IPv4) 
`ssl_dyn_rec_size_lo` = MUT(1500) - IP (40) - TCP (20) - TCP Options(40) - TLS Overhead(60-100)[2] ~= 1300 
send 52 KB data with `ssl_dyn_rec_size_lo`  

- Incr record size to `ssl_dyn_rec_size_hi` which equal 3*`ssl_dyn_rec_size_lo`- Max TLS Overhead(100)[2] = 3800 
then, send  152 KB data with `ssl_dyn_rec_size_hi` 

- After send 204 KB data, incr TLS record size to default ssl buffer size( 16 KB )

- If the connection idles for longer than this time (in seconds) that the TLS record size is reduced to `ssl_dyn_rec_size_lo`

 
this patch's dynamic sizing logic like apache mod_h2 (https://github.com/icing/mod_h2/blob/master/mod_http2/h2_conn_io.c)



 
 
[1]http://chimera.labs.oreilly.com/books/1230000000545/ch04.html#TLS_RECORD_SIZE
[2]https://www.evernote.com/shard/s1/sh/a44a8ee5-d788-44c7-a3ad-6e505f99d592/00e0b141eef44288f338332085044e6a  
