### PR TITLE
reqstatus: fixed segmentation fault of req_status_show_field directive

### DIFF
--- a/src/http/modules/ngx_http_reqstat_module.c
+++ b/src/http/modules/ngx_http_reqstat_module.c
@@ -341,7 +341,6 @@ ngx_http_reqstat_show_field(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     value = cf->args->elts;
-    user = rmcf->user_defined_str->elts;
     for (i = 1; i < cf->args->nelts; i++) {
         valid = 0;
 
@@ -349,17 +348,22 @@ ngx_http_reqstat_show_field(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             value[i].data++;
             value[i].len--;
 
-            for (j = 0; j < rmcf->user_defined_str->nelts; j++) {
-                if (value[i].len != user[j].len
-                    || ngx_strncmp(value[i].data, user[j].data, value[i].len)
-                        != 0)
-                {
-                    continue;
-                }
+            if (rmcf->user_defined_str) {
 
-                *index++ = NGX_HTTP_REQSTAT_RSRV + j;
-                valid = 1;
-                break;
+                user = rmcf->user_defined_str->elts;
+
+                for (j = 0; j < rmcf->user_defined_str->nelts; j++) {
+                    if (value[i].len != user[j].len
+                            || ngx_strncmp(value[i].data, user[j].data, value[i].len)
+                            != 0)
+                    {
+                        continue;
+                    }
+
+                    *index++ = NGX_HTTP_REQSTAT_RSRV + j;
+                    valid = 1;
+                    break;
+                }
             }
 
         } else {


### PR DESCRIPTION
If req_status_show_field is enabled and req_status_zone_add_indicator is
diabled, rmcf->user_defined_str will be NULL, then referring its "elts"
field causes segmentation fault.

The following configure will cause segfault with command `sbin/nginx -t`:

```
req_status_zone server_status "$host" 50M;
req_status server_status;
server {
    listen 8882;
    location = /us {
        req_status_show;
        req_status_show_field bytes_in bytes_out;
    }
}
```