### PR TITLE
remove duplicated code in ngx_http_named_location()

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2833,14 +2833,6 @@ ngx_http_named_location(ngx_http_request_t *r, ngx_str_t *name)
         return NGX_DONE;
     }
 
-    if (r->uri.len == 0) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                      "empty URI in redirect to named location \"%V\"", name);
-
-        ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
-        return NGX_DONE;
-    }
-
     cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
 
     if (cscf->named_locations) {


### PR DESCRIPTION
The deleted code snippet is identical to lines above it (from 2828 to 2835). May be introduced during merge with upstream nginx.
