### PR TITLE
support force_exit

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -727,6 +727,10 @@ if [ $HTTP_UPSTREAM_RBTREE = YES ]; then
     NGX_DSO_ABI_COMPATIBILITY=$(($NGX_DSO_ABI_COMPATIBILITY|$NGX_DSO_UPSTREAM_RBTREE_TAG))
 fi
 
+if [ $NGX_FORCE_EXIT = YES ]; then
+    have=NGX_FORCE_EXIT . auto/have
+fi
+
 #if [ -r $NGX_OBJS/auto ]; then
 #    . $NGX_OBJS/auto
 #fi

--- a/auto/options
+++ b/auto/options
@@ -435,6 +435,8 @@ do
         --with-file-aio)                           NGX_FILE_AIO=YES           ;;
         --with-ipv6)                               NGX_IPV6=YES               ;;
 
+        --with-force-exit)                         NGX_FORCE_EXIT=YES         ;;
+
         --with-syslog)                             NGX_SYSLOG=YES              ;;
         --without-syslog)                          NGX_SYSLOG=NO              ;;
 

--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -139,6 +139,17 @@ static ngx_command_t  ngx_core_commands[] = {
       0,
       NULL },
 
+#if (NGX_FORCE_EXIT)
+
+    { ngx_string("force_exit"),
+      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      0,
+      offsetof(ngx_core_conf_t, force_exit_time),
+      NULL },
+
+#endif
+
 #if (NGX_THREADS)
 
     { ngx_string("worker_threads"),
@@ -998,6 +1009,10 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
     ccf->user = (ngx_uid_t) NGX_CONF_UNSET_UINT;
     ccf->group = (ngx_gid_t) NGX_CONF_UNSET_UINT;
 
+#if (NGX_FORCE_EXIT)
+    ccf->force_exit_time = NGX_CONF_UNSET;
+#endif
+
 #if (NGX_OLD_THREADS)
     ccf->worker_threads = NGX_CONF_UNSET;
     ccf->thread_stack_size = NGX_CONF_UNSET_SIZE;
@@ -1033,6 +1048,10 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
     ngx_conf_init_value(ccf->master, 1);
     ngx_conf_init_msec_value(ccf->timer_resolution, 0);
     ngx_conf_init_value(ccf->debug_points, 0);
+
+#if (NGX_FORCE_EXIT)
+    ngx_conf_init_value(ccf->force_exit_time, 0);
+#endif
 
 #if (NGX_HAVE_CPU_AFFINITY)
 

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -105,6 +105,10 @@ typedef struct {
      ngx_array_t              env;
      char                   **environment;
 
+#if (NGX_FORCE_EXIT)
+     time_t                   force_exit_time;
+#endif
+
 #if (NGX_OLD_THREADS)
      ngx_int_t                worker_threads;
      size_t                   thread_stack_size;

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -71,7 +71,6 @@ static ngx_cycle_t        ngx_exit_cycle;
 static ngx_log_t          ngx_exit_log;
 static ngx_open_file_t    ngx_exit_log_file;
 
-
 void
 ngx_master_process_cycle(ngx_cycle_t *cycle)
 {

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -71,6 +71,15 @@ static ngx_cycle_t        ngx_exit_cycle;
 static ngx_log_t          ngx_exit_log;
 static ngx_open_file_t    ngx_exit_log_file;
 
+
+#if (NGX_FORCE_EXIT)
+typedef struct {
+    time_t         tm;
+    ngx_cycle_t   *cycle;
+} ngx_force_exit_timer_ctx;
+#endif
+
+
 void
 ngx_master_process_cycle(ngx_cycle_t *cycle)
 {
@@ -758,6 +767,46 @@ ngx_master_process_exit(ngx_cycle_t *cycle)
 }
 
 
+#if (NGX_FORCE_EXIT)
+static void
+ngx_force_exit_timer_handler(ngx_event_t *ev)
+{
+    ngx_force_exit_timer_ctx  *ctx;
+
+    if (ev && ev->data) {
+        ctx = (ngx_force_exit_timer_ctx *) ev->data;
+        ctx->tm -= 1000;
+
+        if (ngx_event_timer_rbtree.root == ngx_event_timer_rbtree.sentinel
+            || ctx->tm <= 0)
+        {
+            ngx_worker_process_exit(ctx->cycle);
+            return;
+        }
+
+        ngx_add_timer(ev, 1000);
+    }
+}
+
+
+static void
+ngx_add_force_exit_timer(ngx_event_t *ev, ngx_force_exit_timer_ctx *ctx,
+    time_t t, ngx_cycle_t *cycle)
+{
+    ctx->tm = t;
+    ctx->cycle = cycle;
+
+    ngx_memzero(ev, sizeof(ngx_event_t));
+
+    ev->handler = ngx_force_exit_timer_handler;
+    ev->log = cycle->log;
+    ev->data = ctx;
+
+    ngx_add_timer(ev, 1000);
+}
+#endif
+
+
 static void
 ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
 {
@@ -765,6 +814,12 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
 
     ngx_uint_t         i;
     ngx_connection_t  *c;
+
+#if (NGX_FORCE_EXIT)
+    ngx_event_t                ev;
+    ngx_core_conf_t           *ccf;
+    ngx_force_exit_timer_ctx   force_exit_timer_ctx;
+#endif
 
     ngx_process = NGX_PROCESS_WORKER;
     ngx_worker = worker;
@@ -818,6 +873,13 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
             if (!ngx_exiting) {
                 ngx_close_listening_sockets(cycle);
                 ngx_exiting = 1;
+
+                ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                                       ngx_core_module);
+                if (ccf->force_exit_time != 0) {
+                    ngx_add_force_exit_timer(&ev, &force_exit_timer_ctx,
+                                             ccf->force_exit_time, cycle);
+                }
             }
         }
 

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -874,12 +874,15 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
                 ngx_close_listening_sockets(cycle);
                 ngx_exiting = 1;
 
+#if (NGX_FORCE_EXIT)
                 ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx,
                                                        ngx_core_module);
                 if (ccf->force_exit_time != 0) {
                     ngx_add_force_exit_timer(&ev, &force_exit_timer_ctx,
                                              ccf->force_exit_time, cycle);
                 }
+#endif
+
             }
         }
 


### PR DESCRIPTION
Syntax:	**force_exit** _exit_time;_
Default:	—
Context:	main

force worker processes to exit after _exit_time_

---

Syntax:	**force_exit** _exit_time;_
Default:	—
Context:	main

强制worker进程在接受到QUIT信号后 _exit_time_ 时间退出