### PR TITLE
add main conf merge and multi http block supports for upstream check module 

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -164,6 +164,7 @@ typedef struct {
     ngx_str_t                                check_shm_name;
     ngx_uint_t                               checksum;
     ngx_array_t                              peers;
+    ngx_cycle_t                             *cycle;
     ngx_slab_pool_t                         *shpool;
 
     ngx_http_upstream_check_peers_shm_t     *peers_shm;
@@ -3919,7 +3920,7 @@ ngx_http_upstream_check_shm_size(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return "invalid value";
     }
 
-    if (check_peers_ctx) {
+    if (check_peers_ctx && check_peers_ctx->cycle == ngx_cycle) {
         return "must be set in the first http block only";
     }
 
@@ -4359,7 +4360,7 @@ ngx_http_upstream_check_init_shm(ngx_conf_t *cf, void *conf)
     ngx_http_upstream_check_peer_t       *peers;
     ngx_http_upstream_check_main_conf_t  *ucmcf = conf;
 
-    if (check_peers_ctx == NULL) {
+    if (check_peers_ctx == NULL || check_peers_ctx->cycle != ngx_cycle) {
 
         ngx_http_upstream_check_shm_generation++;
 
@@ -4383,6 +4384,7 @@ ngx_http_upstream_check_init_shm(ngx_conf_t *cf, void *conf)
 
         shm_zone->data = cf->pool;
         check_peers_ctx = ucmcf->peers;
+        check_peers_ctx->cycle = (ngx_cycle_t *) ngx_cycle;
 
         shm_zone->init = ngx_http_upstream_check_init_shm_zone;
 


### PR DESCRIPTION
**# ## 1. let the upstream check module merge http main conf**

 If we have many many upstreams in nginx.conf, it is too fussy to add healthy checks for every of them,

I add main conf merge operations to allow users to define healthy checks params just in http main conf, and merge them when upstreams do not have those params.

**## 2. add multi http block support for upstream check module**

"http {}" can be used multiple times in a single nginx.conf, and upstream check module will not take effect because "check_peers_ctx" will always be reset by the second http block resulting missing timers for those upstreams in the first blcok, I add multi http block support and only allow people to set "check_shm_size" in the first http block only to reuse shm
# 

Test nginx.conf as follows:

<pre><code>

#user  nobody;
worker_processes  1;

#error_log  logs/error.log;
#error_log  logs/error.log  notice;
#error_log  logs/error.log  info;

#pid        logs/nginx.pid;


events {
    worker_connections  1024;
}

# load modules compiled as Dynamic Shared Object (DSO)
#
#dso {
#    load ngx_http_fastcgi_module.so;
#    load ngx_http_rewrite_module.so;
#}

http {
    include       mime.types;
    default_type  application/octet-stream;

    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
    #                  '$status $body_bytes_sent "$http_referer" '
    #                  '"$http_user_agent" "$http_x_forwarded_for"';

    #access_log  logs/access.log  main;

    sendfile        on;
    #tcp_nopush     on;

    #keepalive_timeout  0;
    keepalive_timeout  65;

    #gzip  on;

    server {
        listen       80;
        server_name  localhost;

        #charset koi8-r;

        #access_log  logs/host.access.log  main;

        location / {
            root   html;
            index  index.html index.htm;
        }

        #error_page  404              /404.html;

        # redirect server error pages to the static page /50x.html
        #
        error_page   500 502 503 504  /50x.html;
        location = /50x.html {
            root   html;
        }

        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
        #
        #location ~ \.php$ {
        #    proxy_pass   http://127.0.0.1;
        #}

        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
        #
        #location ~ \.php$ {
        #    root           html;
        #    fastcgi_pass   127.0.0.1:9000;
        #    fastcgi_index  index.php;
        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
        #    include        fastcgi_params;
        #}

        # deny access to .htaccess files, if Apache's document root
        # concurs with nginx's one
        #
        #location ~ /\.ht {
        #    deny  all;
        #}
    }

    check interval=1000 rise=2 fall=5 timeout=1000 type=http;
    check_http_send "HEAD / HTTP/1.0\r\n\r\n";
    check_http_expect_alive http_2xx http_3xx;
    check_shm_size 10m;

    upstream test_upstream_group_0 {
        server 10.211.55.10:8888;
        check interval=2000 rise=10 fall=10 timeout=10 type=http;
        check_http_send "GET / HTTP/1.0\r\n\r\n";
        check_http_expect_alive http_2xx http_3xx;
    }

    upstream test_upstream_group_1 {
        ip_hash;
        server 10.211.55.10:9999;
        #check interval=30000 rise=2 fall=5 timeout=1000 type=http;
        #check interval=11 rise=11 fall=11 timeout=11 type=http;
        check_http_send "POST / HTTP/1.0\r\n\r\n";
        check_http_expect_alive http_5xx;
    }

    upstream test_upstream_group_2 {
        least_conn;
        server 10.211.55.10:8880;
        #check interval=30000 rise=2 fall=5 timeout=1000 type=http;
        #check interval=12 rise=12 fall=12 timeout=12 type=http;
        #check_http_send "HEAD / HTTP/1.0\r\n\r\n";
        check_http_expect_alive http_4xx;
    }

    upstream test_upstream_group_3 {
        server 10.211.55.10:8890;
        #check interval=30000 rise=2 fall=5 timeout=1000 type=http;
        #check_http_send "HEAD / HTTP/1.0\r\n\r\n";
        #check_http_expect_alive http_2xx http_3xx;
    }

    server {
        listen       8000;
        server_name  localhost;

        #charset koi8-r;

        #access_log  logs/host.access.log  main;

        #location / {
        #    root   html;
        #    index  index.html index.htm;
        #}

        location ^~ /api_0/ {

            proxy_next_upstream     http_500 http_502 http_503 http_504 error timeout invalid_header;
            add_header Cache-Control max-age=0,no-cache;
            add_header Expires 'Thu, 05 Jan 1995 22:00:00 GMT';

            proxy_pass http://test_upstream_group_0;
            proxy_redirect     off;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

        }

        location ^~ /api_1/ {
            proxy_pass http://test_upstream_group_1;
            proxy_set_header Host $http_host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        }

        location /nstatus {
            check_status;
            access_log off;
        }

    }


    # another virtual host using mix of IP-, name-, and port-based configuration
    #
    #server {
    #    listen       8000;
    #    listen       somename:8080;
    #    server_name  somename  alias  another.alias;

    #    location / {
    #        root   html;
    #        index  index.html index.htm;
    #    }
    #}


    # HTTPS server
    #
    #server {
    #    listen       443 ssl;
    #    server_name  localhost;

    #    ssl_certificate      cert.pem;
    #    ssl_certificate_key  cert.key;

    #    ssl_session_cache    shared:SSL:1m;
    #    ssl_session_timeout  5m;

    #    ssl_ciphers  HIGH:!aNULL:!MD5;
    #    ssl_prefer_server_ciphers  on;

    #    location / {
    #        root   html;
    #        index  index.html index.htm;
    #    }
    #}

}

http {
    include       mime.types;
    default_type  application/octet-stream;

    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
    #                  '$status $body_bytes_sent "$http_referer" '
    #                  '"$http_user_agent" "$http_x_forwarded_for"';

    #access_log  logs/access.log  main;

    sendfile        on;
    #tcp_nopush     on;

    #keepalive_timeout  0;
    keepalive_timeout  65;

    #gzip  on;

    check interval=1000 rise=20 fall=50 timeout=10000 type=http;
    check_http_send "HEAD / HTTP/1.0\r\n\r\n";
    check_http_expect_alive http_2xx http_3xx;

    upstream test_upstream_group_0 {
        server 10.211.55.10:8899;
        check interval=2000 rise=100 fall=100 timeout=100 type=http;
        check_http_send "GET / HTTP/1.0\r\n\r\n";
        check_http_expect_alive http_2xx http_3xx;
    }

    upstream test_upstream_group_1 {
        ip_hash;
        server 10.211.55.10:8898;
        #check interval=30000 rise=2 fall=5 timeout=1000 type=http;
        #check interval=11 rise=11 fall=11 timeout=11 type=http;
        check_http_send "POST / HTTP/1.0\r\n\r\n";
        check_http_expect_alive http_5xx;
    }


    server {
        listen       9000;
        server_name  localhost;

        #charset koi8-r;

        #access_log  logs/host.access.log  main;

        location ^~ /api_0/ {

            proxy_next_upstream     http_500 http_502 http_503 http_504 error timeout invalid_header;
            add_header Cache-Control max-age=0,no-cache;
            add_header Expires 'Thu, 05 Jan 1995 22:00:00 GMT';

            proxy_pass http://test_upstream_group_0;
            proxy_redirect     off;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

        }

        location ^~ /api_1/ {
            proxy_pass http://test_upstream_group_1;
            proxy_set_header Host $http_host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        }

        location / {
            root   html;
            index  index.html index.htm;
        }

        #error_page  404              /404.html;

        # redirect server error pages to the static page /50x.html
        #
        error_page   500 502 503 504  /50x.html;
        location = /50x.html {
            root   html;
        }

        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
        #
        #location ~ \.php$ {
        #    proxy_pass   http://127.0.0.1;
        #}

        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
        #
        #location ~ \.php$ {
        #    root           html;
        #    fastcgi_pass   127.0.0.1:9000;
        #    fastcgi_index  index.php;
        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
        #    include        fastcgi_params;
        #}

        # deny access to .htaccess files, if Apache's document root
        # concurs with nginx's one
        #
        #location ~ /\.ht {
        #    deny  all;
        #}
    }


    # another virtual host using mix of IP-, name-, and port-based configuration
    #
    #server {
    #    listen       8000;
    #    listen       somename:8080;
    #    server_name  somename  alias  another.alias;

    #    location / {
    #        root   html;
    #        index  index.html index.htm;
    #    }
    #}


    # HTTPS server
    #
    #server {
    #    listen       443 ssl;
    #    server_name  localhost;

    #    ssl_certificate      cert.pem;
    #    ssl_certificate_key  cert.key;

    #    ssl_session_cache    shared:SSL:1m;
    #    ssl_session_timeout  5m;

    #    ssl_ciphers  HIGH:!aNULL:!MD5;
    #    ssl_prefer_server_ciphers  on;

    #    location / {
    #        root   html;
    #        index  index.html index.htm;
    #    }
    #}

}
</code></pre>

