### PR TITLE
[Bug] should not delete cookie when cookie->len == 0 on session sticky module

### DIFF
--- a/src/http/modules/ngx_http_upstream_session_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_session_sticky_module.c
@@ -534,8 +534,10 @@ finish:
     {
         cookie->len -= (end - st);
 
-        while (end < last) {
-            *st++ = *end++;
+        if (cookie->len > 0) {
+            while (end < last) {
+                *st++ = *end++;
+            }
         }
     }
 

--- a/src/http/modules/ngx_http_upstream_session_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_session_sticky_module.c
@@ -299,7 +299,7 @@ ngx_http_session_sticky_get_cookie(ngx_http_request_t *r)
 {
     time_t                           now;
     u_char                          *p, *v, *vv, *st, *last, *end;
-    ngx_int_t                        diff, delimiter, legal, rc;
+    ngx_int_t                        diff, delimiter, legal;
     ngx_str_t                       *cookie;
     ngx_uint_t                       i;
     ngx_table_elt_t                **cookies;
@@ -533,12 +533,6 @@ finish:
         & (NGX_HTTP_SESSION_STICKY_PREFIX | NGX_HTTP_SESSION_STICKY_INDIRECT))
     {
         cookie->len -= (end - st);
-        if (cookie->len == 0) {
-            rc = ngx_list_delete(&r->headers_in.headers, cookies[i]);
-            if (rc != NGX_OK) {
-                return NGX_ERROR;
-            }
-        }
 
         while (end < last) {
             *st++ = *end++;

--- a/src/http/modules/ngx_http_upstream_session_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_session_sticky_module.c
@@ -534,10 +534,13 @@ finish:
     {
         cookie->len -= (end - st);
 
-        if (cookie->len > 0) {
-            while (end < last) {
-                *st++ = *end++;
-            }
+        if (cookie->len == 0) {
+            cookies[i]->hash = 0;
+            return NGX_OK;
+        }
+
+        while (end < last) {
+            *st++ = *end++;
         }
     }
 


### PR DESCRIPTION
we hit the bug about ngx_http_upstream_session_sticky_module on production.




The reproduce as the following:
````
# tengine config file
upstream foo {
	server 127.0.0.1:10000;
	session_sticky cookie=sessionstickytest option=indirect;
}

server {
	listen 7777;
	location / {
		proxy_pass http://foo;
		proxy_set_header Host $http_host;
		session_sticky_hide_cookie upstream=foo;
	}
}

# create nc server 
nc -l 10000

# construct the http request head as the following
 telnet 192.168.33.10 7777

GET / HTTP/1.1
Cookie: sessionstickytest=7e94b1589fae0d4d4d4cecc18536968e
Host: test.com
User-Agent: Mozilla/5.0 (Linux; Android 6.0.1; MI 5 Build/MXB48T)

# nc show the request header as the following:
GET / HTTP/1.0
Host: Mozilla/5.0 (Linux; Android 6.0.1; MI 5 Build/MXB48T) --- oops, it's not right:(
Connection: close
User-Agent: Mozilla/5.0 (Linux; Android 6.0.1; MI 5 Build/MXB48T)
````


on the [code](https://github.com/alibaba/tengine/blob/master/src/http/modules/ngx_http_upstream_session_sticky_module.c#L530):

```` c
finish:

    if (sscf->flag
        & (NGX_HTTP_SESSION_STICKY_PREFIX | NGX_HTTP_SESSION_STICKY_INDIRECT))
    {
        cookie->len -= (end - st);
        if (cookie->len == 0) {
            rc = ngx_list_delete(&r->headers_in.headers, cookies[i]);
            if (rc != NGX_OK) {
                return NGX_ERROR;
            }
        }

        while (end < last) {
            *st++ = *end++;
        }
    }
````

the function ngx_list_delete will delete the cookie on the `r->headers_in.headers` by the `ngx_list_delete_elt` function, the function copy the list dst address to the source address as the following [code](https://github.com/alibaba/tengine/blob/master/src/core/ngx_list.c#L66):
````
static ngx_int_t
ngx_list_delete_elt(ngx_list_t *list, ngx_list_part_t *cur, ngx_uint_t i)
{
    u_char *s, *d, *last;

    s = (u_char *) cur->elts + i * list->size;
    d = s + list->size;
    last = (u_char *) cur->elts + cur->nelts * list->size;

    while (d < last) {
        *s++ = *d++;
    }

    cur->nelts--;

    return NGX_OK;
}
````

But now the r->headers_in->host (including other header )still point the old address, so the variable $http_host will get the string `Mozilla/5.0 (Linux; Android 6.0.1; MI 5 Build/MXB48T)`

with this picture can help you understand 
![session_sticky](https://cloud.githubusercontent.com/assets/3370345/17456216/a680ce50-5c02-11e6-9b8e-b7713e4ad285.jpg)

According the [rfc2616-sec4](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)
````
       message-header = field-name ":" [ field-value ]
       field-name     = token
       field-value    = *( field-content | LWS )
       field-content  = <the OCTETs making up the field-value
                        and consisting of either *TEXT or combinations
                        of token, separators, and quoted-string>
````

the length of field-content  can be zero, so let the cookie field value be empty rather than delete it when cookie->length == 0

