### PR TITLE
support force_exit

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -329,6 +329,10 @@ if [ $HTTP_AUTH_REQUEST = YES ]; then
     HTTP_SRCS="$HTTP_SRCS $HTTP_AUTH_REQUEST_SRCS"
 fi
 
+if [ $NGX_FORCE_EXIT = YES ]; then
+    have=NGX_FORCE_EXIT . auto/have
+fi
+
 if [ $HTTP_AUTH_BASIC = YES ]; then
     USE_MD5=YES
     USE_SHA1=YES

--- a/auto/options
+++ b/auto/options
@@ -435,6 +435,8 @@ do
         --with-file-aio)                           NGX_FILE_AIO=YES           ;;
         --with-ipv6)                               NGX_IPV6=YES               ;;
 
+        --with-force-exit)                         NGX_FORCE_EXIT=YES         ;;
+
         --with-syslog)                             NGX_SYSLOG=YES              ;;
         --without-syslog)                          NGX_SYSLOG=NO              ;;
 

--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -139,7 +139,7 @@ static ngx_command_t  ngx_core_commands[] = {
       0,
       NULL },
 
-#if (NGX_HAVE_FORCE_EXIT)
+#if (NGX_FORCE_EXIT)
 
     { ngx_string("force_exit"),
       NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
@@ -1009,7 +1009,7 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
     ccf->user = (ngx_uid_t) NGX_CONF_UNSET_UINT;
     ccf->group = (ngx_gid_t) NGX_CONF_UNSET_UINT;
 
-#if (NGX_HAVE_FORCE_EXIT)
+#if (NGX_FORCE_EXIT)
     ccf->force_exit_time = NGX_CONF_UNSET;
 #endif
 
@@ -1049,7 +1049,7 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
     ngx_conf_init_msec_value(ccf->timer_resolution, 0);
     ngx_conf_init_value(ccf->debug_points, 0);
 
-#if (NGX_HAVE_FORCE_EXIT)
+#if (NGX_FORCE_EXIT)
     ngx_conf_init_value(ccf->force_exit_time, 0);
 #endif
 

--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -139,6 +139,17 @@ static ngx_command_t  ngx_core_commands[] = {
       0,
       NULL },
 
+#if (NGX_HAVE_FORCE_EXIT)
+
+    { ngx_string("force_exit"),
+      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_sec_slot,
+      0,
+      offsetof(ngx_core_conf_t, force_exit_time),
+      NULL },
+
+#endif
+
 #if (NGX_THREADS)
 
     { ngx_string("worker_threads"),
@@ -998,6 +1009,10 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
     ccf->user = (ngx_uid_t) NGX_CONF_UNSET_UINT;
     ccf->group = (ngx_gid_t) NGX_CONF_UNSET_UINT;
 
+#if (NGX_HAVE_FORCE_EXIT)
+    ccf->force_exit_time = NGX_CONF_UNSET;
+#endif
+
 #if (NGX_OLD_THREADS)
     ccf->worker_threads = NGX_CONF_UNSET;
     ccf->thread_stack_size = NGX_CONF_UNSET_SIZE;
@@ -1033,6 +1048,10 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
     ngx_conf_init_value(ccf->master, 1);
     ngx_conf_init_msec_value(ccf->timer_resolution, 0);
     ngx_conf_init_value(ccf->debug_points, 0);
+
+#if (NGX_HAVE_FORCE_EXIT)
+    ngx_conf_init_value(ccf->force_exit_time, 0);
+#endif
 
 #if (NGX_HAVE_CPU_AFFINITY)
 

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -105,6 +105,10 @@ typedef struct {
      ngx_array_t              env;
      char                   **environment;
 
+#if (NGX_HAVE_FORCE_EXIT)
+     time_t                   force_exit_time;
+#endif
+
 #if (NGX_OLD_THREADS)
      ngx_int_t                worker_threads;
      size_t                   thread_stack_size;

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -105,7 +105,7 @@ typedef struct {
      ngx_array_t              env;
      char                   **environment;
 
-#if (NGX_HAVE_FORCE_EXIT)
+#if (NGX_FORCE_EXIT)
      time_t                   force_exit_time;
 #endif
 

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -758,6 +758,18 @@ ngx_master_process_exit(ngx_cycle_t *cycle)
 }
 
 
+#if (NGX_HAVE_FORCE_EXIT)
+static void
+ngx_force_exit_timer_handler(ngx_event_t *ev)
+{
+    ngx_exiting = 0;
+    if (ev && ev->data) {
+        ngx_worker_process_exit(ev->data);
+    }
+}
+#endif
+
+
 static void
 ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
 {
@@ -765,6 +777,11 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
 
     ngx_uint_t         i;
     ngx_connection_t  *c;
+
+#if (NGX_HAVE_FORCE_EXIT)
+    ngx_event_t        ev;
+    ngx_core_conf_t    *ccf;
+#endif
 
     ngx_process = NGX_PROCESS_WORKER;
     ngx_worker = worker;
@@ -818,6 +835,15 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
             if (!ngx_exiting) {
                 ngx_close_listening_sockets(cycle);
                 ngx_exiting = 1;
+
+#if (NGX_HAVE_FORCE_EXIT)
+                ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx, ngx_core_module);
+                ngx_memzero(&ev, sizeof(ngx_event_t));
+                ev.handler = ngx_force_exit_timer_handler;
+                ev.log = cycle->log;
+                ev.data = cycle;
+                ngx_add_timer(&ev, ccf->force_exit_time);
+#endif
             }
         }
 

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -758,7 +758,7 @@ ngx_master_process_exit(ngx_cycle_t *cycle)
 }
 
 
-#if (NGX_HAVE_FORCE_EXIT)
+#if (NGX_FORCE_EXIT)
 static void
 ngx_force_exit_timer_handler(ngx_event_t *ev)
 {
@@ -778,7 +778,7 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
     ngx_uint_t         i;
     ngx_connection_t  *c;
 
-#if (NGX_HAVE_FORCE_EXIT)
+#if (NGX_FORCE_EXIT)
     ngx_event_t        ev;
     ngx_core_conf_t    *ccf;
 #endif
@@ -836,7 +836,7 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
                 ngx_close_listening_sockets(cycle);
                 ngx_exiting = 1;
 
-#if (NGX_HAVE_FORCE_EXIT)
+#if (NGX_FORCE_EXIT)
                 ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx, ngx_core_module);
                 ngx_memzero(&ev, sizeof(ngx_event_t));
                 ev.handler = ngx_force_exit_timer_handler;


### PR DESCRIPTION
Syntax:	**force_exit** _exit_time;_
Default:	—
Context:	main

force a worker to exit after _exit_time_