### PR TITLE
Port HTTP/2 updates from nginx v1.9.8~1.11.6

### DIFF
--- a/auto/cc/conf
+++ b/auto/cc/conf
@@ -219,6 +219,16 @@ if [ "$NGX_PLATFORM" != win32 ]; then
                           return 1;"
     . auto/feature
 
+    ngx_feature="gcc builtin 64 bit byteswap"
+    ngx_feature_name="NGX_HAVE_GCC_BSWAP64"
+    ngx_feature_run=no
+    ngx_feature_incs=
+    ngx_feature_path=
+    ngx_feature_libs=
+    ngx_feature_test="__builtin_bswap64(0)"
+    . auto/feature
+
+
 #    ngx_feature="inline"
 #    ngx_feature_name=
 #    ngx_feature_run=no

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -19,10 +19,7 @@ typedef struct ngx_http_cache_s       ngx_http_cache_t;
 typedef struct ngx_http_file_cache_s  ngx_http_file_cache_t;
 typedef struct ngx_http_log_ctx_s     ngx_http_log_ctx_t;
 typedef struct ngx_http_chunked_s     ngx_http_chunked_t;
-
-#if (NGX_HTTP_V2)
 typedef struct ngx_http_v2_stream_s   ngx_http_v2_stream_t;
-#endif
 
 typedef ngx_int_t (*ngx_http_header_handler_pt)(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -83,9 +83,7 @@ typedef struct {
 #if (NGX_HTTP_SSL)
     unsigned                   ssl:1;
 #endif
-#if (NGX_HTTP_V2)
     unsigned                   http2:1;
-#endif
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
     unsigned                   ipv6only:1;
 #endif
@@ -253,10 +251,7 @@ struct ngx_http_addr_conf_s {
 #if (NGX_HTTP_SSL)
     unsigned                   ssl:1;
 #endif
-
-#if (NGX_HTTP_V2)
     unsigned                   http2:1;
-#endif
     unsigned                   proxy_protocol:1;
 };
 

--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -95,17 +95,17 @@ static ngx_str_t ngx_http_status_lines[] = {
     ngx_string("414 Request-URI Too Large"),
     ngx_string("415 Unsupported Media Type"),
     ngx_string("416 Requested Range Not Satisfiable"),
+    ngx_null_string,  /* "417 Expectation Failed" */
+    ngx_null_string,  /* "418 unused" */
+    ngx_null_string,  /* "419 unused" */
+    ngx_null_string,  /* "420 unused" */
+    ngx_string("421 Misdirected Request"),
 
-    /* ngx_null_string, */  /* "417 Expectation Failed" */
-    /* ngx_null_string, */  /* "418 unused" */
-    /* ngx_null_string, */  /* "419 unused" */
-    /* ngx_null_string, */  /* "420 unused" */
-    /* ngx_null_string, */  /* "421 unused" */
     /* ngx_null_string, */  /* "422 Unprocessable Entity" */
     /* ngx_null_string, */  /* "423 Locked" */
     /* ngx_null_string, */  /* "424 Failed Dependency" */
 
-#define NGX_HTTP_LAST_4XX  417
+#define NGX_HTTP_LAST_4XX  422
 #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
 
     ngx_string("500 Internal Server Error"),
@@ -113,10 +113,10 @@ static ngx_str_t ngx_http_status_lines[] = {
     ngx_string("502 Bad Gateway"),
     ngx_string("503 Service Temporarily Unavailable"),
     ngx_string("504 Gateway Time-out"),
-
     ngx_null_string,        /* "505 HTTP Version Not Supported" */
     ngx_null_string,        /* "506 Variant Also Negotiates" */
     ngx_string("507 Insufficient Storage"),
+
     /* ngx_null_string, */  /* "508 unused" */
     /* ngx_null_string, */  /* "509 unused" */
     /* ngx_null_string, */  /* "510 Not Extended" */

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2085,7 +2085,7 @@ ngx_http_set_virtual_server(ngx_http_request_t *r, ngx_str_t *host)
             ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                           "client attempted to request the server name "
                           "different from that one was negotiated");
-            ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            ngx_http_finalize_request(r, NGX_HTTP_MISDIRECTED_REQUEST);
             return NGX_ERROR;
         }
     }
@@ -2594,12 +2594,6 @@ ngx_http_set_write_handler(ngx_http_request_t *r)
                                 ngx_http_test_reading;
     r->write_event_handler = ngx_http_writer;
 
-#if (NGX_HTTP_V2)
-    if (r->stream) {
-        return NGX_OK;
-    }
-#endif
-
     wev = r->connection->write;
 
     if (wev->ready && wev->delayed) {
@@ -2684,12 +2678,6 @@ ngx_http_writer(ngx_http_request_t *r)
     }
 
     if (r->buffered || r->postponed || (r == r->main && c->buffered)) {
-
-#if (NGX_HTTP_V2)
-        if (r->stream) {
-            return;
-        }
-#endif
 
         if (!wev->delayed) {
             ngx_add_timer(wev, clcf->send_timeout);

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -95,6 +95,7 @@
 #define NGX_HTTP_REQUEST_URI_TOO_LARGE     414
 #define NGX_HTTP_UNSUPPORTED_MEDIA_TYPE    415
 #define NGX_HTTP_RANGE_NOT_SATISFIABLE     416
+#define NGX_HTTP_MISDIRECTED_REQUEST       421
 
 
 /* Our own HTTP codes */
@@ -283,6 +284,7 @@ typedef struct {
     ngx_chain_t                      *bufs;
     ngx_buf_t                        *buf;
     off_t                             rest;
+    off_t                             received;
     ngx_chain_t                      *free;
     ngx_chain_t                      *busy;
     ngx_http_chunked_t               *chunked;
@@ -436,9 +438,7 @@ struct ngx_http_request_s {
     ngx_uint_t                        us_tries;
 
     ngx_http_connection_t            *http_connection;
-#if (NGX_HTTP_V2)
     ngx_http_v2_stream_t             *stream;
-#endif
 
     ngx_http_log_handler_pt           log_handler;
 

--- a/src/http/ngx_http_special_response.c
+++ b/src/http/ngx_http_special_response.c
@@ -293,6 +293,14 @@ static char ngx_http_error_416_page[] =
 ;
 
 
+static char ngx_http_error_421_page[] =
+"<html>" CRLF
+"<head><title>421 Misdirected Request</title></head>" CRLF
+"<body bgcolor=\"white\">" CRLF
+"<center><h1>421 Misdirected Request</h1></center>" CRLF
+;
+
+
 static char ngx_http_error_494_page[] =
 "<html>" CRLF
 "<head><title>400 Request Header Or Cookie Too Large</title></head>"
@@ -425,8 +433,13 @@ static ngx_str_t ngx_http_error_pages[] = {
     ngx_string(ngx_http_error_414_page),
     ngx_string(ngx_http_error_415_page),
     ngx_string(ngx_http_error_416_page),
+    ngx_null_string,                     /* 417 */
+    ngx_null_string,                     /* 418 */
+    ngx_null_string,                     /* 419 */
+    ngx_null_string,                     /* 420 */
+    ngx_string(ngx_http_error_421_page),
 
-#define NGX_HTTP_LAST_4XX  417
+#define NGX_HTTP_LAST_4XX  422
 #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
 
     ngx_string(ngx_http_error_494_page), /* 494, request header too large */

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -48,9 +48,6 @@
 
 #define NGX_HTTP_V2_DEFAULT_FRAME_SIZE           (1 << 14)
 
-#define NGX_HTTP_V2_MAX_WINDOW                   ((1U << 31) - 1)
-#define NGX_HTTP_V2_DEFAULT_WINDOW               65535
-
 #define NGX_HTTP_V2_ROOT                         (void *) -1
 
 
@@ -112,9 +109,9 @@ static u_char *ngx_http_v2_state_skip_padded(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_skip(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
-static u_char *ngx_http_v2_state_skip_headers(ngx_http_v2_connection_t *h2c,
-    u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_save(ngx_http_v2_connection_t *h2c,
+    u_char *pos, u_char *end, ngx_http_v2_handler_pt handler);
+static u_char *ngx_http_v2_state_headers_save(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end, ngx_http_v2_handler_pt handler);
 static u_char *ngx_http_v2_connection_error(ngx_http_v2_connection_t *h2c,
     ngx_uint_t err);
@@ -139,6 +136,8 @@ static ngx_int_t ngx_http_v2_send_window_update(ngx_http_v2_connection_t *h2c,
     ngx_uint_t sid, size_t window);
 static ngx_int_t ngx_http_v2_send_rst_stream(ngx_http_v2_connection_t *h2c,
     ngx_uint_t sid, ngx_uint_t status);
+static ngx_int_t ngx_http_v2_send_goaway(ngx_http_v2_connection_t *h2c,
+    ngx_uint_t status);
 
 static ngx_http_v2_out_frame_t *ngx_http_v2_get_frame(
     ngx_http_v2_connection_t *h2c, size_t length, ngx_uint_t type,
@@ -163,7 +162,10 @@ static ngx_int_t ngx_http_v2_cookie(ngx_http_request_t *r,
     ngx_http_v2_header_t *header);
 static ngx_int_t ngx_http_v2_construct_cookie_header(ngx_http_request_t *r);
 static void ngx_http_v2_run_request(ngx_http_request_t *r);
-static ngx_int_t ngx_http_v2_init_request_body(ngx_http_request_t *r);
+static ngx_int_t ngx_http_v2_process_request_body(ngx_http_request_t *r,
+    u_char *pos, size_t size, ngx_uint_t last);
+static ngx_int_t ngx_http_v2_filter_request_body(ngx_http_request_t *r);
+static void ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r);
 
 static ngx_int_t ngx_http_v2_terminate_stream(ngx_http_v2_connection_t *h2c,
     ngx_http_v2_stream_t *stream, ngx_uint_t status);
@@ -251,7 +253,7 @@ ngx_http_v2_init(ngx_event_t *rev)
         return;
     }
 
-    cln = ngx_pool_cleanup_add(c->pool, sizeof(ngx_pool_cleanup_file_t));
+    cln = ngx_pool_cleanup_add(c->pool, 0);
     if (cln == NULL) {
         ngx_http_close_connection(c);
         return;
@@ -293,6 +295,8 @@ ngx_http_v2_init(ngx_event_t *rev)
     rev->handler = ngx_http_v2_read_handler;
     c->write->handler = ngx_http_v2_write_handler;
 
+    c->idle = 1;
+
     ngx_http_v2_read_handler(rev);
 }
 
@@ -319,6 +323,30 @@ ngx_http_v2_read_handler(ngx_event_t *rev)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http2 read handler");
 
     h2c->blocked = 1;
+
+    if (c->close) {
+        c->close = 0;
+
+        if (!h2c->goaway) {
+            h2c->goaway = 1;
+
+            if (ngx_http_v2_send_goaway(h2c, NGX_HTTP_V2_NO_ERROR)
+                == NGX_ERROR)
+            {
+                ngx_http_v2_finalize_connection(h2c, 0);
+                return;
+            }
+
+            if (ngx_http_v2_send_output_queue(h2c) == NGX_ERROR) {
+                ngx_http_v2_finalize_connection(h2c, 0);
+                return;
+            }
+        }
+
+        h2c->blocked = 0;
+
+        return;
+    }
 
     h2mcf = ngx_http_get_module_main_conf(h2c->http_connection->conf_ctx,
                                           ngx_http_v2_module);
@@ -410,6 +438,16 @@ ngx_http_v2_write_handler(ngx_event_t *wev)
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http2 write handler");
 
+    if (h2c->last_out == NULL && !c->buffered) {
+
+        if (wev->timer_set) {
+            ngx_del_timer(wev);
+        }
+
+        ngx_http_v2_handle_connection(h2c);
+        return;
+    }
+
     h2c->blocked = 1;
 
     rc = ngx_http_v2_send_output_queue(h2c);
@@ -432,6 +470,10 @@ ngx_http_v2_write_handler(ngx_event_t *wev)
                        "run http2 stream %ui", stream->node->id);
 
         wev = stream->request->connection->write;
+
+        wev->active = 0;
+        wev->ready = 1;
+
         wev->handler(wev);
     }
 
@@ -464,7 +506,7 @@ ngx_http_v2_send_output_queue(ngx_http_v2_connection_t *h2c)
     wev = c->write;
 
     if (!wev->ready) {
-        return NGX_OK;
+        return NGX_AGAIN;
     }
 
     cl = NULL;
@@ -535,15 +577,6 @@ ngx_http_v2_send_output_queue(ngx_http_v2_connection_t *h2c)
         c->tcp_nodelay = NGX_TCP_NODELAY_SET;
     }
 
-    if (cl) {
-        ngx_add_timer(wev, clcf->send_timeout);
-
-    } else {
-        if (wev->timer_set) {
-            ngx_del_timer(wev);
-        }
-    }
-
     for ( /* void */ ; out; out = fn) {
         fn = out->next;
 
@@ -568,6 +601,15 @@ ngx_http_v2_send_output_queue(ngx_http_v2_connection_t *h2c)
 
     h2c->last_out = frame;
 
+    if (!wev->ready) {
+        ngx_add_timer(wev, clcf->send_timeout);
+        return NGX_AGAIN;
+    }
+
+    if (wev->timer_set) {
+        ngx_del_timer(wev);
+    }
+
     return NGX_OK;
 
 error:
@@ -585,7 +627,8 @@ error:
 static void
 ngx_http_v2_handle_connection(ngx_http_v2_connection_t *h2c)
 {
-    ngx_connection_t          *c;
+    ngx_int_t                rc;
+    ngx_connection_t        *c;
     ngx_http_v2_srv_conf_t  *h2scf;
 
     if (h2c->last_out || h2c->processing) {
@@ -600,6 +643,26 @@ ngx_http_v2_handle_connection(ngx_http_v2_connection_t *h2c)
     }
 
     if (c->buffered) {
+        h2c->blocked = 1;
+
+        rc = ngx_http_v2_send_output_queue(h2c);
+
+        h2c->blocked = 0;
+
+        if (rc == NGX_ERROR) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        if (rc == NGX_AGAIN) {
+            return;
+        }
+
+        /* rc == NGX_OK */
+    }
+
+    if (h2c->goaway) {
+        ngx_http_close_connection(c);
         return;
     }
 
@@ -607,11 +670,6 @@ ngx_http_v2_handle_connection(ngx_http_v2_connection_t *h2c)
                                          ngx_http_v2_module);
     if (h2c->state.incomplete) {
         ngx_add_timer(c->read, h2scf->recv_timeout);
-        return;
-    }
-
-    if (ngx_terminate || ngx_exiting) {
-        ngx_http_close_connection(c);
         return;
     }
 
@@ -628,7 +686,6 @@ ngx_http_v2_handle_connection(ngx_http_v2_connection_t *h2c)
 #endif
 
     c->destroyed = 1;
-    c->idle = 1;
     ngx_reusable_connection(c, 1);
 
     c->write->handler = ngx_http_empty_handler;
@@ -757,8 +814,7 @@ ngx_http_v2_state_data(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end)
         if (h2c->state.length == 0) {
             ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                           "client sent padded DATA frame "
-                          "with incorrect length: %uz",
-                          h2c->state.length);
+                          "with incorrect length: 0");
 
             return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
         }
@@ -840,8 +896,9 @@ ngx_http_v2_state_data(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end)
 
     stream->recv_window -= h2c->state.length;
 
-    if (stream->recv_window < NGX_HTTP_V2_MAX_WINDOW / 4) {
-
+    if (stream->no_flow_control
+        && stream->recv_window < NGX_HTTP_V2_MAX_WINDOW / 4)
+    {
         if (ngx_http_v2_send_window_update(h2c, node->id,
                                            NGX_HTTP_V2_MAX_WINDOW
                                            - stream->recv_window)
@@ -880,15 +937,12 @@ static u_char *
 ngx_http_v2_state_read_data(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
-    size_t                     size;
-    ssize_t                    n;
-    ngx_buf_t                 *buf;
-    ngx_int_t                  rc;
-    ngx_temp_file_t           *tf;
-    ngx_http_request_t        *r;
-    ngx_http_v2_stream_t      *stream;
-    ngx_http_request_body_t   *rb;
-    ngx_http_core_loc_conf_t  *clcf;
+    size_t                   size;
+    ngx_buf_t               *buf;
+    ngx_int_t                rc;
+    ngx_http_request_t      *r;
+    ngx_http_v2_stream_t    *stream;
+    ngx_http_v2_srv_conf_t  *h2scf;
 
     stream = h2c->state.stream;
 
@@ -897,127 +951,60 @@ ngx_http_v2_state_read_data(ngx_http_v2_connection_t *h2c, u_char *pos,
     }
 
     if (stream->skip_data) {
-        stream->in_closed = h2c->state.flags & NGX_HTTP_V2_END_STREAM_FLAG;
-
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                       "skipping http2 DATA frame, reason: %d",
-                       stream->skip_data);
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "skipping http2 DATA frame");
 
         return ngx_http_v2_state_skip_padded(h2c, pos, end);
     }
 
     size = end - pos;
 
-    if (size > h2c->state.length) {
+    if (size >= h2c->state.length) {
         size = h2c->state.length;
+        stream->in_closed  = h2c->state.flags & NGX_HTTP_V2_END_STREAM_FLAG;
     }
 
     r = stream->request;
 
-    if (r->request_body == NULL
-        && ngx_http_v2_init_request_body(r) != NGX_OK)
-    {
-        stream->skip_data = NGX_HTTP_V2_DATA_INTERNAL_ERROR;
-        return ngx_http_v2_state_skip_padded(h2c, pos, end);
-    }
+    if (r->request_body) {
+        rc = ngx_http_v2_process_request_body(r, pos, size, stream->in_closed);
 
-    rb = r->request_body;
-    tf = rb->temp_file;
-    buf = rb->buf;
-
-    if (size) {
-        rb->rest += size;
-
-        if (r->headers_in.content_length_n != -1
-            && r->headers_in.content_length_n < rb->rest)
-        {
-            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-                          "client intended to send body data "
-                          "larger than declared");
-
-            stream->skip_data = NGX_HTTP_V2_DATA_ERROR;
-            goto error;
-
-        } else {
-            clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
-
-            if (clcf->client_max_body_size
-                && clcf->client_max_body_size < rb->rest)
-            {
-                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                              "client intended to send "
-                              "too large chunked body: %O bytes", rb->rest);
-
-                stream->skip_data = NGX_HTTP_V2_DATA_ERROR;
-                goto error;
-            }
+        if (rc != NGX_OK) {
+            stream->skip_data = 1;
+            ngx_http_finalize_request(r, rc);
         }
 
-        h2c->state.length -= size;
+    } else if (size) {
+        buf = stream->preread;
 
-        if (tf) {
-            buf->start = pos;
-            buf->pos = pos;
+        if (buf == NULL) {
+            h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
 
-            pos += size;
-
-            buf->end = pos;
-            buf->last = pos;
-
-            n = ngx_write_chain_to_temp_file(tf, rb->bufs);
-
-            /* TODO: n == 0 or not complete and level event */
-
-            if (n == NGX_ERROR) {
-                stream->skip_data = NGX_HTTP_V2_DATA_INTERNAL_ERROR;
-                goto error;
+            buf = ngx_create_temp_buf(r->pool, h2scf->preread_size);
+            if (buf == NULL) {
+                return ngx_http_v2_connection_error(h2c,
+                                                    NGX_HTTP_V2_INTERNAL_ERROR);
             }
 
-            tf->offset += n;
-
-        } else {
-            buf->last = ngx_cpymem(buf->last, pos, size);
-            pos += size;
+            stream->preread = buf;
         }
 
-        r->request_length += size;
+        if (size > (size_t) (buf->end - buf->last)) {
+            ngx_log_error(NGX_LOG_ALERT, h2c->connection->log, 0,
+                          "http2 preread buffer overflow");
+            return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_INTERNAL_ERROR);
+        }
+
+        buf->last = ngx_cpymem(buf->last, pos, size);
     }
+
+    pos += size;
+    h2c->state.length -= size;
 
     if (h2c->state.length) {
         return ngx_http_v2_state_save(h2c, pos, end,
                                       ngx_http_v2_state_read_data);
-    }
-
-    if (h2c->state.flags & NGX_HTTP_V2_END_STREAM_FLAG) {
-        stream->in_closed = 1;
-
-        if (r->headers_in.content_length_n < 0) {
-            r->headers_in.content_length_n = rb->rest;
-
-        } else if (r->headers_in.content_length_n != rb->rest) {
-            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-                          "client prematurely closed stream: "
-                          "only %O out of %O bytes of request body received",
-                          rb->rest, r->headers_in.content_length_n);
-
-            stream->skip_data = NGX_HTTP_V2_DATA_ERROR;
-            goto error;
-        }
-
-        if (tf) {
-            ngx_memzero(buf, sizeof(ngx_buf_t));
-
-            buf->in_file = 1;
-            buf->file_last = tf->file.offset;
-            buf->file = &tf->file;
-
-            rb->buf = NULL;
-        }
-
-        if (rb->post_handler) {
-            r->read_event_handler = ngx_http_block_reading;
-            rb->post_handler(r);
-        }
     }
 
     if (h2c->state.padding) {
@@ -1025,23 +1012,6 @@ ngx_http_v2_state_read_data(ngx_http_v2_connection_t *h2c, u_char *pos,
     }
 
     return ngx_http_v2_state_complete(h2c, pos, end);
-
-error:
-
-    if (rb->post_handler) {
-
-        if (stream->skip_data == NGX_HTTP_V2_DATA_ERROR) {
-            rc = (r->headers_in.content_length_n == -1)
-                 ? NGX_HTTP_REQUEST_ENTITY_TOO_LARGE : NGX_HTTP_BAD_REQUEST;
-
-        } else {
-            rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-        }
-
-        ngx_http_finalize_request(r, rc);
-    }
-
-    return ngx_http_v2_state_skip_padded(h2c, pos, end);
 }
 
 
@@ -1051,6 +1021,7 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 {
     size_t                   size;
     ngx_uint_t               padded, priority, depend, dependency, excl, weight;
+    ngx_uint_t               status;
     ngx_http_v2_node_t      *node;
     ngx_http_v2_stream_t    *stream;
     ngx_http_v2_srv_conf_t  *h2scf;
@@ -1081,6 +1052,12 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
                       "client sent HEADERS frame with empty header block");
 
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+    }
+
+    if (h2c->goaway) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "skipping http2 HEADERS frame");
+        return ngx_http_v2_state_skip(h2c, pos, end);
     }
 
     if ((size_t) (end - pos) < size) {
@@ -1133,20 +1110,18 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     h2c->last_sid = h2c->state.sid;
 
+    h2c->state.pool = ngx_create_pool(1024, h2c->connection->log);
+    if (h2c->state.pool == NULL) {
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
+    }
+
     if (depend == h2c->state.sid) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent HEADERS frame for stream %ui "
                       "with incorrect dependency", h2c->state.sid);
 
-        if (ngx_http_v2_send_rst_stream(h2c, h2c->state.sid,
-                                        NGX_HTTP_V2_PROTOCOL_ERROR)
-            != NGX_OK)
-        {
-            return ngx_http_v2_connection_error(h2c,
-                                                NGX_HTTP_V2_INTERNAL_ERROR);
-        }
-
-        return ngx_http_v2_state_skip_headers(h2c, pos, end);
+        status = NGX_HTTP_V2_PROTOCOL_ERROR;
+        goto rst_stream;
     }
 
     h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
@@ -1158,15 +1133,20 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "concurrent streams exceeded %ui", h2c->processing);
 
-        if (ngx_http_v2_send_rst_stream(h2c, h2c->state.sid,
-                                        NGX_HTTP_V2_REFUSED_STREAM)
-            != NGX_OK)
-        {
-            return ngx_http_v2_connection_error(h2c,
-                                                NGX_HTTP_V2_INTERNAL_ERROR);
-        }
+        status = NGX_HTTP_V2_REFUSED_STREAM;
+        goto rst_stream;
+    }
 
-        return ngx_http_v2_state_skip_headers(h2c, pos, end);
+    if (!h2c->settings_ack
+        && !(h2c->state.flags & NGX_HTTP_V2_END_STREAM_FLAG)
+        && h2scf->preread_size < NGX_HTTP_V2_DEFAULT_WINDOW)
+    {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent stream with data "
+                      "before settings were acknowledged");
+
+        status = NGX_HTTP_V2_REFUSED_STREAM;
+        goto rst_stream;
     }
 
     node = ngx_http_v2_get_node_by_id(h2c, h2c->state.sid, 1);
@@ -1185,17 +1165,38 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
     }
 
+    h2c->state.stream = stream;
+
+    stream->pool = h2c->state.pool;
+    h2c->state.keep_pool = 1;
+
+    stream->request->request_length = h2c->state.length;
+
     stream->in_closed = h2c->state.flags & NGX_HTTP_V2_END_STREAM_FLAG;
     stream->node = node;
 
     node->stream = stream;
 
-    h2c->state.stream = stream;
-    h2c->state.pool = stream->request->pool;
-
     if (priority || node->parent == NULL) {
         node->weight = weight;
         ngx_http_v2_set_dependency(h2c, node, depend, excl);
+    }
+
+    if (h2c->connection->requests >= h2scf->max_requests) {
+        h2c->goaway = 1;
+
+        if (ngx_http_v2_send_goaway(h2c, NGX_HTTP_V2_NO_ERROR) == NGX_ERROR) {
+            return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_INTERNAL_ERROR);
+        }
+    }
+
+    return ngx_http_v2_state_header_block(h2c, pos, end);
+
+rst_stream:
+
+    if (ngx_http_v2_send_rst_stream(h2c, h2c->state.sid, status) != NGX_OK) {
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
     }
 
     return ngx_http_v2_state_header_block(h2c, pos, end);
@@ -1211,8 +1212,8 @@ ngx_http_v2_state_header_block(ngx_http_v2_connection_t *h2c, u_char *pos,
     ngx_uint_t  indexed, size_update, prefix;
 
     if (end - pos < 1) {
-        return ngx_http_v2_state_save(h2c, pos, end,
-                                      ngx_http_v2_state_header_block);
+        return ngx_http_v2_state_headers_save(h2c, pos, end,
+                                              ngx_http_v2_state_header_block);
     }
 
     if (!(h2c->state.flags & NGX_HTTP_V2_END_HEADERS_FLAG)
@@ -1255,8 +1256,8 @@ ngx_http_v2_state_header_block(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     if (value < 0) {
         if (value == NGX_AGAIN) {
-            return ngx_http_v2_state_save(h2c, pos, end,
-                                          ngx_http_v2_state_header_block);
+            return ngx_http_v2_state_headers_save(h2c, pos, end,
+                                               ngx_http_v2_state_header_block);
         }
 
         if (value == NGX_DECLINED) {
@@ -1326,8 +1327,8 @@ ngx_http_v2_state_field_len(ngx_http_v2_connection_t *h2c, u_char *pos,
     }
 
     if (end - pos < 1) {
-        return ngx_http_v2_state_save(h2c, pos, end,
-                                      ngx_http_v2_state_field_len);
+        return ngx_http_v2_state_headers_save(h2c, pos, end,
+                                              ngx_http_v2_state_field_len);
     }
 
     huff = *pos >> 7;
@@ -1335,8 +1336,8 @@ ngx_http_v2_state_field_len(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     if (len < 0) {
         if (len == NGX_AGAIN) {
-            return ngx_http_v2_state_save(h2c, pos, end,
-                                          ngx_http_v2_state_field_len);
+            return ngx_http_v2_state_headers_save(h2c, pos, end,
+                                                  ngx_http_v2_state_field_len);
         }
 
         if (len == NGX_DECLINED) {
@@ -1428,8 +1429,8 @@ ngx_http_v2_state_field_huff(ngx_http_v2_connection_t *h2c, u_char *pos,
     }
 
     if (h2c->state.length) {
-        return ngx_http_v2_state_save(h2c, pos, end,
-                                      ngx_http_v2_state_field_huff);
+        return ngx_http_v2_state_headers_save(h2c, pos, end,
+                                              ngx_http_v2_state_field_huff);
     }
 
     if (h2c->state.flags & NGX_HTTP_V2_END_HEADERS_FLAG) {
@@ -1473,8 +1474,8 @@ ngx_http_v2_state_field_raw(ngx_http_v2_connection_t *h2c, u_char *pos,
     }
 
     if (h2c->state.length) {
-        return ngx_http_v2_state_save(h2c, pos, end,
-                                      ngx_http_v2_state_field_raw);
+        return ngx_http_v2_state_headers_save(h2c, pos, end,
+                                              ngx_http_v2_state_field_raw);
     }
 
     if (h2c->state.flags & NGX_HTTP_V2_END_HEADERS_FLAG) {
@@ -1684,7 +1685,6 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
 error:
 
     h2c->state.stream = NULL;
-    h2c->state.pool = NULL;
 
     return ngx_http_v2_state_header_complete(h2c, pos, end);
 }
@@ -1697,8 +1697,7 @@ ngx_http_v2_state_header_complete(ngx_http_v2_connection_t *h2c, u_char *pos,
     ngx_http_v2_stream_t  *stream;
 
     if (h2c->state.length) {
-        h2c->state.handler = h2c->state.pool ? ngx_http_v2_state_header_block
-                                             : ngx_http_v2_state_skip_headers;
+        h2c->state.handler = ngx_http_v2_state_header_block;
         return pos;
     }
 
@@ -1711,12 +1710,14 @@ ngx_http_v2_state_header_complete(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     if (stream) {
         ngx_http_v2_run_request(stream->request);
+    }
 
-    } else if (h2c->state.pool) {
+    if (!h2c->state.keep_pool) {
         ngx_destroy_pool(h2c->state.pool);
     }
 
     h2c->state.pool = NULL;
+    h2c->state.keep_pool = 0;
 
     if (h2c->state.padding) {
         return ngx_http_v2_state_skip_padded(h2c, pos, end);
@@ -1731,13 +1732,23 @@ ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end, ngx_http_v2_handler_pt handler)
 {
     u_char    *p;
-    size_t     len;
+    size_t     len, skip;
     uint32_t   head;
 
     len = h2c->state.length;
 
+    if (h2c->state.padding && (size_t) (end - pos) > len) {
+        skip = ngx_min(h2c->state.padding, (end - pos) - len);
+
+        h2c->state.padding -= skip;
+
+        p = pos;
+        pos += skip;
+        ngx_memmove(pos, p, len);
+    }
+
     if ((size_t) (end - pos) < len + NGX_HTTP_V2_FRAME_HEADER_SIZE) {
-        return ngx_http_v2_state_save(h2c, pos, end, handler);
+        return ngx_http_v2_state_headers_save(h2c, pos, end, handler);
     }
 
     p = pos + len;
@@ -1751,7 +1762,6 @@ ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
 
-    h2c->state.length += ngx_http_v2_parse_length(head);
     h2c->state.flags |= p[4];
 
     if (h2c->state.sid != ngx_http_v2_parse_sid(&p[5])) {
@@ -1765,6 +1775,14 @@ ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c, u_char *pos,
     pos += NGX_HTTP_V2_FRAME_HEADER_SIZE;
 
     ngx_memcpy(pos, p, len);
+
+    len = ngx_http_v2_parse_length(head);
+
+    h2c->state.length += len;
+
+    if (h2c->state.stream) {
+        h2c->state.stream->request->request_length += len;
+    }
 
     h2c->state.handler = handler;
     return pos;
@@ -1960,7 +1978,7 @@ ngx_http_v2_state_settings(ngx_http_v2_connection_t *h2c, u_char *pos,
             return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
         }
 
-        /* TODO settings acknowledged */
+        h2c->settings_ack = 1;
 
         return ngx_http_v2_state_complete(h2c, pos, end);
     }
@@ -2205,8 +2223,10 @@ ngx_http_v2_state_window_update(ngx_http_v2_connection_t *h2c, u_char *pos,
 
             wev = stream->request->connection->write;
 
-            if (!wev->timer_set) {
-                wev->delayed = 0;
+            wev->active = 0;
+            wev->ready = 1;
+
+            if (!wev->delayed) {
                 wev->handler(wev);
             }
         }
@@ -2238,8 +2258,10 @@ ngx_http_v2_state_window_update(ngx_http_v2_connection_t *h2c, u_char *pos,
 
         wev = stream->request->connection->write;
 
-        if (!wev->timer_set) {
-            wev->delayed = 0;
+        wev->active = 0;
+        wev->ready = 1;
+
+        if (!wev->delayed) {
             wev->handler(wev);
 
             if (h2c->send_window == 0) {
@@ -2318,19 +2340,6 @@ ngx_http_v2_state_skip(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end)
 
 
 static u_char *
-ngx_http_v2_state_skip_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
-    u_char *end)
-{
-    h2c->state.pool = ngx_create_pool(1024, h2c->connection->log);
-    if (h2c->state.pool == NULL) {
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
-    }
-
-    return ngx_http_v2_state_header_block(h2c, pos, end);
-}
-
-
-static u_char *
 ngx_http_v2_state_save(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end,
     ngx_http_v2_handler_pt handler)
 {
@@ -2356,6 +2365,28 @@ ngx_http_v2_state_save(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end,
     h2c->state.incomplete = 1;
 
     return end;
+}
+
+
+static u_char *
+ngx_http_v2_state_headers_save(ngx_http_v2_connection_t *h2c, u_char *pos,
+    u_char *end, ngx_http_v2_handler_pt handler)
+{
+    ngx_event_t               *rev;
+    ngx_http_request_t        *r;
+    ngx_http_core_srv_conf_t  *cscf;
+
+    if (h2c->state.stream) {
+        r = h2c->state.stream->request;
+        rev = r->connection->read;
+
+        if (!rev->timer_set) {
+            cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+            ngx_add_timer(rev, cscf->client_header_timeout);
+        }
+    }
+
+    return ngx_http_v2_state_save(h2c, pos, end, handler);
 }
 
 
@@ -2441,8 +2472,8 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c, ngx_uint_t ack)
     ngx_http_v2_srv_conf_t   *h2scf;
     ngx_http_v2_out_frame_t  *frame;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 send SETTINGS frame");
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 send SETTINGS frame ack:%ui", ack);
 
     frame = ngx_palloc(h2c->pool, sizeof(ngx_http_v2_out_frame_t));
     if (frame == NULL) {
@@ -2493,8 +2524,7 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c, ngx_uint_t ack)
 
         buf->last = ngx_http_v2_write_uint16(buf->last,
                                          NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING);
-        buf->last = ngx_http_v2_write_uint32(buf->last,
-                                             NGX_HTTP_V2_MAX_WINDOW);
+        buf->last = ngx_http_v2_write_uint32(buf->last, h2scf->preread_size);
 
         buf->last = ngx_http_v2_write_uint16(buf->last,
                                            NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING);
@@ -2533,6 +2563,10 @@ ngx_http_v2_send_window_update(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
     ngx_buf_t                *buf;
     ngx_http_v2_out_frame_t  *frame;
 
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 send WINDOW_UPDATE frame sid:%ui, window:%uz",
+                   sid, window);
+
     frame = ngx_http_v2_get_frame(h2c, NGX_HTTP_V2_WINDOW_UPDATE_SIZE,
                                   NGX_HTTP_V2_WINDOW_UPDATE_FRAME,
                                   NGX_HTTP_V2_NO_FLAG, sid);
@@ -2557,6 +2591,10 @@ ngx_http_v2_send_rst_stream(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
     ngx_buf_t                *buf;
     ngx_http_v2_out_frame_t  *frame;
 
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 send RST_STREAM frame sid:%ui, status:%ui",
+                   sid, status);
+
     frame = ngx_http_v2_get_frame(h2c, NGX_HTTP_V2_RST_STREAM_SIZE,
                                   NGX_HTTP_V2_RST_STREAM_FRAME,
                                   NGX_HTTP_V2_NO_FLAG, sid);
@@ -2579,6 +2617,10 @@ ngx_http_v2_send_goaway(ngx_http_v2_connection_t *h2c, ngx_uint_t status)
 {
     ngx_buf_t                *buf;
     ngx_http_v2_out_frame_t  *frame;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 send GOAWAY frame: last sid %ui, error %ui",
+                   h2c->last_sid, status);
 
     frame = ngx_http_v2_get_frame(h2c, NGX_HTTP_V2_GOAWAY_SIZE,
                                   NGX_HTTP_V2_GOAWAY_FRAME,
@@ -2691,6 +2733,7 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
     ngx_http_log_ctx_t        *ctx;
     ngx_http_request_t        *r;
     ngx_http_v2_stream_t      *stream;
+    ngx_http_v2_srv_conf_t    *h2scf;
     ngx_http_core_srv_conf_t  *cscf;
 
     fc = h2c->free_fake_connections;
@@ -2737,6 +2780,7 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
     ngx_memcpy(log, h2c->connection->log, sizeof(ngx_log_t));
 
     log->data = ctx;
+    log->action = "reading client request headers";
 
     ngx_memzero(rev, sizeof(ngx_event_t));
 
@@ -2803,8 +2847,10 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
     stream->request = r;
     stream->connection = h2c;
 
+    h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
+
     stream->send_window = h2c->init_window;
-    stream->recv_window = NGX_HTTP_V2_MAX_WINDOW;
+    stream->recv_window = h2scf->preread_size;
 
     h2c->processing++;
 
@@ -3444,101 +3490,17 @@ ngx_http_v2_run_request(ngx_http_request_t *r)
         ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                       "client prematurely closed stream");
 
-        r->stream->skip_data = NGX_HTTP_V2_DATA_ERROR;
+        r->stream->skip_data = 1;
 
         ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
         return;
     }
 
+    if (r->headers_in.content_length_n == -1 && !r->stream->in_closed) {
+        r->headers_in.chunked = 1;
+    }
+
     ngx_http_process_request(r);
-}
-
-
-static ngx_int_t
-ngx_http_v2_init_request_body(ngx_http_request_t *r)
-{
-    ngx_buf_t                 *buf;
-    ngx_temp_file_t           *tf;
-    ngx_http_request_body_t   *rb;
-    ngx_http_core_loc_conf_t  *clcf;
-
-    rb = ngx_pcalloc(r->pool, sizeof(ngx_http_request_body_t));
-    if (rb == NULL) {
-        return NGX_ERROR;
-    }
-
-    r->request_body = rb;
-
-    if (r->stream->in_closed) {
-        return NGX_OK;
-    }
-
-    rb->rest = r->headers_in.content_length_n;
-
-    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
-
-    if (r->request_body_in_file_only
-        || rb->rest > (off_t) clcf->client_body_buffer_size
-        || rb->rest < 0)
-    {
-        tf = ngx_pcalloc(r->pool, sizeof(ngx_temp_file_t));
-        if (tf == NULL) {
-            return NGX_ERROR;
-        }
-
-        tf->file.fd = NGX_INVALID_FILE;
-        tf->file.log = r->connection->log;
-        tf->path = clcf->client_body_temp_path;
-        tf->pool = r->pool;
-        tf->warn = "a client request body is buffered to a temporary file";
-        tf->log_level = r->request_body_file_log_level;
-        tf->persistent = r->request_body_in_persistent_file;
-        tf->clean = r->request_body_in_clean_file;
-
-        if (r->request_body_file_group_access) {
-            tf->access = 0660;
-        }
-
-        rb->temp_file = tf;
-
-        if (r->stream->in_closed
-            && ngx_create_temp_file(&tf->file, tf->path, tf->pool,
-                                    tf->persistent, tf->clean, tf->access)
-               != NGX_OK)
-        {
-            return NGX_ERROR;
-        }
-
-        buf = ngx_calloc_buf(r->pool);
-        if (buf == NULL) {
-            return NGX_ERROR;
-        }
-
-    } else {
-
-        if (rb->rest == 0) {
-            return NGX_OK;
-        }
-
-        buf = ngx_create_temp_buf(r->pool, (size_t) rb->rest);
-        if (buf == NULL) {
-            return NGX_ERROR;
-        }
-    }
-
-    rb->buf = buf;
-
-    rb->bufs = ngx_alloc_chain_link(r->pool);
-    if (rb->bufs == NULL) {
-        return NGX_ERROR;
-    }
-
-    rb->bufs->buf = buf;
-    rb->bufs->next = NULL;
-
-    rb->rest = 0;
-
-    return NGX_OK;
 }
 
 
@@ -3546,44 +3508,450 @@ ngx_int_t
 ngx_http_v2_read_request_body(ngx_http_request_t *r,
     ngx_http_client_body_handler_pt post_handler)
 {
-    ngx_http_v2_stream_t  *stream;
-
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "http2 read request body");
+    off_t                      len;
+    size_t                     size;
+    ngx_buf_t                 *buf;
+    ngx_int_t                  rc;
+    ngx_http_v2_stream_t      *stream;
+    ngx_http_v2_srv_conf_t    *h2scf;
+    ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
+    ngx_http_v2_connection_t  *h2c;
 
     stream = r->stream;
 
-    switch (stream->skip_data) {
-
-    case NGX_HTTP_V2_DATA_DISCARD:
+    if (stream->skip_data) {
+        r->request_body_no_buffering = 0;
         post_handler(r);
         return NGX_OK;
+    }
 
-    case NGX_HTTP_V2_DATA_ERROR:
-        if (r->headers_in.content_length_n == -1) {
-            return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+    rb = ngx_pcalloc(r->pool, sizeof(ngx_http_request_body_t));
+    if (rb == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /*
+     * set by ngx_pcalloc():
+     *
+     *     rb->bufs = NULL;
+     *     rb->buf = NULL;
+     *     rb->received = 0;
+     *     rb->free = NULL;
+     *     rb->busy = NULL;
+     */
+
+    rb->rest = 1;
+    rb->post_handler = post_handler;
+
+    r->request_body = rb;
+
+    h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    len = r->headers_in.content_length_n;
+
+    if (r->request_body_no_buffering && !stream->in_closed) {
+
+        if (len < 0 || len > (off_t) clcf->client_body_buffer_size) {
+            len = clcf->client_body_buffer_size;
+        }
+
+        /*
+         * We need a room to store data up to the stream's initial window size,
+         * at least until this window will be exhausted.
+         */
+
+        if (len < (off_t) h2scf->preread_size) {
+            len = h2scf->preread_size;
+        }
+
+        if (len > NGX_HTTP_V2_MAX_WINDOW) {
+            len = NGX_HTTP_V2_MAX_WINDOW;
+        }
+
+        rb->buf = ngx_create_temp_buf(r->pool, (size_t) len);
+
+    } else if (len >= 0 && len <= (off_t) clcf->client_body_buffer_size
+               && !r->request_body_in_file_only)
+    {
+        rb->buf = ngx_create_temp_buf(r->pool, (size_t) len);
+
+    } else {
+        rb->buf = ngx_calloc_buf(r->pool);
+
+        if (rb->buf != NULL) {
+            rb->buf->sync = 1;
+        }
+    }
+
+    if (rb->buf == NULL) {
+        stream->skip_data = 1;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    buf = stream->preread;
+
+    if (stream->in_closed) {
+        r->request_body_no_buffering = 0;
+
+        if (buf) {
+            rc = ngx_http_v2_process_request_body(r, buf->pos,
+                                                  buf->last - buf->pos, 1);
+            ngx_pfree(r->pool, buf->start);
+            return rc;
+        }
+
+        return ngx_http_v2_process_request_body(r, NULL, 0, 1);
+    }
+
+    if (buf) {
+        rc = ngx_http_v2_process_request_body(r, buf->pos,
+                                              buf->last - buf->pos, 0);
+
+        ngx_pfree(r->pool, buf->start);
+
+        if (rc != NGX_OK) {
+            stream->skip_data = 1;
+            return rc;
+        }
+    }
+
+    if (r->request_body_no_buffering) {
+        size = (size_t) len - h2scf->preread_size;
+
+    } else {
+        stream->no_flow_control = 1;
+        size = NGX_HTTP_V2_MAX_WINDOW - stream->recv_window;
+    }
+
+    if (size) {
+        if (ngx_http_v2_send_window_update(stream->connection,
+                                           stream->node->id, size)
+            == NGX_ERROR)
+        {
+            stream->skip_data = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        h2c = stream->connection;
+
+        if (!h2c->blocked) {
+            if (ngx_http_v2_send_output_queue(h2c) == NGX_ERROR) {
+                stream->skip_data = 1;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
+        }
+
+        stream->recv_window += size;
+    }
+
+    if (!buf) {
+        ngx_add_timer(r->connection->read, clcf->client_body_timeout);
+    }
+
+    r->read_event_handler = ngx_http_v2_read_client_request_body_handler;
+    r->write_event_handler = ngx_http_request_empty_handler;
+
+    return NGX_AGAIN;
+}
+
+
+static ngx_int_t
+ngx_http_v2_process_request_body(ngx_http_request_t *r, u_char *pos,
+    size_t size, ngx_uint_t last)
+{
+    ngx_buf_t                 *buf;
+    ngx_int_t                  rc;
+    ngx_connection_t          *fc;
+    ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    fc = r->connection;
+    rb = r->request_body;
+    buf = rb->buf;
+
+    if (size) {
+        if (buf->sync) {
+            buf->pos = buf->start = pos;
+            buf->last = buf->end = pos + size;
+
         } else {
+            if (size > (size_t) (buf->end - buf->last)) {
+                ngx_log_error(NGX_LOG_INFO, fc->log, 0,
+                                "client intended to send body data "
+                                "larger than declared");
+
+                return NGX_HTTP_BAD_REQUEST;
+            }
+
+            buf->last = ngx_cpymem(buf->last, pos, size);
+        }
+    }
+
+    if (last) {
+        rb->rest = 0;
+
+        if (fc->read->timer_set) {
+            ngx_del_timer(fc->read);
+        }
+
+        if (r->request_body_no_buffering) {
+            ngx_post_event(fc->read, &ngx_posted_events);
+            return NGX_OK;
+        }
+
+        rc = ngx_http_v2_filter_request_body(r);
+
+        if (rc != NGX_OK) {
+            return rc;
+        }
+
+        if (buf->sync) {
+            /* prevent reusing this buffer in the upstream module */
+            rb->buf = NULL;
+        }
+
+        if (r->headers_in.chunked) {
+            r->headers_in.content_length_n = rb->received;
+        }
+
+        r->read_event_handler = ngx_http_block_reading;
+        rb->post_handler(r);
+
+        return NGX_OK;
+    }
+
+    if (size == 0) {
+        return NGX_OK;
+    }
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+    ngx_add_timer(fc->read, clcf->client_body_timeout);
+
+    if (r->request_body_no_buffering) {
+        ngx_post_event(fc->read, &ngx_posted_events);
+        return NGX_OK;
+    }
+
+    if (buf->sync) {
+        return ngx_http_v2_filter_request_body(r);
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_v2_filter_request_body(ngx_http_request_t *r)
+{
+    ngx_buf_t                 *b, *buf;
+    ngx_int_t                  rc;
+    ngx_chain_t               *cl;
+    ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    rb = r->request_body;
+    buf = rb->buf;
+
+    if (buf->pos == buf->last && rb->rest) {
+        cl = NULL;
+        goto update;
+    }
+
+    cl = ngx_chain_get_free_buf(r->pool, &rb->free);
+    if (cl == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    b = cl->buf;
+
+    ngx_memzero(b, sizeof(ngx_buf_t));
+
+    if (buf->pos != buf->last) {
+        r->request_length += buf->last - buf->pos;
+        rb->received += buf->last - buf->pos;
+
+        if (r->headers_in.content_length_n != -1) {
+            if (rb->received > r->headers_in.content_length_n) {
+                ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                              "client intended to send body data "
+                              "larger than declared");
+
+                return NGX_HTTP_BAD_REQUEST;
+            }
+
+        } else {
+            clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+            if (clcf->client_max_body_size
+                && rb->received > clcf->client_max_body_size)
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "client intended to send too large chunked body: "
+                              "%O bytes", rb->received);
+
+                return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+            }
+        }
+
+        b->temporary = 1;
+        b->pos = buf->pos;
+        b->last = buf->last;
+        b->start = b->pos;
+        b->end = b->last;
+
+        buf->pos = buf->last;
+    }
+
+    if (!rb->rest) {
+        if (r->headers_in.content_length_n != -1
+            && r->headers_in.content_length_n != rb->received)
+        {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client prematurely closed stream: "
+                          "only %O out of %O bytes of request body received",
+                          rb->received, r->headers_in.content_length_n);
+
             return NGX_HTTP_BAD_REQUEST;
         }
 
-    case NGX_HTTP_V2_DATA_INTERNAL_ERROR:
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        b->last_buf = 1;
     }
 
-    if (!r->request_body && ngx_http_v2_init_request_body(r) != NGX_OK) {
-        stream->skip_data = NGX_HTTP_V2_DATA_INTERNAL_ERROR;
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    b->tag = (ngx_buf_tag_t) &ngx_http_v2_filter_request_body;
+    b->flush = r->request_body_no_buffering;
+
+update:
+
+    rc = ngx_http_top_request_body_filter(r, cl);
+
+    ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &cl,
+                            (ngx_buf_tag_t) &ngx_http_v2_filter_request_body);
+
+    return rc;
+}
+
+
+static void
+ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
+{
+    ngx_connection_t  *fc;
+
+    fc = r->connection;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, fc->log, 0,
+                   "http2 read client request body handler");
+
+    if (fc->read->timedout) {
+        ngx_log_error(NGX_LOG_INFO, fc->log, NGX_ETIMEDOUT, "client timed out");
+
+        fc->timedout = 1;
+        r->stream->skip_data = 1;
+
+        ngx_http_finalize_request(r, NGX_HTTP_REQUEST_TIME_OUT);
+        return;
     }
 
-    if (stream->in_closed) {
-        post_handler(r);
+    if (fc->error) {
+        ngx_log_error(NGX_LOG_INFO, fc->log, 0,
+                      "client prematurely closed stream");
+
+        r->stream->skip_data = 1;
+
+        ngx_http_finalize_request(r, NGX_HTTP_CLIENT_CLOSED_REQUEST);
+        return;
+    }
+}
+
+
+ngx_int_t
+ngx_http_v2_read_unbuffered_request_body(ngx_http_request_t *r)
+{
+    size_t                     window;
+    ngx_buf_t                 *buf;
+    ngx_int_t                  rc;
+    ngx_connection_t          *fc;
+    ngx_http_v2_stream_t      *stream;
+    ngx_http_v2_connection_t  *h2c;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    stream = r->stream;
+    fc = r->connection;
+
+    if (fc->read->timedout) {
+        if (stream->recv_window) {
+            stream->skip_data = 1;
+            fc->timedout = 1;
+
+            return NGX_HTTP_REQUEST_TIME_OUT;
+        }
+
+        fc->read->timedout = 0;
+    }
+
+    if (fc->error) {
+        stream->skip_data = 1;
+        return NGX_HTTP_BAD_REQUEST;
+    }
+
+    rc = ngx_http_v2_filter_request_body(r);
+
+    if (rc != NGX_OK) {
+        stream->skip_data = 1;
+        return rc;
+    }
+
+    if (!r->request_body->rest) {
         return NGX_OK;
     }
 
-    r->request_body->post_handler = post_handler;
+    if (r->request_body->busy != NULL) {
+        return NGX_AGAIN;
+    }
 
-    r->read_event_handler = ngx_http_test_reading;
-    r->write_event_handler = ngx_http_request_empty_handler;
+    buf = r->request_body->buf;
+
+    buf->pos = buf->start;
+    buf->last = buf->start;
+
+    window = buf->end - buf->start;
+    h2c = stream->connection;
+
+    if (h2c->state.stream == stream) {
+        window -= h2c->state.length;
+    }
+
+    if (window <= stream->recv_window) {
+        if (window < stream->recv_window) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "http2 negative window update");
+            stream->skip_data = 1;
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        return NGX_AGAIN;
+    }
+
+    if (ngx_http_v2_send_window_update(h2c, stream->node->id,
+                                       window - stream->recv_window)
+        == NGX_ERROR)
+    {
+        stream->skip_data = 1;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (ngx_http_v2_send_output_queue(h2c) == NGX_ERROR) {
+        stream->skip_data = 1;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (stream->recv_window == 0) {
+        clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+        ngx_add_timer(fc->read, clcf->client_body_timeout);
+    }
+
+    stream->recv_window = window;
 
     return NGX_AGAIN;
 }
@@ -3596,13 +3964,18 @@ ngx_http_v2_terminate_stream(ngx_http_v2_connection_t *h2c,
     ngx_event_t       *rev;
     ngx_connection_t  *fc;
 
+    if (stream->rst_sent) {
+        return NGX_OK;
+    }
+
     if (ngx_http_v2_send_rst_stream(h2c, stream->node->id, status)
         == NGX_ERROR)
     {
         return NGX_ERROR;
     }
 
-    stream->out_closed = 1;
+    stream->rst_sent = 1;
+    stream->skip_data = 1;
 
     fc = stream->request->connection;
     fc->error = 1;
@@ -3617,6 +3990,7 @@ ngx_http_v2_terminate_stream(ngx_http_v2_connection_t *h2c,
 void
 ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
 {
+    ngx_pool_t                *pool;
     ngx_event_t               *ev;
     ngx_connection_t          *fc;
     ngx_http_v2_node_t        *node;
@@ -3633,16 +4007,54 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
 
     if (stream->queued) {
         fc->write->handler = ngx_http_v2_close_stream_handler;
+        fc->read->handler = ngx_http_empty_handler;
         return;
     }
 
-    if (!stream->out_closed) {
-        if (ngx_http_v2_send_rst_stream(h2c, node->id,
-                                        NGX_HTTP_V2_INTERNAL_ERROR)
-            != NGX_OK)
-        {
-            h2c->connection->error = 1;
+    if (!stream->rst_sent && !h2c->connection->error) {
+
+        if (!stream->out_closed) {
+            if (ngx_http_v2_send_rst_stream(h2c, node->id,
+                                      fc->timedout ? NGX_HTTP_V2_PROTOCOL_ERROR
+                                                   : NGX_HTTP_V2_INTERNAL_ERROR)
+                != NGX_OK)
+            {
+                h2c->connection->error = 1;
+            }
+
+        } else if (!stream->in_closed) {
+#if 0
+            if (ngx_http_v2_send_rst_stream(h2c, node->id, NGX_HTTP_V2_NO_ERROR)
+                != NGX_OK)
+            {
+                h2c->connection->error = 1;
+            }
+#else
+            /*
+             * At the time of writing at least the latest versions of Chrome
+             * do not properly handle RST_STREAM with NO_ERROR status.
+             *
+             * See: https://bugs.chromium.org/p/chromium/issues/detail?id=603182
+             *
+             * As a workaround, the stream window is maximized before closing
+             * the stream.  This allows a client to send up to 2 GB of data
+             * before getting blocked on flow control.
+             */
+
+            if (stream->recv_window < NGX_HTTP_V2_MAX_WINDOW
+                && ngx_http_v2_send_window_update(h2c, node->id,
+                                                  NGX_HTTP_V2_MAX_WINDOW
+                                                  - stream->recv_window)
+                   != NGX_OK)
+            {
+                h2c->connection->error = 1;
+            }
+#endif
         }
+    }
+
+    if (h2c->state.stream == stream) {
+        h2c->state.stream = NULL;
     }
 
     node->stream = NULL;
@@ -3650,14 +4062,26 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     ngx_queue_insert_tail(&h2c->closed, &node->reuse);
     h2c->closed_nodes++;
 
+    /*
+     * This pool keeps decoded request headers which can be used by log phase
+     * handlers in ngx_http_free_request().
+     *
+     * The pointer is stored into local variable because the stream object
+     * will be destroyed after a call to ngx_http_free_request().
+     */
+    pool = stream->pool;
+
     ngx_http_free_request(stream->request, rc);
 
-    ev = fc->read;
+    if (pool != h2c->state.pool) {
+        ngx_destroy_pool(pool);
 
-    if (ev->active || ev->disabled) {
-        ngx_log_error(NGX_LOG_ALERT, h2c->connection->log, 0,
-                      "fake read event was activated");
+    } else {
+        /* pool will be destroyed when the complete header is parsed */
+        h2c->state.keep_pool = 0;
     }
+
+    ev = fc->read;
 
     if (ev->timer_set) {
         ngx_del_timer(ev);
@@ -3668,11 +4092,6 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     }
 
     ev = fc->write;
-
-    if (ev->active || ev->disabled) {
-        ngx_log_error(NGX_LOG_ALERT, h2c->connection->log, 0,
-                      "fake write event was activated");
-    }
 
     if (ev->timer_set) {
         ngx_del_timer(ev);
@@ -3707,8 +4126,17 @@ ngx_http_v2_close_stream_handler(ngx_event_t *ev)
     fc = ev->data;
     r = fc->data;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, fc->log, 0,
                    "http2 close stream handler");
+
+    if (ev->timedout) {
+        ngx_log_error(NGX_LOG_INFO, fc->log, NGX_ETIMEDOUT, "client timed out");
+
+        fc->timedout = 1;
+
+        ngx_http_v2_close_stream(r->stream, NGX_HTTP_REQUEST_TIME_OUT);
+        return;
+    }
 
     ngx_http_v2_close_stream(r->stream, 0);
 }
@@ -3717,7 +4145,11 @@ ngx_http_v2_close_stream_handler(ngx_event_t *ev)
 static void
 ngx_http_v2_handle_connection_handler(ngx_event_t *rev)
 {
-    ngx_connection_t  *c;
+    ngx_connection_t          *c;
+    ngx_http_v2_connection_t  *h2c;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                   "http2 handle connection handler");
 
     rev->handler = ngx_http_v2_read_handler;
 
@@ -3727,6 +4159,12 @@ ngx_http_v2_handle_connection_handler(ngx_event_t *rev)
     }
 
     c = rev->data;
+    h2c = c->data;
+
+    if (h2c->last_out && ngx_http_v2_send_output_queue(h2c) == NGX_ERROR) {
+        ngx_http_v2_finalize_connection(h2c, 0);
+        return;
+    }
 
     ngx_http_v2_handle_connection(c->data);
 }
@@ -3770,7 +4208,6 @@ ngx_http_v2_idle_handler(ngx_event_t *rev)
 #endif
 
     c->destroyed = 0;
-    c->idle = 0;
     ngx_reusable_connection(c, 0);
 
     h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
@@ -3803,24 +4240,21 @@ ngx_http_v2_finalize_connection(ngx_http_v2_connection_t *h2c,
 
     c = h2c->connection;
 
-    if (h2c->state.stream) {
-        h2c->state.stream->out_closed = 1;
-        h2c->state.pool = NULL;
-        ngx_http_v2_close_stream(h2c->state.stream, NGX_HTTP_BAD_REQUEST);
-    }
-
     h2c->blocked = 1;
 
-    if (!c->error && ngx_http_v2_send_goaway(h2c, status) != NGX_ERROR) {
-        (void) ngx_http_v2_send_output_queue(h2c);
+    if (!c->error && !h2c->goaway) {
+        if (ngx_http_v2_send_goaway(h2c, status) != NGX_ERROR) {
+            (void) ngx_http_v2_send_output_queue(h2c);
+        }
     }
+
+    c->error = 1;
 
     if (!h2c->processing) {
         ngx_http_close_connection(c);
         return;
     }
 
-    c->error = 1;
     c->read->handler = ngx_http_empty_handler;
     c->write->handler = ngx_http_empty_handler;
 
@@ -3849,9 +4283,7 @@ ngx_http_v2_finalize_connection(ngx_http_v2_connection_t *h2c,
 
             if (stream->queued) {
                 stream->queued = 0;
-
                 ev = fc->write;
-                ev->delayed = 0;
 
             } else {
                 ev = fc->read;
@@ -3920,8 +4352,10 @@ ngx_http_v2_adjust_windows(ngx_http_v2_connection_t *h2c, ssize_t delta)
 
                 wev = stream->request->connection->write;
 
-                if (!wev->timer_set) {
-                    wev->delayed = 0;
+                wev->active = 0;
+                wev->ready = 1;
+
+                if (!wev->delayed) {
                     wev->handler(wev);
                 }
             }

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -24,10 +24,6 @@
 #define NGX_HTTP_V2_MAX_FIELD                                                 \
     (127 + (1 << (NGX_HTTP_V2_INT_OCTETS - 1) * 7) - 1)
 
-#define NGX_HTTP_V2_DATA_DISCARD         1
-#define NGX_HTTP_V2_DATA_ERROR           2
-#define NGX_HTTP_V2_DATA_INTERNAL_ERROR  3
-
 #define NGX_HTTP_V2_FRAME_HEADER_SIZE    9
 
 /* frame types */
@@ -49,6 +45,9 @@
 #define NGX_HTTP_V2_END_HEADERS_FLAG     0x04
 #define NGX_HTTP_V2_PADDED_FLAG          0x08
 #define NGX_HTTP_V2_PRIORITY_FLAG        0x20
+
+#define NGX_HTTP_V2_MAX_WINDOW           ((1U << 31) - 1)
+#define NGX_HTTP_V2_DEFAULT_WINDOW       65535
 
 
 typedef struct ngx_http_v2_connection_s   ngx_http_v2_connection_t;
@@ -73,6 +72,7 @@ typedef struct {
     unsigned                         flags:8;
 
     unsigned                         incomplete:1;
+    unsigned                         keep_pool:1;
 
     /* HPACK */
     unsigned                         parse_name:1;
@@ -144,7 +144,9 @@ struct ngx_http_v2_connection_s {
     ngx_uint_t                       last_sid;
 
     unsigned                         closed_nodes:8;
+    unsigned                         settings_ack:1;
     unsigned                         blocked:1;
+    unsigned                         goaway:1;
 };
 
 
@@ -167,7 +169,6 @@ struct ngx_http_v2_stream_s {
     ngx_http_v2_connection_t        *connection;
     ngx_http_v2_node_t              *node;
 
-    ngx_uint_t                       header_buffers;
     ngx_uint_t                       queued;
 
     /*
@@ -176,6 +177,8 @@ struct ngx_http_v2_stream_s {
      */
     ssize_t                          send_window;
     size_t                           recv_window;
+
+    ngx_buf_t                       *preread;
 
     ngx_http_v2_out_frame_t         *free_frames;
     ngx_chain_t                     *free_frame_headers;
@@ -187,12 +190,16 @@ struct ngx_http_v2_stream_s {
 
     size_t                           header_limit;
 
+    ngx_pool_t                      *pool;
+
     unsigned                         handled:1;
     unsigned                         blocked:1;
     unsigned                         exhausted:1;
     unsigned                         in_closed:1;
     unsigned                         out_closed:1;
-    unsigned                         skip_data:2;
+    unsigned                         rst_sent:1;
+    unsigned                         no_flow_control:1;
+    unsigned                         skip_data:1;
 };
 
 
@@ -260,6 +267,7 @@ void ngx_http_v2_request_headers_init(void);
 
 ngx_int_t ngx_http_v2_read_request_body(ngx_http_request_t *r,
     ngx_http_client_body_handler_pt post_handler);
+ngx_int_t ngx_http_v2_read_unbuffered_request_body(ngx_http_request_t *r);
 
 void ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc);
 
@@ -275,6 +283,8 @@ ngx_int_t ngx_http_v2_table_size(ngx_http_v2_connection_t *h2c, size_t size);
 
 ngx_int_t ngx_http_v2_huff_decode(u_char *state, u_char *src, size_t len,
     u_char **dst, ngx_uint_t last, ngx_log_t *log);
+size_t ngx_http_v2_huff_encode(u_char *src, size_t len, u_char *dst,
+    ngx_uint_t lower);
 
 
 #define ngx_http_v2_prefix(bits)  ((1 << (bits)) - 1)
@@ -289,7 +299,7 @@ ngx_int_t ngx_http_v2_huff_decode(u_char *state, u_char *src, size_t len,
 
 #define ngx_http_v2_parse_uint16(p)  ((p)[0] << 8 | (p)[1])
 #define ngx_http_v2_parse_uint32(p)                                           \
-    ((p)[0] << 24 | (p)[1] << 16 | (p)[2] << 8 | (p)[3])
+    ((uint32_t) (p)[0] << 24 | (p)[1] << 16 | (p)[2] << 8 | (p)[3])
 
 #endif
 

--- a/src/http/v2/ngx_http_v2_huff_encode.c
+++ b/src/http/v2/ngx_http_v2_huff_encode.c
@@ -2,9 +2,253 @@
 /*
  * Copyright (C) Nginx, Inc.
  * Copyright (C) Valentin V. Bartenev
+ * Copyright (C) 2015 Vlad Krasnov
  */
 
 
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+
+
+typedef struct {
+    uint32_t  code;
+    uint32_t  len;
+} ngx_http_v2_huff_encode_code_t;
+
+
+static ngx_http_v2_huff_encode_code_t  ngx_http_v2_huff_encode_table[256] =
+{
+    {0x00001ff8, 13}, {0x007fffd8, 23}, {0x0fffffe2, 28}, {0x0fffffe3, 28},
+    {0x0fffffe4, 28}, {0x0fffffe5, 28}, {0x0fffffe6, 28}, {0x0fffffe7, 28},
+    {0x0fffffe8, 28}, {0x00ffffea, 24}, {0x3ffffffc, 30}, {0x0fffffe9, 28},
+    {0x0fffffea, 28}, {0x3ffffffd, 30}, {0x0fffffeb, 28}, {0x0fffffec, 28},
+    {0x0fffffed, 28}, {0x0fffffee, 28}, {0x0fffffef, 28}, {0x0ffffff0, 28},
+    {0x0ffffff1, 28}, {0x0ffffff2, 28}, {0x3ffffffe, 30}, {0x0ffffff3, 28},
+    {0x0ffffff4, 28}, {0x0ffffff5, 28}, {0x0ffffff6, 28}, {0x0ffffff7, 28},
+    {0x0ffffff8, 28}, {0x0ffffff9, 28}, {0x0ffffffa, 28}, {0x0ffffffb, 28},
+    {0x00000014,  6}, {0x000003f8, 10}, {0x000003f9, 10}, {0x00000ffa, 12},
+    {0x00001ff9, 13}, {0x00000015,  6}, {0x000000f8,  8}, {0x000007fa, 11},
+    {0x000003fa, 10}, {0x000003fb, 10}, {0x000000f9,  8}, {0x000007fb, 11},
+    {0x000000fa,  8}, {0x00000016,  6}, {0x00000017,  6}, {0x00000018,  6},
+    {0x00000000,  5}, {0x00000001,  5}, {0x00000002,  5}, {0x00000019,  6},
+    {0x0000001a,  6}, {0x0000001b,  6}, {0x0000001c,  6}, {0x0000001d,  6},
+    {0x0000001e,  6}, {0x0000001f,  6}, {0x0000005c,  7}, {0x000000fb,  8},
+    {0x00007ffc, 15}, {0x00000020,  6}, {0x00000ffb, 12}, {0x000003fc, 10},
+    {0x00001ffa, 13}, {0x00000021,  6}, {0x0000005d,  7}, {0x0000005e,  7},
+    {0x0000005f,  7}, {0x00000060,  7}, {0x00000061,  7}, {0x00000062,  7},
+    {0x00000063,  7}, {0x00000064,  7}, {0x00000065,  7}, {0x00000066,  7},
+    {0x00000067,  7}, {0x00000068,  7}, {0x00000069,  7}, {0x0000006a,  7},
+    {0x0000006b,  7}, {0x0000006c,  7}, {0x0000006d,  7}, {0x0000006e,  7},
+    {0x0000006f,  7}, {0x00000070,  7}, {0x00000071,  7}, {0x00000072,  7},
+    {0x000000fc,  8}, {0x00000073,  7}, {0x000000fd,  8}, {0x00001ffb, 13},
+    {0x0007fff0, 19}, {0x00001ffc, 13}, {0x00003ffc, 14}, {0x00000022,  6},
+    {0x00007ffd, 15}, {0x00000003,  5}, {0x00000023,  6}, {0x00000004,  5},
+    {0x00000024,  6}, {0x00000005,  5}, {0x00000025,  6}, {0x00000026,  6},
+    {0x00000027,  6}, {0x00000006,  5}, {0x00000074,  7}, {0x00000075,  7},
+    {0x00000028,  6}, {0x00000029,  6}, {0x0000002a,  6}, {0x00000007,  5},
+    {0x0000002b,  6}, {0x00000076,  7}, {0x0000002c,  6}, {0x00000008,  5},
+    {0x00000009,  5}, {0x0000002d,  6}, {0x00000077,  7}, {0x00000078,  7},
+    {0x00000079,  7}, {0x0000007a,  7}, {0x0000007b,  7}, {0x00007ffe, 15},
+    {0x000007fc, 11}, {0x00003ffd, 14}, {0x00001ffd, 13}, {0x0ffffffc, 28},
+    {0x000fffe6, 20}, {0x003fffd2, 22}, {0x000fffe7, 20}, {0x000fffe8, 20},
+    {0x003fffd3, 22}, {0x003fffd4, 22}, {0x003fffd5, 22}, {0x007fffd9, 23},
+    {0x003fffd6, 22}, {0x007fffda, 23}, {0x007fffdb, 23}, {0x007fffdc, 23},
+    {0x007fffdd, 23}, {0x007fffde, 23}, {0x00ffffeb, 24}, {0x007fffdf, 23},
+    {0x00ffffec, 24}, {0x00ffffed, 24}, {0x003fffd7, 22}, {0x007fffe0, 23},
+    {0x00ffffee, 24}, {0x007fffe1, 23}, {0x007fffe2, 23}, {0x007fffe3, 23},
+    {0x007fffe4, 23}, {0x001fffdc, 21}, {0x003fffd8, 22}, {0x007fffe5, 23},
+    {0x003fffd9, 22}, {0x007fffe6, 23}, {0x007fffe7, 23}, {0x00ffffef, 24},
+    {0x003fffda, 22}, {0x001fffdd, 21}, {0x000fffe9, 20}, {0x003fffdb, 22},
+    {0x003fffdc, 22}, {0x007fffe8, 23}, {0x007fffe9, 23}, {0x001fffde, 21},
+    {0x007fffea, 23}, {0x003fffdd, 22}, {0x003fffde, 22}, {0x00fffff0, 24},
+    {0x001fffdf, 21}, {0x003fffdf, 22}, {0x007fffeb, 23}, {0x007fffec, 23},
+    {0x001fffe0, 21}, {0x001fffe1, 21}, {0x003fffe0, 22}, {0x001fffe2, 21},
+    {0x007fffed, 23}, {0x003fffe1, 22}, {0x007fffee, 23}, {0x007fffef, 23},
+    {0x000fffea, 20}, {0x003fffe2, 22}, {0x003fffe3, 22}, {0x003fffe4, 22},
+    {0x007ffff0, 23}, {0x003fffe5, 22}, {0x003fffe6, 22}, {0x007ffff1, 23},
+    {0x03ffffe0, 26}, {0x03ffffe1, 26}, {0x000fffeb, 20}, {0x0007fff1, 19},
+    {0x003fffe7, 22}, {0x007ffff2, 23}, {0x003fffe8, 22}, {0x01ffffec, 25},
+    {0x03ffffe2, 26}, {0x03ffffe3, 26}, {0x03ffffe4, 26}, {0x07ffffde, 27},
+    {0x07ffffdf, 27}, {0x03ffffe5, 26}, {0x00fffff1, 24}, {0x01ffffed, 25},
+    {0x0007fff2, 19}, {0x001fffe3, 21}, {0x03ffffe6, 26}, {0x07ffffe0, 27},
+    {0x07ffffe1, 27}, {0x03ffffe7, 26}, {0x07ffffe2, 27}, {0x00fffff2, 24},
+    {0x001fffe4, 21}, {0x001fffe5, 21}, {0x03ffffe8, 26}, {0x03ffffe9, 26},
+    {0x0ffffffd, 28}, {0x07ffffe3, 27}, {0x07ffffe4, 27}, {0x07ffffe5, 27},
+    {0x000fffec, 20}, {0x00fffff3, 24}, {0x000fffed, 20}, {0x001fffe6, 21},
+    {0x003fffe9, 22}, {0x001fffe7, 21}, {0x001fffe8, 21}, {0x007ffff3, 23},
+    {0x003fffea, 22}, {0x003fffeb, 22}, {0x01ffffee, 25}, {0x01ffffef, 25},
+    {0x00fffff4, 24}, {0x00fffff5, 24}, {0x03ffffea, 26}, {0x007ffff4, 23},
+    {0x03ffffeb, 26}, {0x07ffffe6, 27}, {0x03ffffec, 26}, {0x03ffffed, 26},
+    {0x07ffffe7, 27}, {0x07ffffe8, 27}, {0x07ffffe9, 27}, {0x07ffffea, 27},
+    {0x07ffffeb, 27}, {0x0ffffffe, 28}, {0x07ffffec, 27}, {0x07ffffed, 27},
+    {0x07ffffee, 27}, {0x07ffffef, 27}, {0x07fffff0, 27}, {0x03ffffee, 26}
+};
+
+
+/* same as above, but embeds lowercase transformation */
+static ngx_http_v2_huff_encode_code_t  ngx_http_v2_huff_encode_table_lc[256] =
+{
+    {0x00001ff8, 13}, {0x007fffd8, 23}, {0x0fffffe2, 28}, {0x0fffffe3, 28},
+    {0x0fffffe4, 28}, {0x0fffffe5, 28}, {0x0fffffe6, 28}, {0x0fffffe7, 28},
+    {0x0fffffe8, 28}, {0x00ffffea, 24}, {0x3ffffffc, 30}, {0x0fffffe9, 28},
+    {0x0fffffea, 28}, {0x3ffffffd, 30}, {0x0fffffeb, 28}, {0x0fffffec, 28},
+    {0x0fffffed, 28}, {0x0fffffee, 28}, {0x0fffffef, 28}, {0x0ffffff0, 28},
+    {0x0ffffff1, 28}, {0x0ffffff2, 28}, {0x3ffffffe, 30}, {0x0ffffff3, 28},
+    {0x0ffffff4, 28}, {0x0ffffff5, 28}, {0x0ffffff6, 28}, {0x0ffffff7, 28},
+    {0x0ffffff8, 28}, {0x0ffffff9, 28}, {0x0ffffffa, 28}, {0x0ffffffb, 28},
+    {0x00000014,  6}, {0x000003f8, 10}, {0x000003f9, 10}, {0x00000ffa, 12},
+    {0x00001ff9, 13}, {0x00000015,  6}, {0x000000f8,  8}, {0x000007fa, 11},
+    {0x000003fa, 10}, {0x000003fb, 10}, {0x000000f9,  8}, {0x000007fb, 11},
+    {0x000000fa,  8}, {0x00000016,  6}, {0x00000017,  6}, {0x00000018,  6},
+    {0x00000000,  5}, {0x00000001,  5}, {0x00000002,  5}, {0x00000019,  6},
+    {0x0000001a,  6}, {0x0000001b,  6}, {0x0000001c,  6}, {0x0000001d,  6},
+    {0x0000001e,  6}, {0x0000001f,  6}, {0x0000005c,  7}, {0x000000fb,  8},
+    {0x00007ffc, 15}, {0x00000020,  6}, {0x00000ffb, 12}, {0x000003fc, 10},
+    {0x00001ffa, 13}, {0x00000003,  5}, {0x00000023,  6}, {0x00000004,  5},
+    {0x00000024,  6}, {0x00000005,  5}, {0x00000025,  6}, {0x00000026,  6},
+    {0x00000027,  6}, {0x00000006,  5}, {0x00000074,  7}, {0x00000075,  7},
+    {0x00000028,  6}, {0x00000029,  6}, {0x0000002a,  6}, {0x00000007,  5},
+    {0x0000002b,  6}, {0x00000076,  7}, {0x0000002c,  6}, {0x00000008,  5},
+    {0x00000009,  5}, {0x0000002d,  6}, {0x00000077,  7}, {0x00000078,  7},
+    {0x00000079,  7}, {0x0000007a,  7}, {0x0000007b,  7}, {0x00001ffb, 13},
+    {0x0007fff0, 19}, {0x00001ffc, 13}, {0x00003ffc, 14}, {0x00000022,  6},
+    {0x00007ffd, 15}, {0x00000003,  5}, {0x00000023,  6}, {0x00000004,  5},
+    {0x00000024,  6}, {0x00000005,  5}, {0x00000025,  6}, {0x00000026,  6},
+    {0x00000027,  6}, {0x00000006,  5}, {0x00000074,  7}, {0x00000075,  7},
+    {0x00000028,  6}, {0x00000029,  6}, {0x0000002a,  6}, {0x00000007,  5},
+    {0x0000002b,  6}, {0x00000076,  7}, {0x0000002c,  6}, {0x00000008,  5},
+    {0x00000009,  5}, {0x0000002d,  6}, {0x00000077,  7}, {0x00000078,  7},
+    {0x00000079,  7}, {0x0000007a,  7}, {0x0000007b,  7}, {0x00007ffe, 15},
+    {0x000007fc, 11}, {0x00003ffd, 14}, {0x00001ffd, 13}, {0x0ffffffc, 28},
+    {0x000fffe6, 20}, {0x003fffd2, 22}, {0x000fffe7, 20}, {0x000fffe8, 20},
+    {0x003fffd3, 22}, {0x003fffd4, 22}, {0x003fffd5, 22}, {0x007fffd9, 23},
+    {0x003fffd6, 22}, {0x007fffda, 23}, {0x007fffdb, 23}, {0x007fffdc, 23},
+    {0x007fffdd, 23}, {0x007fffde, 23}, {0x00ffffeb, 24}, {0x007fffdf, 23},
+    {0x00ffffec, 24}, {0x00ffffed, 24}, {0x003fffd7, 22}, {0x007fffe0, 23},
+    {0x00ffffee, 24}, {0x007fffe1, 23}, {0x007fffe2, 23}, {0x007fffe3, 23},
+    {0x007fffe4, 23}, {0x001fffdc, 21}, {0x003fffd8, 22}, {0x007fffe5, 23},
+    {0x003fffd9, 22}, {0x007fffe6, 23}, {0x007fffe7, 23}, {0x00ffffef, 24},
+    {0x003fffda, 22}, {0x001fffdd, 21}, {0x000fffe9, 20}, {0x003fffdb, 22},
+    {0x003fffdc, 22}, {0x007fffe8, 23}, {0x007fffe9, 23}, {0x001fffde, 21},
+    {0x007fffea, 23}, {0x003fffdd, 22}, {0x003fffde, 22}, {0x00fffff0, 24},
+    {0x001fffdf, 21}, {0x003fffdf, 22}, {0x007fffeb, 23}, {0x007fffec, 23},
+    {0x001fffe0, 21}, {0x001fffe1, 21}, {0x003fffe0, 22}, {0x001fffe2, 21},
+    {0x007fffed, 23}, {0x003fffe1, 22}, {0x007fffee, 23}, {0x007fffef, 23},
+    {0x000fffea, 20}, {0x003fffe2, 22}, {0x003fffe3, 22}, {0x003fffe4, 22},
+    {0x007ffff0, 23}, {0x003fffe5, 22}, {0x003fffe6, 22}, {0x007ffff1, 23},
+    {0x03ffffe0, 26}, {0x03ffffe1, 26}, {0x000fffeb, 20}, {0x0007fff1, 19},
+    {0x003fffe7, 22}, {0x007ffff2, 23}, {0x003fffe8, 22}, {0x01ffffec, 25},
+    {0x03ffffe2, 26}, {0x03ffffe3, 26}, {0x03ffffe4, 26}, {0x07ffffde, 27},
+    {0x07ffffdf, 27}, {0x03ffffe5, 26}, {0x00fffff1, 24}, {0x01ffffed, 25},
+    {0x0007fff2, 19}, {0x001fffe3, 21}, {0x03ffffe6, 26}, {0x07ffffe0, 27},
+    {0x07ffffe1, 27}, {0x03ffffe7, 26}, {0x07ffffe2, 27}, {0x00fffff2, 24},
+    {0x001fffe4, 21}, {0x001fffe5, 21}, {0x03ffffe8, 26}, {0x03ffffe9, 26},
+    {0x0ffffffd, 28}, {0x07ffffe3, 27}, {0x07ffffe4, 27}, {0x07ffffe5, 27},
+    {0x000fffec, 20}, {0x00fffff3, 24}, {0x000fffed, 20}, {0x001fffe6, 21},
+    {0x003fffe9, 22}, {0x001fffe7, 21}, {0x001fffe8, 21}, {0x007ffff3, 23},
+    {0x003fffea, 22}, {0x003fffeb, 22}, {0x01ffffee, 25}, {0x01ffffef, 25},
+    {0x00fffff4, 24}, {0x00fffff5, 24}, {0x03ffffea, 26}, {0x007ffff4, 23},
+    {0x03ffffeb, 26}, {0x07ffffe6, 27}, {0x03ffffec, 26}, {0x03ffffed, 26},
+    {0x07ffffe7, 27}, {0x07ffffe8, 27}, {0x07ffffe9, 27}, {0x07ffffea, 27},
+    {0x07ffffeb, 27}, {0x0ffffffe, 28}, {0x07ffffec, 27}, {0x07ffffed, 27},
+    {0x07ffffee, 27}, {0x07ffffef, 27}, {0x07fffff0, 27}, {0x03ffffee, 26}
+};
+
+
+#if (NGX_PTR_SIZE == 8)
+
+#if (NGX_HAVE_LITTLE_ENDIAN)
+
+#if (NGX_HAVE_GCC_BSWAP64)
+#define ngx_http_v2_huff_encode_buf(dst, buf)                                 \
+    (*(uint64_t *) (dst) = __builtin_bswap64(buf))
+#else
+#define ngx_http_v2_huff_encode_buf(dst, buf)                                 \
+    ((dst)[0] = (u_char) ((buf) >> 56),                                       \
+     (dst)[1] = (u_char) ((buf) >> 48),                                       \
+     (dst)[2] = (u_char) ((buf) >> 40),                                       \
+     (dst)[3] = (u_char) ((buf) >> 32),                                       \
+     (dst)[4] = (u_char) ((buf) >> 24),                                       \
+     (dst)[5] = (u_char) ((buf) >> 16),                                       \
+     (dst)[6] = (u_char) ((buf) >> 8),                                        \
+     (dst)[7] = (u_char)  (buf))
+#endif
+
+#else /* !NGX_HAVE_LITTLE_ENDIAN */
+#define ngx_http_v2_huff_encode_buf(dst, buf)                                 \
+    (*(uint64_t *) (dst) = (buf))
+#endif
+
+#else /* NGX_PTR_SIZE == 4 */
+
+#define ngx_http_v2_huff_encode_buf(dst, buf)                                 \
+    (*(uint32_t *) (dst) = htonl(buf))
+
+#endif
+
+
+size_t
+ngx_http_v2_huff_encode(u_char *src, size_t len, u_char *dst, ngx_uint_t lower)
+{
+    u_char                          *end;
+    size_t                           hlen;
+    ngx_uint_t                       buf, pending, code;
+    ngx_http_v2_huff_encode_code_t  *table, *next;
+
+    table = lower ? ngx_http_v2_huff_encode_table_lc
+                  : ngx_http_v2_huff_encode_table;
+    hlen = 0;
+    buf = 0;
+    pending = 0;
+
+    end = src + len;
+
+    while (src != end) {
+        next = &table[*src++];
+
+        code = next->code;
+        pending += next->len;
+
+        /* accumulate bits */
+        if (pending < sizeof(buf) * 8) {
+            buf |= code << (sizeof(buf) * 8 - pending);
+            continue;
+        }
+
+        if (hlen + sizeof(buf) >= len) {
+            return 0;
+        }
+
+        pending -= sizeof(buf) * 8;
+
+        buf |= code >> pending;
+
+        ngx_http_v2_huff_encode_buf(&dst[hlen], buf);
+
+        hlen += sizeof(buf);
+
+        buf = pending ? code << (sizeof(buf) * 8 - pending) : 0;
+    }
+
+    if (pending == 0) {
+        return hlen;
+    }
+
+    buf |= (ngx_uint_t) -1 >> pending;
+
+    pending = ngx_align(pending, 8);
+
+    if (hlen + pending / 8 >= len) {
+        return 0;
+    }
+
+    buf >>= sizeof(buf) * 8 - pending;
+
+    do {
+        pending -= 8;
+        dst[hlen++] = (u_char) (buf >> pending);
+    } while (pending);
+
+    return hlen;
+}

--- a/src/http/v2/ngx_http_v2_module.c
+++ b/src/http/v2/ngx_http_v2_module.c
@@ -30,6 +30,7 @@ static char *ngx_http_v2_merge_loc_conf(ngx_conf_t *cf, void *parent,
 static char *ngx_http_v2_recv_buffer_size(ngx_conf_t *cf, void *post,
     void *data);
 static char *ngx_http_v2_pool_size(ngx_conf_t *cf, void *post, void *data);
+static char *ngx_http_v2_preread_size(ngx_conf_t *cf, void *post, void *data);
 static char *ngx_http_v2_streams_index_mask(ngx_conf_t *cf, void *post,
     void *data);
 static char *ngx_http_v2_chunk_size(ngx_conf_t *cf, void *post, void *data);
@@ -41,6 +42,8 @@ static ngx_conf_post_t  ngx_http_v2_recv_buffer_size_post =
     { ngx_http_v2_recv_buffer_size };
 static ngx_conf_post_t  ngx_http_v2_pool_size_post =
     { ngx_http_v2_pool_size };
+static ngx_conf_post_t  ngx_http_v2_preread_size_post =
+    { ngx_http_v2_preread_size };
 static ngx_conf_post_t  ngx_http_v2_streams_index_mask_post =
     { ngx_http_v2_streams_index_mask };
 static ngx_conf_post_t  ngx_http_v2_chunk_size_post =
@@ -70,6 +73,13 @@ static ngx_command_t  ngx_http_v2_commands[] = {
       offsetof(ngx_http_v2_srv_conf_t, concurrent_streams),
       NULL },
 
+    { ngx_string("http2_max_requests"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v2_srv_conf_t, max_requests),
+      NULL },
+
     { ngx_string("http2_max_field_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
@@ -83,6 +93,13 @@ static ngx_command_t  ngx_http_v2_commands[] = {
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_v2_srv_conf_t, max_header_size),
       NULL },
+
+    { ngx_string("http2_body_preread_size"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v2_srv_conf_t, preread_size),
+      &ngx_http_v2_preread_size_post },
 
     { ngx_string("http2_streams_index_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
@@ -312,9 +329,12 @@ ngx_http_v2_create_srv_conf(ngx_conf_t *cf)
     h2scf->pool_size = NGX_CONF_UNSET_SIZE;
 
     h2scf->concurrent_streams = NGX_CONF_UNSET_UINT;
+    h2scf->max_requests = NGX_CONF_UNSET_UINT;
 
     h2scf->max_field_size = NGX_CONF_UNSET_SIZE;
     h2scf->max_header_size = NGX_CONF_UNSET_SIZE;
+
+    h2scf->preread_size = NGX_CONF_UNSET_SIZE;
 
     h2scf->streams_index_mask = NGX_CONF_UNSET_UINT;
 
@@ -335,11 +355,14 @@ ngx_http_v2_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_uint_value(conf->concurrent_streams,
                               prev->concurrent_streams, 128);
+    ngx_conf_merge_uint_value(conf->max_requests, prev->max_requests, 1000);
 
     ngx_conf_merge_size_value(conf->max_field_size, prev->max_field_size,
                               4096);
     ngx_conf_merge_size_value(conf->max_header_size, prev->max_header_size,
                               16384);
+
+    ngx_conf_merge_size_value(conf->preread_size, prev->preread_size, 65536);
 
     ngx_conf_merge_uint_value(conf->streams_index_mask,
                               prev->streams_index_mask, 32 - 1);
@@ -411,6 +434,23 @@ ngx_http_v2_pool_size(ngx_conf_t *cf, void *post, void *data)
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "the pool size must be a multiple of %uz",
                            NGX_POOL_ALIGNMENT);
+
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_http_v2_preread_size(ngx_conf_t *cf, void *post, void *data)
+{
+    size_t *sp = data;
+
+    if (*sp > NGX_HTTP_V2_MAX_WINDOW) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "the maximum body preread buffer size is %uz",
+                           NGX_HTTP_V2_MAX_WINDOW);
 
         return NGX_CONF_ERROR;
     }

--- a/src/http/v2/ngx_http_v2_module.h
+++ b/src/http/v2/ngx_http_v2_module.h
@@ -23,8 +23,10 @@ typedef struct {
 typedef struct {
     size_t                          pool_size;
     ngx_uint_t                      concurrent_streams;
+    ngx_uint_t                      max_requests;
     size_t                          max_field_size;
     size_t                          max_header_size;
+    size_t                          preread_size;
     ngx_uint_t                      streams_index_mask;
     ngx_msec_t                      recv_timeout;
     ngx_msec_t                      idle_timeout;

--- a/tests/nginx-tests/nginx-tests/h2.t
+++ b/tests/nginx-tests/nginx-tests/h2.t
@@ -12,31 +12,21 @@ use strict;
 
 use Test::More;
 
-use IO::Select;
 use Socket qw/ CRLF /;
 
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
 use Test::Nginx;
+use Test::Nginx::HTTP2;
 
 ###############################################################################
 
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-eval { require IO::Socket::SSL; };
-plan(skip_all => 'IO::Socket::SSL not installed') if $@;
-eval { IO::Socket::SSL::SSL_VERIFY_NONE(); };
-plan(skip_all => 'IO::Socket::SSL too old') if $@;
-
-my $t = Test::Nginx->new()->has(qw/http http_ssl http_v2 proxy cache/)
-        ->has(qw/limit_conn rewrite realip/)
-	->has_daemon('openssl')->plan(318);
-
-# Some systems may have also a bug in not treating zero writev iovcnt as EINVAL
-
-$t->todo_alerts();
+my $t = Test::Nginx->new()->has(qw/http http_v2 proxy rewrite charset gzip/)
+	->plan(141);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -50,23 +40,10 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    proxy_cache_path %%TESTDIR%%/cache    keys_zone=NAME:1m;
-    limit_conn_zone  $binary_remote_addr  zone=conn:1m;
-    limit_req_zone   $binary_remote_addr  zone=req:1m rate=1r/s;
-
     server {
         listen       127.0.0.1:8080 http2;
         listen       127.0.0.1:8081;
-        listen       127.0.0.1:8082 proxy_protocol http2;
-        listen       127.0.0.1:8084 http2 ssl;
-        listen       127.0.0.1:8092 http2 sndbuf=128;
-        listen       127.0.0.1:8094 ssl;
         server_name  localhost;
-
-        ssl_certificate_key localhost.key;
-        ssl_certificate localhost.crt;
-        http2_max_field_size 128k;
-        http2_max_header_size 128k;
 
         location / {
             add_header X-Header X-Foo;
@@ -76,9 +53,6 @@ http {
         }
         location /t {
         }
-        location /t3.html {
-            limit_conn conn 1;
-        }
         location /gzip.html {
             gzip on;
             gzip_min_length 0;
@@ -86,40 +60,9 @@ http {
             alias %%TESTDIR%%/t2.html;
         }
         location /frame_size {
-            add_header X-LongHeader $arg_h;
-            add_header X-LongHeader $arg_h;
-            add_header X-LongHeader $arg_h;
             http2_chunk_size 64k;
             alias %%TESTDIR%%/t1.html;
             output_buffers 2 1m;
-        }
-        location /continuation {
-            add_header X-LongHeader $arg_h;
-            add_header X-LongHeader $arg_h;
-            add_header X-LongHeader $arg_h;
-            return 200 body;
-
-            location /continuation/204 {
-                return 204;
-            }
-        }
-        location /pp {
-            set_real_ip_from 127.0.0.1/32;
-            real_ip_header proxy_protocol;
-            alias %%TESTDIR%%/t2.html;
-            add_header X-PP $remote_addr;
-        }
-        location /h2 {
-            return 200 $http2;
-        }
-        location /sp {
-            return 200 $server_protocol;
-        }
-        location /scheme {
-            return 200 $scheme;
-        }
-        location /https {
-            return 200 $https;
         }
         location /chunk_size {
             http2_chunk_size 1;
@@ -138,104 +81,36 @@ http {
         location /return301_relative {
             return 301 /;
         }
-        location /proxy/ {
-            add_header X-UC-a $upstream_cookie_a;
-            add_header X-UC-c $upstream_cookie_c;
-            proxy_pass http://127.0.0.1:8083/;
-            proxy_set_header X-Cookie-a $cookie_a;
-            proxy_set_header X-Cookie-c $cookie_c;
-        }
-        location /proxy2/ {
-            add_header X-Body "$request_body";
-            add_header X-Body-File $request_body_file;
-            client_body_in_file_only on;
-            proxy_pass http://127.0.0.1:8081/;
-        }
-        location /proxy_ssl/ {
-            proxy_pass https://127.0.0.1:8094/;
-        }
-        location /limit_req {
-            limit_req  zone=req burst=2;
-            alias %%TESTDIR%%/t2.html;
-        }
-        location /proxy_limit_req/ {
-            add_header X-Body $request_body;
-            add_header X-Body-File $request_body_file;
-            client_body_in_file_only on;
-            proxy_pass http://127.0.0.1:8081/;
-            limit_req  zone=req burst=2;
-        }
-        location /cache/ {
-            proxy_pass http://127.0.0.1:8081/;
-            proxy_cache NAME;
-            proxy_cache_valid 1m;
-        }
-        location /proxy_buffering_off {
-            proxy_pass http://127.0.0.1:8081/;
-            proxy_cache NAME;
-            proxy_cache_valid 1m;
-            proxy_buffering off;
-        }
-        location /client_max_body_size {
-            add_header X-Body $request_body;
-            add_header X-Body-File $request_body_file;
-            client_body_in_single_buffer on;
-            client_body_in_file_only on;
-            proxy_pass http://127.0.0.1:8081/;
-            client_max_body_size 10;
-        }
-        location /set-cookie {
-            add_header Set-Cookie a=b;
-            add_header Set-Cookie c=d;
-            return 200;
-        }
-        location /cookie {
-            add_header X-Cookie $http_cookie;
-            add_header X-Cookie-a $cookie_a;
-            add_header X-Cookie-c $cookie_c;
-            return 200;
-        }
         location /charset {
             charset utf-8;
             return 200;
         }
+        location /pid {
+            return 200 "pid $pid";
+        }
     }
 
     server {
-        listen       127.0.0.1:8085 http2;
+        listen       127.0.0.1:8082 http2;
         server_name  localhost;
         return 200   first;
     }
 
     server {
-        listen       127.0.0.1:8085 http2;
+        listen       127.0.0.1:8082 http2;
         server_name  localhost2;
         return 200   second;
     }
 
     server {
-        listen       127.0.0.1:8086 http2;
+        listen       127.0.0.1:8083 http2;
         server_name  localhost;
 
         http2_max_concurrent_streams 1;
     }
 
     server {
-        listen       127.0.0.1:8087 http2;
-        server_name  localhost;
-
-        http2_max_field_size 22;
-    }
-
-    server {
-        listen       127.0.0.1:8088 http2;
-        server_name  localhost;
-
-        http2_max_header_size 64;
-    }
-
-    server {
-        listen       127.0.0.1:8089 http2;
+        listen       127.0.0.1:8084 http2;
         server_name  localhost;
 
         http2_recv_timeout 1s;
@@ -244,27 +119,27 @@ http {
     }
 
     server {
-        listen       127.0.0.1:8090 http2;
+        listen       127.0.0.1:8085 http2;
         server_name  localhost;
 
         http2_idle_timeout 1s;
         client_body_timeout 1s;
 
         location /proxy2/ {
-            add_header X-Body "$request_body";
+            add_header X-Body $request_body;
             proxy_pass http://127.0.0.1:8081/;
         }
     }
 
     server {
-        listen       127.0.0.1:8091 http2;
+        listen       127.0.0.1:8086 http2;
         server_name  localhost;
 
         send_timeout 1s;
     }
 
     server {
-        listen       127.0.0.1:8093 http2;
+        listen       127.0.0.1:8087 http2;
         server_name  localhost;
 
         client_header_timeout 1s;
@@ -278,31 +153,7 @@ http {
 
 EOF
 
-$t->write_file('openssl.conf', <<EOF);
-[ req ]
-default_bits = 2048
-encrypt_key = no
-distinguished_name = req_distinguished_name
-[ req_distinguished_name ]
-EOF
-
-my $d = $t->testdir();
-
-foreach my $name ('localhost') {
-	system('openssl req -x509 -new '
-		. "-config '$d/openssl.conf' -subj '/CN=$name/' "
-		. "-out '$d/$name.crt' -keyout '$d/$name.key' "
-		. ">>$d/openssl.out 2>&1") == 0
-		or die "Can't create certificate for $name: $!\n";
-}
-
-$t->run_daemon(\&http_daemon);
-
-open OLDERR, ">&", \*STDERR; close STDERR;
 $t->run();
-open STDERR, ">&", \*OLDERR;
-
-$t->waitforsocket('127.0.0.1:8083');
 
 # file size is slightly beyond initial window size: 2**16 + 80 bytes
 
@@ -312,21 +163,6 @@ $t->write_file('tbig.html',
 	join('', map { sprintf "XX%06dXX", $_ } (1 .. 500000)));
 
 $t->write_file('t2.html', 'SEE-THIS');
-$t->write_file('t3.html', 'SEE-THIS');
-$t->write_file('t4.html', 'SEE-THIS');
-
-my %cframe = (
-	0 => { name => 'DATA', value => \&data },
-	1 => { name => 'HEADERS', value => \&headers },
-#	2 => { name => 'PRIORITY', value => \&priority },
-	3 => { name => 'RST_STREAM', value => \&rst_stream },
-	4 => { name => 'SETTINGS', value => \&settings },
-#	5 => { name => 'PUSH_PROMISE', value => \&push_promise },
-	6 => { name => 'PING', value => \&ping },
-	7 => { name => 'GOAWAY', value => \&goaway },
-	8 => { name => 'WINDOW_UPDATE', value => \&window_update },
-	9 => { name => 'CONTINUATION', value => \&headers },
-);
 
 ###############################################################################
 
@@ -351,8 +187,8 @@ like($r, qr!Upgrade: h2c!, 'upgrade - token');
 
 # SETTINGS
 
-my $sess = new_session(8080, pure => 1);
-my $frames = h2_read($sess, all => [
+my $s = Test::Nginx::HTTP2->new(port(8080), pure => 1);
+my $frames = $s->read(all => [
 	{ type => 'WINDOW_UPDATE' },
 	{ type => 'SETTINGS'}
 ]);
@@ -368,10 +204,10 @@ ok($frame, 'SETTINGS frame');
 is($frame->{flags}, 0, 'SETTINGS flags');
 is($frame->{sid}, 0, 'SETTINGS stream');
 
-h2_settings($sess, 1);
-h2_settings($sess, 0);
+$s->h2_settings(1);
+$s->h2_settings(0);
 
-$frames = h2_read($sess, all => [{ type => 'SETTINGS' }]);
+$frames = $s->read(all => [{ type => 'SETTINGS' }]);
 
 ($frame) = grep { $_->{type} eq 'SETTINGS' } @$frames;
 ok($frame, 'SETTINGS frame ack');
@@ -379,8 +215,8 @@ is($frame->{flags}, 1, 'SETTINGS flags ack');
 
 # PING
 
-h2_ping($sess, 'SEE-THIS');
-$frames = h2_read($sess, all => [{ type => 'PING' }]);
+$s->h2_ping('SEE-THIS');
+$frames = $s->read(all => [{ type => 'PING' }]);
 
 ($frame) = grep { $_->{type} eq "PING" } @$frames;
 ok($frame, 'PING frame');
@@ -390,46 +226,51 @@ is($frame->{sid}, 0, 'PING stream');
 
 # timeouts
 
-push my @sess, new_session(8089);
-push @sess, new_session(8089);
-h2_ping($sess[-1], 'SEE-THIS');
-push @sess, new_session(8090);
-push @sess, new_session(8090);
-h2_ping($sess[-1], 'SEE-THIS');
+SKIP: {
+skip 'long tests', 6 unless $ENV{TEST_NGINX_UNSAFE};
+
+push my @s, Test::Nginx::HTTP2->new(port(8084), pure => 1);
+push @s, Test::Nginx::HTTP2->new(port(8084), pure => 1);
+$s[-1]->h2_ping('SEE-THIS');
+push @s, Test::Nginx::HTTP2->new(port(8085), pure => 1);
+push @s, Test::Nginx::HTTP2->new(port(8085), pure => 1);
+$s[-1]->h2_ping('SEE-THIS');
 
 select undef, undef, undef, 2.1;
 
-$frames = h2_read(shift @sess, all => [{ type => "GOAWAY" }]);
+$frames = (shift @s)->read(all => [{ type => "GOAWAY" }]);
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'recv timeout - new connection GOAWAY');
 is($frame->{code}, 1, 'recv timeout - new connection code');
 
-$frames = h2_read(shift @sess, all => [{ type => "GOAWAY" }]);
+$frames = (shift @s)->read(all => [{ type => "GOAWAY" }]);
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 is($frame, undef, 'recv timeout - idle connection GOAWAY');
 
-$frames = h2_read(shift @sess, all => [{ type => "GOAWAY" }]);
+$frames = (shift @s)->read(all => [{ type => "GOAWAY" }]);
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 is($frame, undef, 'idle timeout - new connection GOAWAY');
 
-$frames = h2_read(shift @sess, all => [{ type => "GOAWAY" }]);
+$frames = (shift @s)->read(all => [{ type => "GOAWAY" }]);
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'idle timeout - idle connection GOAWAY');
 is($frame->{code}, 0, 'idle timeout - idle connection code');
 
+}
+
 # GOAWAY
 
-h2_goaway(new_session(), 0, 0, 5);
-h2_goaway(new_session(), 0, 0, 5, 'foobar');
-h2_goaway(new_session(), 0, 0, 5, 'foobar', split => [ 8, 8, 4 ]);
+Test::Nginx::HTTP2->new()->h2_goaway(0, 0, 5);
+Test::Nginx::HTTP2->new()->h2_goaway(0, 0, 5, 'foobar');
+Test::Nginx::HTTP2->new()->h2_goaway(0, 0, 5, 'foobar', split => [ 8, 8, 4 ]);
 
-$sess = new_session();
-h2_goaway($sess, 0, 0, 5);
-h2_goaway($sess, 0, 0, 5);
+$s = Test::Nginx::HTTP2->new();
+$s->h2_goaway(0, 0, 5);
+$s->h2_goaway(0, 0, 5);
 
-$sess = new_session();
-h2_goaway($sess, 0, 0, 5, 'foobar', len => 0);
-$frames = h2_read($sess, all => [{ type => "GOAWAY" }]);
+$s = Test::Nginx::HTTP2->new();
+$s->h2_goaway(0, 0, 5, 'foobar', len => 0);
+$frames = $s->read(all => [{ type => "GOAWAY" }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'GOAWAY invalid length - GOAWAY frame');
@@ -442,9 +283,9 @@ is($frame->{code}, 6, 'GOAWAY invalid length - GOAWAY FRAME_SIZE_ERROR');
 TODO: {
 local $TODO = 'not yet';
 
-$sess = new_session();
-h2_goaway($sess, 1, 0, 5, 'foobar');
-$frames = h2_read($sess, all => [{ type => "GOAWAY" }]);
+$s = Test::Nginx::HTTP2->new();
+$s->h2_goaway(1, 0, 5, 'foobar');
+$frames = $s->read(all => [{ type => "GOAWAY" }], wait => 0.5);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'GOAWAY invalid stream - GOAWAY frame');
@@ -455,9 +296,9 @@ is($frame->{code}, 1, 'GOAWAY invalid stream - GOAWAY PROTOCOL_ERROR');
 # client-initiated PUSH_PROMISE, just to ensure nothing went wrong
 # N.B. other implementation returns zero code, which is not anyhow regulated
 
-$sess = new_session();
-raw_write($sess->{socket}, pack("x2C2xN", 4, 0x5, 1));
-$frames = h2_read($sess, all => [{ type => "GOAWAY" }]);
+$s = Test::Nginx::HTTP2->new();
+syswrite($s->{socket}, pack("x2C2xN", 4, 0x5, 1));
+$frames = $s->read(all => [{ type => "GOAWAY" }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'client-initiated PUSH_PROMISE - GOAWAY frame');
@@ -465,9 +306,9 @@ is($frame->{code}, 1, 'client-initiated PUSH_PROMISE - GOAWAY PROTOCOL_ERROR');
 
 # GET
 
-$sess = new_session();
-my $sid = new_stream($sess);
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+my $sid = $s->new_stream();
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 ok($frame, 'HEADERS frame');
@@ -482,8 +323,8 @@ is($frame->{data}, 'body', 'DATA payload');
 
 # GET in the new stream on same connection
 
-$sid = new_stream($sess);
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$sid = $s->new_stream();
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{sid}, $sid, 'HEADERS stream 2');
@@ -496,416 +337,11 @@ is($frame->{sid}, $sid, 'HEADERS stream 2');
 is($frame->{length}, length 'body', 'DATA length 2');
 is($frame->{data}, 'body', 'DATA payload 2');
 
-# various HEADERS compression/encoding, see hpack() for mode details
-
-# 6.1. Indexed Header Field Representation
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'indexed header field');
-
-# 6.2.1. Literal Header Field with Incremental Indexing
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 1, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 1, huff => 0 },
-	{ name => ':path', value => '/', mode => 1, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal with indexing');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 1, huff => 1 },
-	{ name => ':scheme', value => 'http', mode => 1, huff => 1 },
-	{ name => ':path', value => '/', mode => 1, huff => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1, huff => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal with indexing - huffman');
-
-# 6.2.1. Literal Header Field with Incremental Indexing -- New Name
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 2, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 2, huff => 0 },
-	{ name => ':path', value => '/', mode => 2, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 2, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal with indexing - new');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 2, huff => 1 },
-	{ name => ':scheme', value => 'http', mode => 2, huff => 1 },
-	{ name => ':path', value => '/', mode => 2, huff => 1 },
-	{ name => ':authority', value => 'localhost', mode => 2, huff => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal with indexing - new huffman');
-
-# 6.2.2. Literal Header Field without Indexing
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 3, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 3, huff => 0 },
-	{ name => ':path', value => '/', mode => 3, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 3, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal without indexing');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 3, huff => 1 },
-	{ name => ':scheme', value => 'http', mode => 3, huff => 1 },
-	{ name => ':path', value => '/', mode => 3, huff => 1 },
-	{ name => ':authority', value => 'localhost', mode => 3, huff => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal without indexing - huffman');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 3, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 3, huff => 0 },
-	{ name => ':path', value => '/', mode => 3, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 3, huff => 0 },
-	{ name => 'referer', value => 'foo', mode => 3, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'literal without indexing - multibyte index');
-is($frame->{headers}->{'x-referer'}, 'foo',
-	'literal without indexing - multibyte index value');
-
-# 6.2.2. Literal Header Field without Indexing -- New Name
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 4, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 4, huff => 0 },
-	{ name => ':path', value => '/', mode => 4, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 4, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal without indexing - new');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 4, huff => 1 },
-	{ name => ':scheme', value => 'http', mode => 4, huff => 1 },
-	{ name => ':path', value => '/', mode => 4, huff => 1 },
-	{ name => ':authority', value => 'localhost', mode => 4, huff => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'literal without indexing - new huffman');
-
-# 6.2.3. Literal Header Field Never Indexed
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 5, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 5, huff => 0 },
-	{ name => ':path', value => '/', mode => 5, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 5, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal never indexed');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 5, huff => 1 },
-	{ name => ':scheme', value => 'http', mode => 5, huff => 1 },
-	{ name => ':path', value => '/', mode => 5, huff => 1 },
-	{ name => ':authority', value => 'localhost', mode => 5, huff => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal never indexed - huffman');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 5, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 5, huff => 0 },
-	{ name => ':path', value => '/', mode => 5, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 5, huff => 0 },
-	{ name => 'referer', value => 'foo', mode => 5, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'literal never indexed - multibyte index');
-is($frame->{headers}->{'x-referer'}, 'foo',
-	'literal never indexed - multibyte index value');
-
-# 6.2.3. Literal Header Field Never Indexed -- New Name
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 6, huff => 0 },
-	{ name => ':scheme', value => 'http', mode => 6, huff => 0 },
-	{ name => ':path', value => '/', mode => 6, huff => 0 },
-	{ name => ':authority', value => 'localhost', mode => 6, huff => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal never indexed - new');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 6, huff => 1 },
-	{ name => ':scheme', value => 'http', mode => 6, huff => 1 },
-	{ name => ':path', value => '/', mode => 6, huff => 1 },
-	{ name => ':authority', value => 'localhost', mode => 6, huff => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'literal never indexed - new huffman');
-
-# reuse literal with multibyte indexing
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'referer', value => 'foo', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-referer'}, 'foo', 'value with indexing - new');
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 0 },
-	{ name => 'referer', value => 'foo', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-referer'}, 'foo', 'value with indexing - indexed');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'x-foo', value => 'X-Bar', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-sent-foo'}, 'X-Bar', 'name with indexing - new');
-
-# reuse literal with multibyte indexing - reused name
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 0 },
-	{ name => 'x-foo', value => 'X-Bar', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-sent-foo'}, 'X-Bar', 'name with indexing - indexed');
-
-# reuse literal with multibyte indexing - reused name only
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 0 },
-	{ name => 'x-foo', value => 'X-Baz', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-sent-foo'}, 'X-Baz',
-	'name with indexing - indexed name');
-
-# response header field with characters not suitable for huffman encoding
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'x-foo', value => '{{{{{', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-sent-foo'}, '{{{{{', 'rare chars');
-like($sess->{headers}, qr/\Q{{{{{/, 'rare chars - no huffman encoding');
-
-# response header field with huffman encoding
-# NB: implementation detail, not obligated
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'x-foo', value => 'aaaaa', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-sent-foo'}, 'aaaaa', 'well known chars');
-
-TODO: {
-local $TODO = 'not yet' unless $t->has_version('1.9.12');
-
-unlike($sess->{headers}, qr/aaaaa/, 'well known chars - huffman encoding');
-
-}
-
-# response header field with huffman encoding - complete table mod \0, CR, LF
-# first saturate with short-encoded characters (NB: implementation detail)
-
-my $field = pack "C*", ((map { 97 } (1 .. 862)), 1 .. 9, 11, 12, 14 .. 255);
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'x-foo', value => $field, mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-sent-foo'}, $field, 'all chars');
-
-TODO: {
-local $TODO = 'not yet' unless $t->has_version('1.9.12');
-
-unlike($sess->{headers}, qr/abcde/, 'all chars - huffman encoding');
-
-}
-
-# 6.3.  Dynamic Table Size Update
-
-# remove some indexed headers from the dynamic table
-# by maintaining dynamic table space only for index 0
-# 'x-foo' has index 0, and 'referer' has index 1
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'referer', value => 'foo', mode => 1 },
-	{ name => 'x-foo', value => 'X-Bar', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-$sid = new_stream($sess, { table_size => 61, headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => 'x-foo', value => 'X-Bar', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-isnt($frame, undef, 'updated table size - remaining index');
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'referer', value => 'foo', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame, undef, 'invalid index');
-
-# 5.4.1.  Connection Error Handling
-#   An endpoint that encounters a connection error SHOULD first send a
-#   GOAWAY frame <..>
-
-($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
-ok($frame, 'invalid index - GOAWAY');
-
-# RFC 7541, 2.3.3.  Index Address Space
-#   Indices strictly greater than the sum of the lengths of both tables
-#   MUST be treated as a decoding error.
-
-# 4.3.  Header Compression and Decompression
-#   A decoding error in a header block MUST be treated
-#   as a connection error of type COMPRESSION_ERROR.
-
-is($frame->{last_sid}, $sid, 'invalid index - GOAWAY last stream');
-is($frame->{code}, 9, 'invalid index - GOAWAY COMPRESSION_ERROR');
-
-# HPACK zero index
-
-# RFC 7541, 6.1  Indexed Header Field Representation
-#   The index value of 0 is not used.  It MUST be treated as a decoding
-#   error if found in an indexed header field representation.
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => '', value => '', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-ok($frame, 'zero index - GOAWAY');
-is($frame->{code}, 9, 'zero index - GOAWAY COMPRESSION_ERROR');
-
-# invalid table size update
-
-$sess = new_session();
-$sid = new_stream($sess, { table_size => 4097, headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => 'x-foo', value => 'X-Bar', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
-ok($frame, 'invalid table size - GOAWAY');
-is($frame->{last_sid}, $sid, 'invalid table size - GOAWAY last stream');
-is($frame->{code}, 9, 'invalid table size - GOAWAY COMPRESSION_ERROR');
-
 # HEAD
 
-$sess = new_session();
-$sid = new_stream($sess, { method => 'HEAD' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 0x4 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ method => 'HEAD' });
+$frames = $s->read(all => [{ sid => $sid, fin => 0x4 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{sid}, $sid, 'HEAD - HEADERS');
@@ -915,27 +351,16 @@ is($frame->{headers}->{'x-header'}, 'X-Foo', 'HEAD - HEADERS header');
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
 is($frame, undef, 'HEAD - no body');
 
-# GET with PROXY protocol
-
-my $proxy = 'PROXY TCP4 192.0.2.1 192.0.2.2 1234 5678' . CRLF;
-$sess = new_session(8082, proxy => $proxy);
-$sid = new_stream($sess, { path => '/pp' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-ok($frame, 'PROXY HEADERS frame');
-is($frame->{headers}->{'x-pp'}, '192.0.2.1', 'PROXY remote addr');
-
 # range filter
 
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/t1.html', mode => 1 },
 	{ name => ':authority', value => 'localhost', mode => 1 },
 	{ name => 'range', value => 'bytes=10-19', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 206, 'range - HEADERS status');
@@ -944,167 +369,11 @@ is($frame->{headers}->{':status'}, 206, 'range - HEADERS status');
 is($frame->{length}, 10, 'range - DATA length');
 is($frame->{data}, '002XXXX000', 'range - DATA payload');
 
-# $http2
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/h2' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'h2c', 'http variable - h2c');
-
-# SSL/TLS connection, NPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_npn() or die; };
-skip 'OpenSSL NPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, npn => 'h2');
-$sid = new_stream($sess, { path => '/h2' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'h2', 'http variable - npn');
-
-}
-
-# SSL/TLS connection, ALPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_alpn() or die; };
-skip 'OpenSSL ALPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, alpn => 'h2');
-$sid = new_stream($sess, { path => '/h2' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'h2', 'http variable - alpn');
-
-}
-
-# $server_protocol
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/sp' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'HTTP/2.0', 'server_protocol variable');
-
-# $server_protocol - SSL/TLS connection, NPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_npn() or die; };
-skip 'OpenSSL NPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, npn => 'h2');
-$sid = new_stream($sess, { path => '/sp' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'HTTP/2.0', 'server_protocol variable - npn');
-
-}
-
-# $server_protocol - SSL/TLS connection, ALPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_alpn() or die; };
-skip 'OpenSSL ALPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, alpn => 'h2');
-$sid = new_stream($sess, { path => '/sp' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'HTTP/2.0', 'server_protocol variable - alpn');
-
-}
-
-# $scheme
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/scheme' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'http', 'scheme variable');
-
-# $scheme - SSL/TLS connection, NPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_npn() or die; };
-skip 'OpenSSL NPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, npn => 'h2');
-$sid = new_stream($sess, { path => '/scheme' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'https', 'scheme variable - npn');
-
-}
-
-# $scheme - SSL/TLS connection, ALPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_alpn() or die; };
-skip 'OpenSSL ALPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, alpn => 'h2');
-$sid = new_stream($sess, { path => '/scheme' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'https', 'scheme variable - alpn');
-
-}
-
-# $https
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/https' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, '', 'https variable');
-
-# $https - SSL/TLS connection, NPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_npn() or die; };
-skip 'OpenSSL NPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, npn => 'h2');
-$sid = new_stream($sess, { path => '/https' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'on', 'https variable - npn');
-
-}
-
-# $https - SSL/TLS connection, ALPN
-
-SKIP: {
-eval { IO::Socket::SSL->can_alpn() or die; };
-skip 'OpenSSL ALPN support required', 1 if $@;
-
-$sess = new_session(8084, SSL => 1, alpn => 'h2');
-$sid = new_stream($sess, { path => '/https' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{data}, 'on', 'https variable - alpn');
-
-}
-
 # http2_chunk_size=1
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/chunk_size' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/chunk_size' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 my @data = grep { $_->{type} eq "DATA" } @$frames;
 is(@data, 4, 'chunk_size frames');
@@ -1113,17 +382,17 @@ is(join(' ', map { $_->{flags} } @data), '0 0 0 1', 'chunk_size flags');
 
 # CONTINUATION
 
-$sess = new_session();
-$sid = new_stream($sess, { continuation => 1, headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ continuation => 1, headers => [
 	{ name => ':method', value => 'HEAD', mode => 1 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => ':authority', value => 'localhost', mode => 1 }]});
-h2_continue($sess, $sid, { continuation => 1, headers => [
+$s->h2_continue($sid, { continuation => 1, headers => [
 	{ name => 'x-foo', value => 'X-Bar', mode => 2 }]});
-h2_continue($sess, $sid, { headers => [
+$s->h2_continue($sid, { headers => [
 	{ name => 'referer', value => 'foo', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
 is($frame, undef, 'CONTINUATION - fragment 1');
@@ -1134,22 +403,22 @@ is($frame->{headers}->{'x-referer'}, 'foo', 'CONTINUATION - fragment 3');
 
 # CONTINUATION - in the middle of request header field
 
-$sess = new_session();
-$sid = new_stream($sess, { continuation => [ 2, 4, 1, 5 ], headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ continuation => [ 2, 4, 1, 5 ], headers => [
 	{ name => ':method', value => 'HEAD', mode => 1 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200, 'CONTINUATION - in header field');
 
 # CONTINUATION on a closed stream
 
-h2_continue($sess, 1, { headers => [
+$s->h2_continue(1, { headers => [
 	{ name => 'x-foo', value => 'X-Bar', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => 1, fin => 1 }]);
+$frames = $s->read(all => [{ sid => 1, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 is($frame->{type}, 'GOAWAY', 'GOAWAY - CONTINUATION closed stream');
@@ -1157,131 +426,46 @@ is($frame->{code}, 1, 'GOAWAY - CONTINUATION closed stream - PROTOCOL_ERROR');
 
 # frame padding
 
-$sess = new_session();
-$sid = new_stream($sess, { padding => 42, headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ padding => 42, headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200, 'padding - HEADERS status');
 
-$sid = new_stream($sess, { headers => [
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200, 'padding - next stream');
 
 # padding followed by CONTINUATION
 
-TODO: {
-local $TODO = 'not yet' unless $t->has_version('1.9.11');
-
-$sess = new_session();
-$sid = new_stream($sess, { padding => 42, continuation => [ 2, 4, 1, 5 ],
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ padding => 42, continuation => [ 2, 4, 1, 5 ],
 	headers => [
 	{ name => ':method', value => 'GET', mode => 1 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200, 'padding - CONTINUATION');
 
-}
-
-# request header field with multiple values
-
-# 8.1.2.5.  Compressing the Cookie Header Field
-#   To allow for better compression efficiency, the Cookie header field
-#   MAY be split into separate header fields <..>.
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/cookie', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'cookie', value => 'a=b', mode => 2},
-	{ name => 'cookie', value => 'c=d', mode => 2}]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-cookie-a'}, 'b',
-	'multiple request header fields - cookie');
-is($frame->{headers}->{'x-cookie-c'}, 'd',
-	'multiple request header fields - cookie 2');
-is($frame->{headers}->{'x-cookie'}, 'a=b; c=d',
-	'multiple request header fields - semi-colon');
-
-# request header field with multiple values to HTTP backend
-
-# 8.1.2.5.  Compressing the Cookie Header Field
-#   these MUST be concatenated into a single octet string
-#   using the two-octet delimiter of 0x3B, 0x20 (the ASCII string "; ")
-#   before being passed into a non-HTTP/2 context, such as an HTTP/1.1
-#   connection <..>
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/proxy/cookie', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'cookie', value => 'a=b', mode => 2 },
-	{ name => 'cookie', value => 'c=d', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-sent-cookie'}, 'a=b; c=d',
-	'multiple request header fields proxied - semi-colon');
-is($frame->{headers}->{'x-sent-cookie2'}, '',
-	'multiple request header fields proxied - dublicate cookie');
-is($frame->{headers}->{'x-sent-cookie-a'}, 'b',
-	'multiple request header fields proxied - cookie 1');
-is($frame->{headers}->{'x-sent-cookie-c'}, 'd',
-	'multiple request header fields proxied - cookie 2');
-
-# response header field with multiple values
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/set-cookie' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'set-cookie'}[0], 'a=b',
-	'multiple response header fields - cookie');
-is($frame->{headers}->{'set-cookie'}[1], 'c=d',
-	'multiple response header fields - cookie 2');
-
-# response header field with multiple values from HTTP backend
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy/set-cookie' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'set-cookie'}[0], 'a=b',
-	'multiple response header proxied - cookie');
-is($frame->{headers}->{'set-cookie'}[1], 'c=d',
-	'multiple response header proxied - cookie 2');
-is($frame->{headers}->{'x-uc-a'}, 'b',
-	'multiple response header proxied - upstream cookie');
-is($frame->{headers}->{'x-uc-c'}, 'd',
-	'multiple response header proxied - upstream cookie 2');
-
 # internal redirect
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/redirect' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/redirect' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 405, 'redirect - HEADERS');
@@ -1292,9 +476,9 @@ is($frame->{data}, 'body', 'redirect - DATA payload');
 
 # return 301 with absolute URI
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/return301_absolute' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/return301_absolute' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 301, 'return 301 absolute - status');
@@ -1302,56 +486,56 @@ is($frame->{headers}->{'location'}, 'text', 'return 301 absolute - location');
 
 # return 301 with relative URI
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/return301_relative' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/return301_relative' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 301, 'return 301 relative - status');
-is($frame->{headers}->{'location'}, 'http://127.0.0.1:8080/',
+is($frame->{headers}->{'location'}, 'http://localhost:' . port(8080) . '/',
 	'return 301 relative - location');
 
 # return 301 with relative URI and ':authority' request header field
 
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/return301_relative', mode => 2 },
 	{ name => ':authority', value => 'localhost', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 301,
 	'return 301 relative - authority - status');
-is($frame->{headers}->{'location'}, 'http://localhost:8080/',
+is($frame->{headers}->{'location'}, 'http://localhost:' . port(8080) . '/',
 	'return 301 relative - authority - location');
 
 # return 301 with relative URI and 'host' request header field
 
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/return301_relative', mode => 2 },
 	{ name => 'host', value => 'localhost', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 301,
 	'return 301 relative - host - status');
-is($frame->{headers}->{'location'}, 'http://localhost:8080/',
+is($frame->{headers}->{'location'}, 'http://localhost:' . port(8080) . '/',
 	'return 301 relative - host - location');
 
 # virtual host
 
-$sess = new_session(8085);
-$sid = new_stream($sess, { headers => [
+$s = Test::Nginx::HTTP2->new(port(8082));
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => 'host', value => 'localhost', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200,
@@ -1360,12 +544,12 @@ is($frame->{headers}->{':status'}, 200,
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
 is($frame->{data}, 'first', 'virtual host - host - DATA');
 
-$sid = new_stream($sess, { headers => [
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => ':authority', value => 'localhost', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200,
@@ -1376,12 +560,12 @@ is($frame->{data}, 'first', 'virtual host - authority - DATA');
 
 # virtual host - second
 
-$sid = new_stream($sess, { headers => [
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => 'host', value => 'localhost2', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200,
@@ -1390,12 +574,12 @@ is($frame->{headers}->{':status'}, 200,
 ($frame) = grep { $_->{type} eq "DATA" } @$frames;
 is($frame->{data}, 'second', 'virtual host 2 - host - DATA');
 
-$sid = new_stream($sess, { headers => [
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/', mode => 0 },
 	{ name => ':authority', value => 'localhost2', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200,
@@ -1406,14 +590,14 @@ is($frame->{data}, 'second', 'virtual host 2 - authority - DATA');
 
 # gzip tests for internal nginx version
 
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET', mode => 0 },
 	{ name => ':scheme', value => 'http', mode => 0 },
 	{ name => ':path', value => '/gzip.html' },
 	{ name => ':authority', value => 'localhost', mode => 1 },
 	{ name => 'accept-encoding', value => 'gzip' }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{'content-encoding'}, 'gzip', 'gzip - encoding');
@@ -1424,567 +608,64 @@ gunzip_like($frame->{data}, qr/^SEE-THIS\Z/, 'gzip - DATA');
 
 # charset
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/charset' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/charset' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{'content-type'}, 'text/plain; charset=utf-8', 'charset');
 
-# simple proxy cache test
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/cache/t4.html' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, '200', 'proxy cache');
-
-my $etag = $frame->{headers}->{'etag'};
-
-($frame) = grep { $_->{type} eq "DATA" } @$frames;
-is($frame->{length}, length 'SEE-THIS', 'proxy cache - DATA');
-is($frame->{data}, 'SEE-THIS', 'proxy cache - DATA payload');
-
-$t->write_file('t4.html', 'NOOP');
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/cache/t4.html' },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'if-none-match', value => $etag }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 304, 'proxy cache conditional');
-
-# HEADERS could be received with fin, followed by DATA
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/cache/t2.html?1', method => 'HEAD' });
-
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-push @$frames, $_ for @{h2_read($sess, all => [{ sid => $sid }])};
-ok(!grep ({ $_->{type} eq "DATA" } @$frames), 'proxy cache HEAD - no body');
-
-# proxy cache - expect no stray empty DATA frame
-
-TODO: {
-local $TODO = 'not yet';
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/cache/t2.html?2' });
-
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-@data = grep ({ $_->{type} eq "DATA" } @$frames);
-is(@data, 1, 'proxy cache write - data frames');
-is(join(' ', map { $_->{data} } @data), 'SEE-THIS', 'proxy cache write - data');
-is(join(' ', map { $_->{flags} } @data), '1', 'proxy cache write - flags');
-
-}
-
-# HEAD on empty cache with proxy_buffering off
-
-$sess = new_session();
-$sid = new_stream($sess,
-	{ path => '/proxy_buffering_off/t2.html?1', method => 'HEAD' });
-
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-push @$frames, $_ for @{h2_read($sess, all => [{ sid => $sid }])};
-ok(!grep ({ $_->{type} eq "DATA" } @$frames),
-	'proxy cache HEAD buffering off - no body');
-
-# request body (uses proxied response)
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy2/t2.html', body_more => 1 });
-h2_body($sess, 'TEST');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TEST', 'request body');
-
-# request body with padding (uses proxied response)
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy2/t2.html', body_more => 1 });
-h2_body($sess, 'TEST', { body_padding => 42 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TEST',
-	'request body with padding');
-
-$sid = new_stream($sess);
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, '200', 'request body with padding - next');
-
-# request body sent in multiple DATA frames (uses proxied response)
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy2/t2.html', body_more => 1 });
-h2_body($sess, 'TEST', { body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TEST',
-	'request body in multiple frames');
-
-# request body with an empty DATA frame
-# "zero size buf in output" alerts seen
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy2/', body_more => 1 });
-h2_body($sess, '');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'request body - empty');
-
-TODO: {
-local $TODO = 'not yet';
-
-ok($frame->{headers}{'x-body-file'}, 'request body - empty body file');
-
-}
-
-TODO: {
-todo_skip 'empty body file', 1 unless $frame->{headers}{'x-body-file'};
-
-is(read_body_file($frame->{headers}{'x-body-file'}), '',
-	'request body - empty content');
-
-}
-
-# same as above but proxied to ssl backend
-
-TODO: {
-local $TODO = 'not yet';
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy_ssl/', body_more => 1 });
-h2_body($sess, '');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'request body - empty - proxy ssl');
-
-}
-
-# request body delayed in limit_req
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy_limit_req/', body_more => 1 });
-h2_body($sess, 'TEST');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TEST',
-	'request body - limit req');
-
-# request body delayed in limit_req - with an empty DATA frame
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy_limit_req/', body_more => 1 });
-h2_body($sess, '');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'request body - limit req - empty');
-
-# predict send windows
-
-$sid = new_stream($sess);
-my ($maxwin) = sort {$a <=> $b} $sess->{streams}{$sid}, $sess->{conn_window};
-
-SKIP: {
-skip 'leaves coredump', 1 unless $t->has_version('1.9.7');
-skip 'not enough window', 1 if $maxwin < 5;
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/proxy_limit_req/', body => 'TEST2' });
-select undef, undef, undef, 1.1;
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TEST2',
-	'request body - limit req 2');
-
-}
-
-# partial request body data frame received (to be discarded) within request
-# delayed in limit_req, the rest of data frame is received after response
-
-$sess = new_session();
-
-SKIP: {
-skip 'not enough window', 1 if $maxwin < 4;
-
-TODO: {
-todo_skip 'use-after-free', 1 unless $ENV{TEST_NGINX_UNSAFE}
-	or $t->has_version('1.9.12');
-
-$sid = new_stream($sess, { path => '/limit_req', body => 'TEST', split => [61],
-	split_delay => 1.1 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, '200', 'discard body - limit req - limited');
-
-}
-
-}
-
-$sid = new_stream($sess, { path => '/' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, '200', 'discard body - limit req - next');
-
-# ditto, but instead of receiving the rest of data frame, connection is closed
-# 'http request already closed while closing request' alert can be produced
-
-SKIP: {
-skip 'not enough window', 1 if $maxwin < 4;
-
-TODO: {
-todo_skip 'use-after-free', 1 unless $ENV{TEST_NGINX_UNSAFE}
-	or $t->has_version('1.9.12');
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/limit_req', body => 'TEST', split => [61],
-	abort => 1 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, '200', 'discard body - limit req - eof');
-
-select undef, undef, undef, 1.1;
-undef $sess;
-
-}
-
-}
-
 # partial request header frame received (field split),
 # the rest of frame is received after client header timeout
 
-TODO: {
-local $TODO = 'not yet' unless $t->has_version('1.9.12');
-
-$sess = new_session(8093);
-$sid = new_stream($sess, { path => '/t2.html', split => [35],
+$s = Test::Nginx::HTTP2->new(port(8087));
+$sid = $s->new_stream({ path => '/t2.html', split => [35],
 	split_delay => 2.1 });
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
+$frames = $s->read(all => [{ type => 'RST_STREAM' }]);
 
 ($frame) = grep { $_->{type} eq "RST_STREAM" } @$frames;
 ok($frame, 'client header timeout');
 is($frame->{code}, 1, 'client header timeout - protocol error');
 
-}
-
-h2_ping($sess, 'SEE-THIS');
-$frames = h2_read($sess, all => [{ type => 'PING' }]);
+$s->h2_ping('SEE-THIS');
+$frames = $s->read(all => [{ type => 'PING' }]);
 
 ($frame) = grep { $_->{type} eq "PING" && $_->{flags} & 0x1 } @$frames;
 ok($frame, 'client header timeout - PING');
 
 # partial request body data frame received, the rest is after body timeout
 
-TODO: {
-local $TODO = 'not yet' unless $t->has_version('1.9.12');
-
-$sess = new_session(8093);
-$sid = new_stream($sess, { path => '/proxy/t2.html', body_more => 1 });
-h2_body($sess, 'TEST', { split => [10], split_delay => 2.1 });
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
+$s = Test::Nginx::HTTP2->new(port(8087));
+$sid = $s->new_stream({ path => '/proxy/t2.html', body_more => 1 });
+$s->h2_body('TEST', { split => [10], split_delay => 2.1 });
+$frames = $s->read(all => [{ type => 'RST_STREAM' }]);
 
 ($frame) = grep { $_->{type} eq "RST_STREAM" } @$frames;
 ok($frame, 'client body timeout');
 is($frame->{code}, 1, 'client body timeout - protocol error');
 
-}
-
-h2_ping($sess, 'SEE-THIS');
-$frames = h2_read($sess, all => [{ type => 'PING' }]);
+$s->h2_ping('SEE-THIS');
+$frames = $s->read(all => [{ type => 'PING' }]);
 
 ($frame) = grep { $_->{type} eq "PING" && $_->{flags} & 0x1 } @$frames;
 ok($frame, 'client body timeout - PING');
 
-# malformed request body length not equal to content-length
-
-$sess = new_session();
-$sid = new_stream($sess,
-	{ path => '/proxy2/t2.html', body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/client_max_body_size', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'content-length', value => '5', mode => 1 }]});
-h2_body($sess, 'TEST');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 400, 'request body less than content-length');
-
-$sid = new_stream($sess,
-	{ path => '/proxy2/t2.html', body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/client_max_body_size', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'content-length', value => '3', mode => 1 }]});
-h2_body($sess, 'TEST');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 400, 'request body more than content-length');
-
-# client_max_body_size
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST12');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'client_max_body_size - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST12',
-	'client_max_body_size - body');
-
-# client_max_body_size - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST123');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413, 'client_max_body_size - limited');
-
-# client_max_body_size - many DATA frames
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST12', { body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'client_max_body_size many - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST12',
-	'client_max_body_size many - body');
-
-# client_max_body_size - many DATA frames - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST123', { body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413, 'client_max_body_size many - limited');
-
-# client_max_body_size - padded DATA
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST12', { body_padding => 42 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200, 'client_max_body_size pad - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST12',
-	'client_max_body_size pad - body');
-
-# client_max_body_size - padded DATA - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST123', { body_padding => 42 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413, 'client_max_body_size pad - limited');
-
-# client_max_body_size - many padded DATA frames
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST12', { body_padding => 42, body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'client_max_body_size many pad - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST12',
-	'client_max_body_size many pad - body');
-
-# client_max_body_size - many padded DATA frames - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/client_max_body_size/t2.html',
-	body_more => 1 });
-h2_body($sess, 'TESTTEST123', { body_padding => 42, body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413,
-	'client_max_body_size many pad - limited');
-
-# request body without content-length
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST12');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'request body without content-length - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST12',
-	'request body without content-length - body');
-
-# request body without content-length - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST123');
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413,
-	'request body without content-length - limited');
-
-# request body without content-length - many DATA frames
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST12', { body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'request body without content-length many - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST12',
-	'request body without content-length many - body');
-
-# request body without content-length - many DATA frames - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST123', { body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413,
-	'request body without content-length many - limited');
-
-# request body without content-length - padding
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST12', { body_padding => 42 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'request body without content-length pad - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST12',
-	'request body without content-length pad - body');
-
-# request body without content-length - padding - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST123', { body_padding => 42 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413,
-	'request body without content-length pad - limited');
-
-# request body without content-length - padding with many DATA frames
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST', { body_padding => 42, body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 200,
-	'request body without content-length many pad - status');
-is(read_body_file($frame->{headers}->{'x-body-file'}), 'TESTTEST',
-	'request body without content-length many pad - body');
-
-# request body without content-length - padding with many DATA frames - limited
-
-$sess = new_session();
-$sid = new_stream($sess, { body_more => 1, headers => [
-	{ name => ':method', value => 'GET', mode => 2 },
-	{ name => ':scheme', value => 'http', mode => 2 },
-	{ name => ':path', value => '/client_max_body_size', mode => 2 },
-	{ name => ':authority', value => 'localhost', mode => 2 }]});
-h2_body($sess, 'TESTTEST123', { body_padding => 42, body_split => [2] });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 413,
-	'request body without content-length many pad - limited');
-
 # proxied request with logging pristine request header field (e.g., referer)
 
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET' },
 	{ name => ':scheme', value => 'http' },
 	{ name => ':path', value => '/proxy2/' },
 	{ name => ':authority', value => 'localhost' },
 	{ name => 'referer', value => 'foo' }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200, 'proxy with logging request headers');
 
-$sid = new_stream($sess);
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$sid = $s->new_stream();
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 ok($frame->{headers}, 'proxy with logging request headers - next');
@@ -1996,9 +677,9 @@ ok($frame->{headers}, 'proxy with logging request headers - next');
 #   created with an initial flow-control window size of 65,535 octets.
 #   The connection flow-control window is also 65,535 octets.
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/t1.html' });
-$frames = h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/t1.html' });
+$frames = $s->read(all => [{ sid => $sid, length => 2**16 - 1 }]);
 
 # with the default http2_chunk_size, data is divided into 8 data frames
 
@@ -2007,18 +688,18 @@ my $lengths = join ' ', map { $_->{length} } @data;
 is($lengths, '8192 8192 8192 8192 8192 8192 8192 8191',
 	'iws - stream blocked on initial window size');
 
-h2_ping($sess, 'SEE-THIS');
-$frames = h2_read($sess, all => [{ type => 'PING' }]);
+$s->h2_ping('SEE-THIS');
+$frames = $s->read(all => [{ type => 'PING' }]);
 
 ($frame) = grep { $_->{type} eq "PING" && $_->{flags} & 0x1 } @$frames;
 ok($frame, 'iws - PING not blocked');
 
-h2_window($sess, 2**16, $sid);
-$frames = h2_read($sess);
+$s->h2_window(2**16, $sid);
+$frames = $s->read(wait => 0.2);
 is(@$frames, 0, 'iws - updated stream window');
 
-h2_window($sess, 2**16);
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s->h2_window(2**16);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 @data = grep { $_->{type} eq "DATA" } @$frames;
 my $sum = eval join '+', map { $_->{length} } @data;
@@ -2032,12 +713,12 @@ is($sum, 81, 'iws - updated connection window');
 #   frame that forms part of the connection preface.  The connection
 #   flow-control window can only be changed using WINDOW_UPDATE frames.
 
-$sess = new_session();
-h2_settings($sess, 0, 0x4 => 2**17);
-h2_window($sess, 2**17);
+$s = Test::Nginx::HTTP2->new();
+$s->h2_settings(0, 0x4 => 2**17);
+$s->h2_window(2**17);
 
-$sid = new_stream($sess, { path => '/t1.html' });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$sid = $s->new_stream({ path => '/t1.html' });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 @data = grep { $_->{type} eq "DATA" } @$frames;
 $sum = eval join '+', map { $_->{length} } @data;
@@ -2052,15 +733,15 @@ is($sum, 2**16 + 80, 'iws - increased');
 #   controlled frames until it receives WINDOW_UPDATE frames that cause
 #   the flow-control window to become positive.
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/t1.html' });
+$s->read(all => [{ sid => $sid, length => 2**16 - 1 }]);
 
-h2_window($sess, 1);
-h2_settings($sess, 0, 0x4 => 42);
-h2_window($sess, 1024, $sid);
+$s->h2_window(1);
+$s->h2_settings(0, 0x4 => 42);
+$s->h2_window(1024, $sid);
 
-$frames = h2_read($sess, all => [{ type => 'SETTINGS' }]);
+$frames = $s->read(all => [{ type => 'SETTINGS' }]);
 
 ($frame) = grep { $_->{type} eq 'SETTINGS' } @$frames;
 ok($frame, 'negative window - SETTINGS frame ack');
@@ -2071,14 +752,14 @@ is($frame, undef, 'negative window - no data');
 
 # predefined window size, minus new iws settings, minus window update
 
-h2_window($sess, 2**16 - 1 - 42 - 1024, $sid);
+$s->h2_window(2**16 - 1 - 42 - 1024, $sid);
 
-$frames = h2_read($sess);
+$frames = $s->read(wait => 0.2);
 is(@$frames, 0, 'zero window - no data');
 
-h2_window($sess, 1, $sid);
+$s->h2_window(1, $sid);
 
-$frames = h2_read($sess, all => [{ sid => $sid, length => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, length => 1 }]);
 is(@$frames, 1, 'positive window');
 
 SKIP: {
@@ -2091,13 +772,13 @@ is(@$frames[0]->{length}, 1, 'positive window - data length');
 
 # ask write handler in sending large response
 
-$sid = new_stream($sess, { path => '/tbig.html' });
+$sid = $s->new_stream({ path => '/tbig.html' });
 
-h2_window($sess, 2**30, $sid);
-h2_window($sess, 2**30);
+$s->h2_window(2**30, $sid);
+$s->h2_window(2**30);
 
 sleep 1;
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200, 'large response - HEADERS');
@@ -2107,414 +788,88 @@ $sum = eval join '+', map { $_->{length} } @data;
 is($sum, 5000000, 'large response - DATA');
 
 # Make sure http2 write handler doesn't break a connection.
-# Some buggy systems tolerate ill-use of writev() triggered by write handler,
-# while others, such as darwin and NetBSD, follow POSIX strictly, which causes
-# a connection to close in nginx.  While this also breaks the 'no alerts' test,
-# it doesn't suit well, because error.log is currently polluted with much more
-# alerts due to other various bugs in ngx_http_v2_module.  We catch it here in
-# a separate test as well to make it clear.
 
-SKIP: {
-skip 'tolerant operating system', 1 unless $^O eq 'darwin' or $^O eq 'netbsd';
-
-TODO: {
-local $TODO = 'not yet';
-
-$sid = new_stream($sess);
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$sid = $s->new_stream();
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{headers}->{':status'}, 200, 'new stream after large response');
 
-}
-
-}
-
 # write event send timeout
 
-$sess = new_session(8091);
-$sid = new_stream($sess, { path => '/tbig.html' });
-h2_window($sess, 2**30, $sid);
-h2_window($sess, 2**30);
+$s = Test::Nginx::HTTP2->new(port(8086));
+$sid = $s->new_stream({ path => '/tbig.html' });
+$s->h2_window(2**30, $sid);
+$s->h2_window(2**30);
 
 select undef, undef, undef, 2.1;
 
-h2_ping($sess, 'SEE-THIS');
+$s->h2_ping('SEE-THIS');
 
-$frames = h2_read($sess, all => [{ type => 'PING' }]);
+$frames = $s->read(all => [{ type => 'PING' }]);
 ok(!grep ({ $_->{type} eq "PING" } @$frames), 'large response - send timeout');
 
 # stream with large response queued on write - RST_STREAM handling
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/tbig.html' });
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/tbig.html' });
 
-h2_window($sess, 2**30, $sid);
-h2_window($sess, 2**30);
+$s->h2_window(2**30, $sid);
+$s->h2_window(2**30);
 
 select undef, undef, undef, 0.4;
 
-h2_rst($sess, $sid, 8);
-h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s->h2_rst($sid, 8);
+$s->read(all => [{ sid => $sid, fin => 1 }], wait => 0.2);
 
-$sid = new_stream($sess);
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$sid = $s->new_stream();
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
 is($frame->{sid}, 3, 'large response - queued with RST_STREAM');
 
 # SETTINGS_MAX_FRAME_SIZE
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/frame_size' });
-h2_window($sess, 2**18, 1);
-h2_window($sess, 2**18);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/frame_size' });
+$s->h2_window(2**18, 1);
+$s->h2_window(2**18);
 
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 @data = grep { $_->{type} eq "DATA" } @$frames;
 is($data[0]->{length}, 2**14, 'max frame size - default');
 
-$sess = new_session();
-h2_settings($sess, 0, 0x5 => 2**15);
-$sid = new_stream($sess, { path => '/frame_size' });
-h2_window($sess, 2**18, 1);
-h2_window($sess, 2**18);
+$s = Test::Nginx::HTTP2->new();
+$s->h2_settings(0, 0x5 => 2**15);
+$sid = $s->new_stream({ path => '/frame_size' });
+$s->h2_window(2**18, 1);
+$s->h2_window(2**18);
 
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 @data = grep { $_->{type} eq "DATA" } @$frames;
 is($data[0]->{length}, 2**15, 'max frame size - custom');
 
-# CONTINUATION in response
-# put three long header fields (not less than SETTINGS_MAX_FRAME_SIZE/2)
-# to break header block into separate frames, one such field per frame
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/continuation?h=' . 'x' x 2**13 });
-
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 0x4 }]);
-@data = grep { $_->{type} =~ "HEADERS|CONTINUATION" } @$frames;
-is(@{$data[-1]->{headers}{'x-longheader'}}, 3,
-	'response CONTINUATION - headers');
-is($data[-1]->{headers}{'x-longheader'}[0], 'x' x 2**13,
-	'response CONTINUATION - header 1');
-is($data[-1]->{headers}{'x-longheader'}[1], 'x' x 2**13,
-	'response CONTINUATION - header 2');
-is($data[-1]->{headers}{'x-longheader'}[2], 'x' x 2**13,
-	'response CONTINUATION - header 3');
-@data = sort { $a <=> $b } map { $_->{length} } @data;
-cmp_ok($data[-1], '<=', 2**14, 'response CONTINUATION - max frame size');
-
-# same but without response DATA frames
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/continuation/204?h=' . 'x' x 2**13 });
-
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 0x4 }]);
-@data = grep { $_->{type} =~ "HEADERS|CONTINUATION" } @$frames;
-is(@{$data[-1]->{headers}{'x-longheader'}}, 3,
-	'no body CONTINUATION - headers');
-is($data[-1]->{headers}{'x-longheader'}[0], 'x' x 2**13,
-	'no body CONTINUATION - header 1');
-is($data[-1]->{headers}{'x-longheader'}[1], 'x' x 2**13,
-	'no body CONTINUATION - header 2');
-is($data[-1]->{headers}{'x-longheader'}[2], 'x' x 2**13,
-	'no body CONTINUATION - header 3');
-@data = sort { $a <=> $b } map { $_->{length} } @data;
-cmp_ok($data[-1], '<=', 2**14, 'no body CONTINUATION - max frame size');
-
-# response header block is always split by SETTINGS_MAX_FRAME_SIZE
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/continuation?h=' . 'x' x 2**15 });
-
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 0x4 }]);
-@data = grep { $_->{type} =~ "HEADERS|CONTINUATION" } @$frames;
-@data = sort { $a <=> $b } map { $_->{length} } @data;
-cmp_ok($data[-1], '<=', 2**14, 'response header frames limited');
-
-# response header frame sent in parts
-
-TODO: {
-local $TODO = 'not yet' unless $t->has_version('1.9.7');
-
-$sess = new_session(8092);
-h2_settings($sess, 0, 0x5 => 2**17);
-
-$sid = new_stream($sess, { path => '/frame_size?h=' . 'x' x 2**15 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 0x4 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-ok($frame, 'response header - parts');
-
-SKIP: {
-skip 'response header failed', 1 unless $frame;
-
-is(length join('', @{$frame->{headers}->{'x-longheader'}}), 98304,
-	'response header - headers');
-
-}
-
-# response header block split and sent in parts
-
-$sess = new_session(8092);
-$sid = new_stream($sess, { path => '/continuation?h=' . 'x' x 2**15 });
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 0x4 }]);
-
-@data = grep { $_->{type} =~ "HEADERS|CONTINUATION" } @$frames;
-($lengths) = sort { $b <=> $a } map { $_->{length} } @data;
-cmp_ok($lengths, '<=', 16384, 'response header split - max size');
-
-is(length join('', @{@$frames[-1]->{headers}->{'x-longheader'}}), 98304,
-	'response header split - headers');
-
-}
-
-# max_field_size - header field name
-
-$sess = new_session(8087);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname10' x 2 . 'x', value => 'value', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'field name size less');
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname10' x 2 . 'x', value => 'value', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'field name size second');
-
-$sess = new_session(8087);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname10' x 2 . 'xx', value => 'value', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'field name size equal');
-
-$sess = new_session(8087);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname10' x 2 . 'xxx', value => 'value', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-is($frame, undef, 'field name size greater');
-
-# max_field_size - header field value
-
-$sess = new_session(8087);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'name', value => 'valu5' x 4 . 'x', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'field value size less');
-
-$sess = new_session(8087);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'name', value => 'valu5' x 4 . 'xx', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'field value size equal');
-
-$sess = new_session(8087);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'name', value => 'valu5' x 4 . 'xxx', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-is($frame, undef, 'field value size greater');
-
-# max_header_size
-
-$sess = new_session(8088);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname9', value => 'x', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'header size less');
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname9', value => 'x', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'header size second');
-
-$sess = new_session(8088);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname9', value => 'xx', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'header size equal');
-
-$sess = new_session(8088);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname9', value => 'xxx', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-is($frame, undef, 'header size greater');
-
-# header size is based on (decompressed) header list
-# two extra 1-byte indices would otherwise fit in max_header_size
-
-$sess = new_session(8088);
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname9', value => 'x', mode => 2 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'header size new index');
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname9', value => 'x', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'DATA' } @$frames;
-ok($frame, 'header size indexed');
-
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/t2.html', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'longname9', value => 'x', mode => 0 },
-	{ name => 'longname9', value => 'x', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq 'GOAWAY' } @$frames;
-is($frame->{code}, 0xb, 'header size indexed greater');
-
-# HPACK table boundary
-
-$sess = new_session();
-h2_read($sess, all => [{ sid => new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => '', mode => 0 },
-	{ name => 'x' x 2016, value => 'x' x 2048, mode => 2 }]}), fin => 1 }]);
-$frames = h2_read($sess, all => [{ sid => new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => '', mode => 0 },
-	{ name => 'x' x 2016, value => 'x' x 2048, mode => 0 }]}), fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-ok($frame, 'HPACK table boundary');
-
-h2_read($sess, all => [{ sid => new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => '', mode => 0 },
-	{ name => 'x' x 33, value => 'x' x 4031, mode => 2 }]}), fin => 1 }]);
-$frames = h2_read($sess, all => [{ sid => new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => '', mode => 0 },
-	{ name => 'x' x 33, value => 'x' x 4031, mode => 0 }]}), fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-ok($frame, 'HPACK table boundary - header field name');
-
-h2_read($sess, all => [{ sid => new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => '', mode => 0 },
-	{ name => 'x', value => 'x' x 64, mode => 2 }]}), fin => 1 }]);
-$frames = h2_read($sess, all => [{ sid => new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => '', mode => 0 },
-	{ name => 'x', value => 'x' x 64, mode => 0 }]}), fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-ok($frame, 'HPACK table boundary - header field value');
-
 # stream multiplexing + WINDOW_UPDATE
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/t1.html' });
-$frames = h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/t1.html' });
+$frames = $s->read(all => [{ sid => $sid, length => 2**16 - 1 }]);
 
 @data = grep { $_->{type} eq "DATA" } @$frames;
 $sum = eval join '+', map { $_->{length} } @data;
 is($sum, 2**16 - 1, 'multiple - stream1 data');
 
-my $sid2 = new_stream($sess, { path => '/t1.html' });
-$frames = h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
+my $sid2 = $s->new_stream({ path => '/t1.html' });
+$frames = $s->read(all => [{ sid => $sid2, fin => 0x4 }]);
 
 @data = grep { $_->{type} eq "DATA" } @$frames;
 is(@data, 0, 'multiple - stream2 no data');
 
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
+$s->h2_window(2**17, $sid);
+$s->h2_window(2**17, $sid2);
+$s->h2_window(2**17);
 
-$frames = h2_read($sess, all => [
+$frames = $s->read(all => [
 	{ sid => $sid, fin => 1 },
 	{ sid => $sid2, fin => 1 }
 ]);
@@ -2527,454 +882,24 @@ is($sum, 81, 'multiple - stream1 remain data');
 $sum = eval join '+', map { $_->{length} } @data;
 is($sum, 2**16 + 80, 'multiple - stream2 full data');
 
-# stream muliplexing + PRIORITY frames
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_priority($sess, 0, $sid);
-h2_priority($sess, 255, $sid2);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 }
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-is(join(' ', map { $_->{sid} } @data), "$sid2 $sid", 'weight - PRIORITY 1');
-
-# and vice versa
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_priority($sess, 255, $sid);
-h2_priority($sess, 0, $sid2);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 }
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-is(join(' ', map { $_->{sid} } @data), "$sid $sid2", 'weight - PRIORITY 2');
-
-# stream muliplexing + HEADERS PRIORITY flag
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/t1.html', prio => 0 });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html', prio => 255 });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 }
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-my $sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid2 $sid", 'weight - HEADERS PRIORITY 1');
-
-# and vice versa
-
-$sess = new_session();
-$sid = new_stream($sess, { path => '/t1.html', prio => 255 });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html', prio => 0 });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 }
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-$sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid $sid2", 'weight - HEADERS PRIORITY 2');
-
-# 5.3.1.  Stream Dependencies
-
-# PRIORITY frame
-
-$sess = new_session();
-
-h2_priority($sess, 16, 3, 0);
-h2_priority($sess, 16, 1, 3);
-
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 },
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-$sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid2 $sid", 'dependency - PRIORITY 1');
-
-# and vice versa
-
-$sess = new_session();
-
-h2_priority($sess, 16, 1, 0);
-h2_priority($sess, 16, 3, 1);
-
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 },
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-$sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid $sid2", 'dependency - PRIORITY 2');
-
-# PRIORITY - self dependency
-
-# 5.3.1.  Stream Dependencies
-#   A stream cannot depend on itself.  An endpoint MUST treat this as a
-#   stream error of type PROTOCOL_ERROR.
-
-$sess = new_session();
-$sid = new_stream($sess);
-h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-h2_priority($sess, 0, $sid, $sid);
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
-
-($frame) = grep { $_->{type} eq "RST_STREAM" } @$frames;
-is($frame->{sid}, $sid, 'dependency - PRIORITY self - RST_STREAM');
-is($frame->{code}, 1, 'dependency - PRIORITY self - PROTOCOL_ERROR');
-
-# HEADERS PRIORITY flag, reprioritize prior PRIORITY frame records
-
-$sess = new_session();
-
-h2_priority($sess, 16, 1, 0);
-h2_priority($sess, 16, 3, 0);
-
-$sid = new_stream($sess, { path => '/t1.html', dep => 3 });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 },
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-$sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid2 $sid", 'dependency - HEADERS PRIORITY 1');
-
-# and vice versa
-
-$sess = new_session();
-
-h2_priority($sess, 16, 1, 0);
-h2_priority($sess, 16, 3, 0);
-
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html', dep => 1 });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-h2_window($sess, 2**17, $sid);
-h2_window($sess, 2**17, $sid2);
-h2_window($sess, 2**17);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 },
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-$sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid $sid2", 'dependency - HEADERS PRIORITY 2');
-
-# HEADERS - self dependency
-
-$sess = new_session();
-$sid = new_stream($sess, { dep => 1 });
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
-
-($frame) = grep { $_->{type} eq "RST_STREAM" } @$frames;
-is($frame->{sid}, $sid, 'dependency - HEADERS self - RST_STREAM');
-is($frame->{code}, 1, 'dependency - HEADERS self - PROTOCOL_ERROR');
-
-# PRIORITY frame, weighted dependencies
-
-$sess = new_session();
-
-h2_priority($sess, 16, 5, 0);
-h2_priority($sess, 255, 1, 5);
-h2_priority($sess, 0, 3, 5);
-
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-my $sid3 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid3, fin => 0x4 }]);
-
-h2_window($sess, 2**16, 1);
-h2_window($sess, 2**16, 3);
-h2_window($sess, 2**16, 5);
-h2_window($sess, 2**16);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 },
-	{ sid => $sid3, fin => 1 },
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-$sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid3 $sid $sid2", 'weighted dependency - PRIORITY 1');
-
-# and vice versa
-
-$sess = new_session();
-
-h2_priority($sess, 16, 5, 0);
-h2_priority($sess, 0, 1, 5);
-h2_priority($sess, 255, 3, 5);
-
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid2, fin => 0x4 }]);
-
-$sid3 = new_stream($sess, { path => '/t2.html' });
-h2_read($sess, all => [{ sid => $sid3, fin => 0x4 }]);
-
-h2_window($sess, 2**16, 1);
-h2_window($sess, 2**16, 3);
-h2_window($sess, 2**16, 5);
-h2_window($sess, 2**16);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 },
-	{ sid => $sid3, fin => 1 },
-]);
-
-@data = grep { $_->{type} eq "DATA" } @$frames;
-$sids = join ' ', map { $_->{sid} } @data;
-is($sids, "$sid3 $sid2 $sid", 'weighted dependency - PRIORITY 2');
-
-# PRIORITY - reprioritization with circular dependency - after [3] removed
-# initial dependency tree:
-# 1 <- [3] <- 5
-
-$sess = new_session();
-
-h2_window($sess, 2**18);
-
-h2_priority($sess, 16, 1, 0);
-h2_priority($sess, 16, 3, 1);
-h2_priority($sess, 16, 5, 3);
-
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid2, length => 2**16 - 1 }]);
-
-$sid3 = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid3, length => 2**16 - 1 }]);
-
-h2_window($sess, 2**16, $sid2);
-
-$frames = h2_read($sess, all => [{ sid => $sid2, fin => 1 }]);
-$sids = join ' ', map { $_->{sid} } grep { $_->{type} eq "DATA" } @$frames;
-is($sids, $sid2, 'removed dependency');
-
-for (1 .. 40) {
-	h2_read($sess, all => [{ sid => new_stream($sess), fin => 1 }]);
-}
-
-# make circular dependency
-# 1 <- 5 -- current dependency tree before reprioritization
-# 5 <- 1
-# 1 <- 5
-
-h2_priority($sess, 16, 1, 5);
-h2_priority($sess, 16, 5, 1);
-
-h2_window($sess, 2**16, $sid);
-h2_window($sess, 2**16, $sid3);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid3, fin => 1 },
-]);
-
-($frame) = grep { $_->{type} eq "DATA" && $_->{sid} == $sid } @$frames;
-is($frame->{length}, 81, 'removed dependency - first stream');
-
-($frame) = grep { $_->{type} eq "DATA" && $_->{sid} == $sid3 } @$frames;
-is($frame->{length}, 81, 'removed dependency - last stream');
-
-# PRIORITY - reprioritization with circular dependency - exclusive [5]
-# 1 <- [5] <- 3
-
-$sess = new_session();
-
-h2_window($sess, 2**18);
-
-h2_priority($sess, 16, 1, 0);
-h2_priority($sess, 16, 3, 1);
-h2_priority($sess, 16, 5, 1, excl => 1);
-
-$sid = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid, length => 2**16 - 1 }]);
-
-$sid2 = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid2, length => 2**16 - 1 }]);
-
-$sid3 = new_stream($sess, { path => '/t1.html' });
-h2_read($sess, all => [{ sid => $sid3, length => 2**16 - 1 }]);
-
-h2_window($sess, 2**16, $sid);
-
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-$sids = join ' ', map { $_->{sid} } grep { $_->{type} eq "DATA" } @$frames;
-is($sids, $sid, 'exclusive dependency - parent removed');
-
-# make circular dependency
-# 5 <- 3 -- current dependency tree before reprioritization
-# 3 <- 5
-
-h2_priority($sess, 16, 5, 3);
-
-h2_window($sess, 2**16, $sid2);
-h2_window($sess, 2**16, $sid3);
-
-$frames = h2_read($sess, all => [
-	{ sid => $sid2, fin => 1 },
-	{ sid => $sid3, fin => 1 },
-]);
-
-($frame) = grep { $_->{type} eq "DATA" && $_->{sid} == $sid2 } @$frames;
-is($frame->{length}, 81, 'exclusive dependency - first stream');
-
-($frame) = grep { $_->{type} eq "DATA" && $_->{sid} == $sid3 } @$frames;
-is($frame->{length}, 81, 'exclusive dependency - last stream');
-
-# limit_conn
-
-$sess = new_session();
-h2_settings($sess, 0, 0x4 => 1);
-
-$sid = new_stream($sess, { path => '/t3.html' });
-$frames = h2_read($sess, all => [{ sid => $sid, length => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" && $_->{sid} == $sid } @$frames;
-is($frame->{headers}->{':status'}, 200, 'limit_conn first stream');
-
-$sid2 = new_stream($sess, { path => '/t3.html' });
-$frames = h2_read($sess, all => [{ sid => $sid2, fin => 0 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" && $_->{sid} == $sid2 } @$frames;
-is($frame->{headers}->{':status'}, 503, 'limit_conn rejected');
-
-h2_settings($sess, 0, 0x4 => 2**16);
-
-h2_read($sess, all => [
-	{ sid => $sid, fin => 1 },
-	{ sid => $sid2, fin => 1 }
-]);
-
-# limit_conn + client's RST_STREAM
-
-$sess = new_session();
-h2_settings($sess, 0, 0x4 => 1);
-
-$sid = new_stream($sess, { path => '/t3.html' });
-$frames = h2_read($sess, all => [{ sid => $sid, length => 1 }]);
-h2_rst($sess, $sid, 5);
-
-($frame) = grep { $_->{type} eq "HEADERS" && $_->{sid} == $sid } @$frames;
-is($frame->{headers}->{':status'}, 200, 'RST_STREAM 1');
-
-$sid2 = new_stream($sess, { path => '/t3.html' });
-$frames = h2_read($sess, all => [{ sid => $sid2, fin => 0 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" && $_->{sid} == $sid2 } @$frames;
-is($frame->{headers}->{':status'}, 200, 'RST_STREAM 2');
-
 # http2_max_concurrent_streams
 
-$sess = new_session(8086, pure => 1);
-$frames = h2_read($sess, all => [{ type => 'SETTINGS' }]);
+$s = Test::Nginx::HTTP2->new(port(8083), pure => 1);
+$frames = $s->read(all => [{ type => 'SETTINGS' }]);
 
 ($frame) = grep { $_->{type} eq 'SETTINGS' } @$frames;
 is($frame->{3}, 1, 'http2_max_concurrent_streams SETTINGS');
 
-h2_window($sess, 2**18);
+$s->h2_window(2**18);
 
-$sid = new_stream($sess, { path => '/t1.html' });
-$frames = h2_read($sess, all => [{ sid => $sid, length => 2 ** 16 - 1 }]);
+$sid = $s->new_stream({ path => '/t1.html' });
+$frames = $s->read(all => [{ sid => $sid, length => 2 ** 16 - 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" && $_->{sid} == $sid } @$frames;
 is($frame->{headers}->{':status'}, 200, 'http2_max_concurrent_streams');
 
-$sid2 = new_stream($sess, { path => '/t1.html' });
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
+$sid2 = $s->new_stream({ path => '/t1.html' });
+$frames = $s->read(all => [{ type => 'RST_STREAM' }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" && $_->{sid} == $sid2 } @$frames;
 isnt($frame->{headers}->{':status'}, 200, 'http2_max_concurrent_streams 2');
@@ -2987,38 +912,38 @@ is($frame->{code}, 7, 'http2_max_concurrent_streams RST_STREAM code');
 
 # properly skip header field that's not/never indexed from discarded streams
 
-$sid2 = new_stream($sess, { headers => [
+$sid2 = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET' },
 	{ name => ':scheme', value => 'http' },
 	{ name => ':path', value => '/', mode => 6 },
 	{ name => ':authority', value => 'localhost' },
 	{ name => 'x-foo', value => 'Foo', mode => 2 }]});
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
+$frames = $s->read(all => [{ type => 'RST_STREAM' }]);
 
 # also if split across writes
 
-$sid2 = new_stream($sess, { split => [ 22 ], headers => [
+$sid2 = $s->new_stream({ split => [ 22 ], headers => [
 	{ name => ':method', value => 'GET' },
 	{ name => ':scheme', value => 'http' },
 	{ name => ':path', value => '/', mode => 6 },
 	{ name => ':authority', value => 'localhost' },
 	{ name => 'x-bar', value => 'Bar', mode => 2 }]});
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
+$frames = $s->read(all => [{ type => 'RST_STREAM' }]);
 
 # also if split across frames
 
-$sid2 = new_stream($sess, { continuation => [ 17 ], headers => [
+$sid2 = $s->new_stream({ continuation => [ 17 ], headers => [
 	{ name => ':method', value => 'GET' },
 	{ name => ':scheme', value => 'http' },
 	{ name => ':path', value => '/', mode => 6 },
 	{ name => ':authority', value => 'localhost' },
 	{ name => 'x-baz', value => 'Baz', mode => 2 }]});
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
+$frames = $s->read(all => [{ type => 'RST_STREAM' }]);
 
-h2_window($sess, 2**16, $sid);
-h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s->h2_window(2**16, $sid);
+$s->read(all => [{ sid => $sid, fin => 1 }]);
 
-$sid = new_stream($sess, { headers => [
+$sid = $s->new_stream({ headers => [
 	{ name => ':method', value => 'GET' },
 	{ name => ':scheme', value => 'http' },
 	{ name => ':path', value => '/t2.html' },
@@ -3027,7 +952,7 @@ $sid = new_stream($sess, { headers => [
 	{ name => 'x-foo', value => 'Foo', mode => 0 },
 	{ name => 'x-bar', value => 'Bar', mode => 0 },
 	{ name => 'x-baz', value => 'Baz', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
 
 ($frame) = grep { $_->{type} eq "HEADERS" && $_->{sid} == $sid } @$frames;
 is($frame->{headers}->{':status'}, 200, 'http2_max_concurrent_streams 3');
@@ -3037,88 +962,26 @@ is($frame->{headers}->{':status'}, 200, 'http2_max_concurrent_streams 3');
 
 # invalid connection preface
 
-$sess = new_session(8080, preface => 'x' x 16, pure => 1);
-$frames = h2_read($sess, all => [{ type => 'GOAWAY' }]);
+$s = Test::Nginx::HTTP2->new(port(8080), preface => 'x' x 16, pure => 1);
+$frames = $s->read(all => [{ type => 'GOAWAY' }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'invalid preface - GOAWAY frame');
 is($frame->{code}, 1, 'invalid preface - error code');
 
-$sess = new_session(8080, preface => 'PRI * HTTP/2.0' . CRLF . CRLF . 'x' x 8,
-	pure => 1);
-$frames = h2_read($sess, all => [{ type => 'GOAWAY' }]);
+my $preface = 'PRI * HTTP/2.0' . CRLF . CRLF . 'x' x 8;
+$s = Test::Nginx::HTTP2->new(port(8080), preface => $preface, pure => 1);
+$frames = $s->read(all => [{ type => 'GOAWAY' }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'invalid preface 2 - GOAWAY frame');
 is($frame->{code}, 1, 'invalid preface 2 - error code');
 
-# invalid PROXY protocol string
-
-$sess = new_session(8082, proxy => 'BOGUS TCP4 192.0.2.1 192.0.2.2 1234 5678',
-	pure => 1);
-$frames = h2_read($sess, all => [{ type => 'GOAWAY' }]);
-
-($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
-ok($frame, 'invalid PROXY - GOAWAY frame');
-is($frame->{code}, 1, 'invalid PROXY - error code');
-
-# ensure that request header field value with newline doesn't get split
-#
-# 10.3.  Intermediary Encapsulation Attacks
-#   Any request or response that contains a character not permitted
-#   in a header field value MUST be treated as malformed.
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/proxy2/', mode => 1 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'x-foo', value => "x-bar\r\nreferer:see-this", mode => 2 }]});
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
-
-# 10.3.  Intermediary Encapsulation Attacks
-#   An intermediary therefore cannot translate an HTTP/2 request or response
-#   containing an invalid field name into an HTTP/1.1 message.
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-isnt($frame->{headers}->{'x-referer'}, 'see-this', 'newline in request header');
-
-# 8.1.2.6.  Malformed Requests and Responses
-#   Malformed requests or responses that are detected MUST be treated
-#   as a stream error (Section 5.4.2) of type PROTOCOL_ERROR.
-
-($frame) = grep { $_->{type} eq "RST_STREAM" } @$frames;
-is($frame->{sid}, $sid, 'newline in request header - RST_STREAM sid');
-is($frame->{length}, 4, 'newline in request header - RST_STREAM length');
-is($frame->{flags}, 0, 'newline in request header - RST_STREAM flags');
-is($frame->{code}, 1, 'newline in request header - RST_STREAM code');
-
-# invalid header name as seen with underscore should not lead to ignoring rest
-
-TODO: {
-local $TODO = 'not yet' unless $t->has_version('1.9.7');
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 },
-	{ name => 'x_foo', value => "x-bar", mode => 2 },
-	{ name => 'referer', value => "see-this", mode => 1 }]});
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{'x-referer'}, 'see-this', 'after invalid header name');
-
-}
-
 # GOAWAY on SYN_STREAM with even StreamID
 
-$sess = new_session();
-new_stream($sess, { path => '/' }, 2);
-$frames = h2_read($sess, all => [{ type => 'GOAWAY' }]);
+$s = Test::Nginx::HTTP2->new();
+$s->new_stream({ path => '/' }, 2);
+$frames = $s->read(all => [{ type => 'GOAWAY' }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'even stream - GOAWAY frame');
@@ -3131,12 +994,12 @@ is($frame->{last_sid}, 0, 'even stream - last stream');
 #   The first use of a new stream identifier implicitly closes all
 #   streams in the "idle" state <..> with a lower-valued stream identifier.
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/' }, 3);
-h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/' }, 3);
+$s->read(all => [{ sid => $sid, fin => 1 }]);
 
-$sid2 = new_stream($sess, { path => '/' }, 1);
-$frames = h2_read($sess, all => [{ type => 'GOAWAY' }]);
+$sid2 = $s->new_stream({ path => '/' }, 1);
+$frames = $s->read(all => [{ type => 'GOAWAY' }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'backward stream - GOAWAY frame');
@@ -3145,1140 +1008,116 @@ is($frame->{last_sid}, $sid, 'backward stream - last stream');
 
 # GOAWAY on the second SYN_STREAM with same StreamID
 
-$sess = new_session();
-$sid = new_stream($sess, { path => '/' });
-h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ path => '/' });
+$s->read(all => [{ sid => $sid, fin => 1 }]);
 
-$sid2 = new_stream($sess, { path => '/' }, $sid);
-$frames = h2_read($sess, all => [{ type => 'GOAWAY' }]);
+$sid2 = $s->new_stream({ path => '/' }, $sid);
+$frames = $s->read(all => [{ type => 'GOAWAY' }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
 ok($frame, 'dup stream - GOAWAY frame');
 is($frame->{code}, 1, 'dup stream - error code');
 is($frame->{last_sid}, $sid, 'dup stream - last stream');
 
-# missing mandatory request header ':scheme'
-
-TODO: {
-local $TODO = 'not yet';
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => 'localhost', mode => 1 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 400, 'incomplete headers');
-
-}
-
-# empty request header ':authority'
-
-$sess = new_session();
-$sid = new_stream($sess, { headers => [
-	{ name => ':method', value => 'GET', mode => 0 },
-	{ name => ':scheme', value => 'http', mode => 0 },
-	{ name => ':path', value => '/', mode => 0 },
-	{ name => ':authority', value => '', mode => 0 }]});
-$frames = h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
-($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
-is($frame->{headers}->{':status'}, 400, 'empty authority');
-
 # aborted stream with zero HEADERS payload followed by client connection close
 
-new_stream(new_session(), { split => [ 9 ], abort => 1 });
+Test::Nginx::HTTP2->new()->new_stream({ split => [ 9 ], abort => 1 });
 
 # unknown frame type
 
-$sess = new_session();
-h2_unknown($sess, 'payload');
-h2_ping($sess, 'SEE-THIS');
-$frames = h2_read($sess, all => [{ type => 'PING' }]);
+$s = Test::Nginx::HTTP2->new();
+$s->h2_unknown('payload');
+$s->h2_ping('SEE-THIS');
+$frames = $s->read(all => [{ type => 'PING' }]);
 
 ($frame) = grep { $_->{type} eq "PING" } @$frames;
 is($frame->{value}, 'SEE-THIS', 'unknown frame type');
 
-# client sent invalid :path header
-
-$sid = new_stream($sess, { path => 't1.html' });
-$frames = h2_read($sess, all => [{ type => 'RST_STREAM' }]);
-
-($frame) = grep { $_->{type} eq "RST_STREAM" } @$frames;
-is($frame->{code}, 1, 'invalid path');
-
-# GOAWAY - force closing a connection by server
-
-$sid = new_stream($sess);
-h2_read($sess, all => [{ sid => $sid, fin => 1 }]);
-
 # graceful shutdown with stream waiting on HEADERS payload
 
-my $grace = new_session(8089);
-new_stream($grace, { split => [ 9 ], abort => 1 });
+my $grace = Test::Nginx::HTTP2->new(port(8084));
+$grace->new_stream({ split => [ 9 ], abort => 1 });
 
 # graceful shutdown with stream waiting on WINDOW_UPDATE
 
-my $grace2 = new_session(8089);
-$sid = new_stream($grace2, { path => '/t1.html' });
-h2_read($grace2, all => [{ sid => $sid, length => 2**16 - 1 }]);
+my $grace2 = Test::Nginx::HTTP2->new(port(8084));
+$sid = $grace2->new_stream({ path => '/t1.html' });
+$grace2->read(all => [{ sid => $sid, length => 2**16 - 1 }]);
 
 # graceful shutdown waiting on incomplete request body DATA frames
 
-my $grace3 = new_session(8090);
-$sid = new_stream($grace3, { path => '/proxy2/t2.html', body_more => 1 });
-h2_body($grace3, 'TEST', { body_more => 1 });
+my $grace3 = Test::Nginx::HTTP2->new(port(8085));
+$sid = $grace3->new_stream({ path => '/proxy2/t2.html', body_more => 1 });
+$grace3->h2_body('TEST', { body_more => 1 });
 
 # partial request body data frame with connection close after body timeout
 
-my $grace4 = new_session(8093);
-$sid = new_stream($grace4, { path => '/proxy/t2.html', body_more => 1 });
-h2_body($grace4, 'TEST', { split => [ 12 ], abort => 1 });
+my $grace4 = Test::Nginx::HTTP2->new(port(8087));
+$sid = $grace4->new_stream({ path => '/proxy/t2.html', body_more => 1 });
+$grace4->h2_body('TEST', { split => [ 12 ], abort => 1 });
 
 select undef, undef, undef, 1.1;
 undef $grace4;
 
-$t->stop();
+# GOAWAY without awaiting active streams, further streams ignored
 
-$frames = h2_read($sess, all => [{ type => 'GOAWAY' }]);
+SKIP: {
+skip 'win32', 3 if $^O eq 'MSWin32';
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.11.6');
+
+$s = Test::Nginx::HTTP2->new(port(8080));
+$sid = $s->new_stream({ path => '/t1.html' });
+$s->read(all => [{ sid => $sid, length => 2**16 - 1 }]);
+
+hup('/pid', 8081, $t);
+
+$frames = $s->read(all => [{ type => 'GOAWAY' }]);
 
 ($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
-ok($frame, 'GOAWAY on connection close');
+is($frame->{last_sid}, $sid, 'GOAWAY with active stream - last sid');
+
+$sid2 = $s->new_stream();
+$frames = $s->read(all => [{ sid => $sid2, fin => 0x4 }], wait => 0.5);
+
+($frame) = grep { $_->{type} eq 'HEADERS' } @$frames;
+is($frame, undef, 'GOAWAY with active stream - no new stream');
+
+}
+
+$s->h2_window(100, $sid);
+$s->h2_window(100);
+$frames = $s->read(all => [{ sid => $sid, fin => 0x1 }]);
+
+@data = grep { $_->{type} eq "DATA" && $_->{sid} == $sid } @$frames;
+$sum = eval join '+', map { $_->{length} } @data;
+is($sum, 81, 'GOAWAY with active stream - active stream DATA after GOAWAY');
+
+}
+
+# GOAWAY - force closing a connection by server with idle or active streams
+
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream();
+$s->read(all => [{ sid => $sid, fin => 1 }]);
+
+my $active = Test::Nginx::HTTP2->new(port(8086));
+$sid = $active->new_stream({ path => '/t1.html' });
+$active->read(all => [{ sid => $sid, length => 2**16 - 1 }]);
+
+$t->stop();
+
+$frames = $s->read(all => [{ type => 'GOAWAY' }]);
+($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
+ok($frame, 'GOAWAY on connection close - idle stream');
+
+$frames = $active->read(all => [{ type => 'GOAWAY' }]);
+($frame) = grep { $_->{type} eq "GOAWAY" } @$frames;
+ok($frame, 'GOAWAY on connection close - active stream');
 
 ###############################################################################
-
-sub h2_ping {
-	my ($sess, $payload) = @_;
-
-	raw_write($sess->{socket}, pack("x2C2x5a8", 8, 0x6, $payload));
-}
-
-sub h2_rst {
-	my ($sess, $stream, $error) = @_;
-
-	raw_write($sess->{socket}, pack("x2C2xNN", 4, 0x3, $stream, $error));
-}
-
-sub h2_goaway {
-	my ($sess, $stream, $lstream, $err, $debug, %extra) = @_;
-	$debug = '' unless defined $debug;
-	my $len = defined $extra{len} ? $extra{len} : 8 + length($debug);
-	my $buf = pack("x2C2xN3A*", $len, 0x7, $stream, $lstream, $err, $debug);
-
-	my @bufs = map {
-		raw_write($sess->{socket}, substr $buf, 0, $_, "");
-		select undef, undef, undef, 0.4;
-	} @{$extra{split}};
-
-	raw_write($sess->{socket}, $buf);
-}
-
-sub h2_priority {
-	my ($sess, $w, $stream, $dep, %extra) = @_;
-
-	$stream = 0 unless defined $stream;
-	$dep = 0 unless defined $dep;
-	$dep |= $extra{excl} << 31 if exists $extra{excl};
-	raw_write($sess->{socket}, pack("x2C2xNNC", 5, 0x2, $stream, $dep, $w));
-}
-
-sub h2_window {
-	my ($sess, $win, $stream) = @_;
-
-	$stream = 0 unless defined $stream;
-	raw_write($sess->{socket}, pack("x2C2xNN", 4, 0x8, $stream, $win));
-}
-
-sub h2_settings {
-	my ($sess, $ack, %extra) = @_;
-
-	my $len = 6 * keys %extra;
-	my $buf = pack_length($len) . pack "CCx4", 0x4, $ack ? 0x1 : 0x0;
-	$buf .= join '', map { pack "nN", $_, $extra{$_} } keys %extra;
-	raw_write($sess->{socket}, $buf);
-}
-
-sub h2_unknown {
-	my ($sess, $payload) = @_;
-
-	my $buf = pack_length(length($payload)) . pack("Cx5a*", 0xa, $payload);
-	raw_write($sess->{socket}, $buf);
-}
-
-sub h2_continue {
-	my ($ctx, $stream, $uri) = @_;
-
-	$uri->{h2_continue} = 1;
-	return new_stream($ctx, $uri, $stream);
-}
-
-sub h2_body {
-	my ($sess, $body, $extra) = @_;
-	$extra = {} unless defined $extra;
-
-	my $len = length $body;
-	my $sid = $sess->{last_stream};
-
-	if ($len > $sess->{conn_window} || $len > $sess->{streams}{$sid}) {
-		h2_read($sess, all => [{ type => 'WINDOW_UPDATE' }]);
-	}
-
-	if ($len > $sess->{conn_window} || $len > $sess->{streams}{$sid}) {
-		return;
-	}
-
-	$sess->{conn_window} -= $len;
-	$sess->{streams}{$sid} -= $len;
-
-	my $buf;
-
-	my $split = ref $extra->{body_split} && $extra->{body_split} || [];
-	for (@$split) {
-		$buf .= pack_body($sess, substr($body, 0, $_, ""), 0x0, $extra);
-	}
-
-	$buf .= pack_body($sess, $body, 0x1, $extra) if defined $body;
-
-	$split = ref $extra->{split} && $extra->{split} || [];
-	for (@$split) {
-		raw_write($sess->{socket}, substr($buf, 0, $_, ""));
-		return if $extra->{abort};
-		select undef, undef, undef, ($extra->{split_delay} || 0.2);
-	}
-
-	raw_write($sess->{socket}, $buf);
-}
-
-sub pack_body {
-	my ($ctx, $body, $flags, $extra) = @_;
-
-	my $pad = defined $extra->{body_padding} ? $extra->{body_padding} : 0;
-	my $padlen = defined $extra->{body_padding} ? 1 : 0;
-
-	my $buf = pack_length(length($body) + $pad + $padlen);
-	$flags |= 0x8 if $padlen;
-	vec($flags, 0, 1) = 0 if $extra->{body_more};
-	$buf .= pack 'CC', 0x0, $flags;		# DATA, END_STREAM
-	$buf .= pack 'N', $ctx->{last_stream};
-	$buf .= pack 'C', $pad if $padlen;	# DATA Pad Length?
-	$buf .= $body;
-	$buf .= pack "x$pad" if $padlen;	# DATA Padding
-	return $buf;
-}
-
-sub new_stream {
-	my ($ctx, $uri, $stream) = @_;
-	my ($input, $buf);
-	my ($d, $status);
-
-	$ctx->{headers} = '';
-
-	my $host = $uri->{host} || '127.0.0.1:8080';
-	my $method = $uri->{method} || 'GET';
-	my $scheme = $uri->{scheme} || 'http';
-	my $path = $uri->{path} || '/';
-	my $headers = $uri->{headers};
-	my $body = $uri->{body};
-	my $prio = $uri->{prio};
-	my $dep = $uri->{dep};
-
-	my $pad = defined $uri->{padding} ? $uri->{padding} : 0;
-	my $padlen = defined $uri->{padding} ? 1 : 0;
-
-	my $type = defined $uri->{h2_continue} ? 0x9 : 0x1;
-	my $flags = defined $uri->{continuation} ? 0x0 : 0x4;
-	$flags |= 0x1 unless defined $body || defined $uri->{body_more};
-	$flags |= 0x8 if $padlen;
-	$flags |= 0x20 if defined $dep || defined $prio;
-
-	if ($stream) {
-		$ctx->{last_stream} = $stream;
-	} else {
-		$ctx->{last_stream} += 2;
-		$ctx->{streams}{$ctx->{last_stream}} = $ctx->{iws};
-	}
-
-	$buf = pack("xxx");			# Length stub
-	$buf .= pack("CC", $type, $flags);	# END_HEADERS
-	$buf .= pack("N", $ctx->{last_stream});	# Stream-ID
-
-	$dep = 0 if defined $prio and not defined $dep;
-	$prio = 16 if defined $dep and not defined $prio;
-
-	unless ($headers) {
-		$input = hpack($ctx, ":method", $method);
-		$input .= hpack($ctx, ":scheme", $scheme);
-		$input .= hpack($ctx, ":path", $path);
-		$input .= hpack($ctx, ":authority", $host);
-		$input .= hpack($ctx, "content-length", length($body)) if $body;
-
-	} else {
-		$input = join '', map {
-			hpack($ctx, $_->{name}, $_->{value},
-			mode => $_->{mode}, huff => $_->{huff})
-		} @$headers if $headers;
-	}
-
-	$input = pack("B*", '001' . ipack(5, $uri->{table_size})) . $input
-		if defined $uri->{table_size};
-
-	my $split = ref $uri->{continuation} && $uri->{continuation} || [];
-	my @input = map { substr $input, 0, $_, "" } @$split;
-	push @input, $input;
-
-	# set length, attach headers, padding, priority
-
-	my $hlen = length($input[0]) + $pad + $padlen;
-	$hlen += 5 if $flags & 0x20;
-	$buf |= pack_length($hlen);
-
-	$buf .= pack 'C', $pad if $padlen;		# Pad Length?
-	$buf .= pack 'NC', $dep, $prio if $flags & 0x20;
-	$buf .= $input[0];
-	$buf .= (pack 'C', 0) x $pad if $padlen;	# Padding
-
-	shift @input;
-
-	while (@input) {
-		$input = shift @input;
-		$flags = @input ? 0x0 : 0x4;
-		$buf .= pack_length(length($input));
-		$buf .= pack("CC", 0x9, $flags);
-		$buf .= pack("N", $ctx->{last_stream});
-		$buf .= $input;
-	}
-
-	$split = ref $uri->{body_split} && $uri->{body_split} || [];
-	for (@$split) {
-		$buf .= pack_body($ctx, substr($body, 0, $_, ""), 0x0, $uri);
-	}
-
-	$buf .= pack_body($ctx, $body, 0x1, $uri) if defined $body;
-
-	$split = ref $uri->{split} && $uri->{split} || [];
-	for (@$split) {
-		raw_write($ctx->{socket}, substr($buf, 0, $_, ""));
-		goto done if $uri->{abort};
-		select undef, undef, undef, ($uri->{split_delay} || 0.2);
-	}
-
-	raw_write($ctx->{socket}, $buf);
-done:
-	return $ctx->{last_stream};
-}
-
-sub h2_read {
-	my ($sess, %extra) = @_;
-	my (@got);
-	my $s = $sess->{socket};
-	my $buf = '';
-
-	while (1) {
-		$buf = raw_read($s, $buf, 9);
-		last if length $buf < 9;
-
-		my $length = unpack_length($buf);
-		my $type = unpack('x3C', $buf);
-		my $flags = unpack('x4C', $buf);
-
-		my $stream = unpack "x5 B32", $buf;
-		substr($stream, 0, 1) = 0;
-		$stream = unpack("N", pack("B32", $stream));
-
-		$buf = raw_read($s, $buf, $length + 9);
-		last if length($buf) < $length + 9;
-
-		$buf = substr($buf, 9);
-
-		my $frame = $cframe{$type}{value}($sess, $buf, $length, $flags,
-			$stream);
-		$frame->{length} = $length;
-		$frame->{type} = $cframe{$type}{name};
-		$frame->{flags} = $flags;
-		$frame->{sid} = $stream;
-		push @got, $frame;
-
-		$buf = substr($buf, $length);
-
-		last unless $extra{all} && test_fin($got[-1], $extra{all});
-	};
-	return \@got;
-}
-
-sub test_fin {
-	my ($frame, $all) = @_;
-	my @test = @{$all};
-
-	# wait for the specified DATA length
-
-	for (@test) {
-		if ($_->{length} && $frame->{type} eq 'DATA') {
-			# check also for StreamID if needed
-
-			if (!$_->{sid} || $_->{sid} == $frame->{sid}) {
-				$_->{length} -= $frame->{length};
-			}
-		}
-	}
-	@test = grep { !(defined $_->{length} && $_->{length} == 0) } @test;
-
-	# wait for the fin flag
-
-	@test = grep { !(defined $_->{fin}
-		&& $_->{sid} == $frame->{sid} && $_->{fin} & $frame->{flags})
-	} @test if defined $frame->{flags};
-
-	# wait for the specified frame
-
-	@test = grep { !($_->{type} && $_->{type} eq $frame->{type}) } @test;
-
-	@{$all} = @test;
-}
-
-sub headers {
-	my ($ctx, $buf, $len, $flags) = @_;
-	$ctx->{headers} .= substr($buf, 0, $len);
-	return unless $flags & 0x4;
-	{ headers => hunpack($ctx, $ctx->{headers}, length($ctx->{headers})) };
-}
-
-sub data {
-	my ($ctx, $buf, $len) = @_;
-	return { data => substr($buf, 0, $len) };
-}
-
-sub settings {
-	my ($ctx, $buf, $len) = @_;
-	my %payload;
-	my $skip = 0;
-
-	for (1 .. $len / 6) {
-		my $id = hex unpack "\@$skip n", $buf; $skip += 2;
-		$payload{$id} = unpack "\@$skip N", $buf; $skip += 4;
-
-		$ctx->{iws} = $payload{$id} if $id == 4;
-	}
-	return \%payload;
-}
-
-sub ping {
-	my ($ctx, $buf, $len) = @_;
-	return { value => unpack "A$len", $buf };
-}
-
-sub rst_stream {
-	my ($ctx, $buf, $len) = @_;
-	return { code => unpack "N", $buf };
-}
-
-sub goaway {
-	my ($ctx, $buf, $len) = @_;
-	my %payload;
-
-	my $stream = unpack "B32", $buf;
-	substr($stream, 0, 1) = 0;
-	$stream = unpack("N", pack("B32", $stream));
-	$payload{last_sid} = $stream;
-
-	$len -= 4;
-	$payload{code} = unpack "x4 N", $buf;
-	$payload{debug} = unpack "x8 A$len", $buf;
-	return \%payload;
-}
-
-sub window_update {
-	my ($ctx, $buf, $len, $flags, $sid) = @_;
-	my $value = unpack "B32", $buf;
-	substr($value, 0, 1) = 0;
-	$value = unpack("N", pack("B32", $value));
-
-	unless ($sid) {
-		$ctx->{conn_window} += $value;
-
-	} else {
-		$ctx->{streams}{$sid} = $ctx->{iws}
-			unless defined $ctx->{streams}{$sid};
-		$ctx->{streams}{$sid} += $value;
-	}
-
-	return { wdelta => $value };
-}
-
-sub pack_length {
-	pack 'c3', unpack 'xc3', pack 'N', $_[0];
-}
-
-sub unpack_length {
-	unpack 'N', pack 'xc3', unpack 'c3', $_[0];
-}
-
-sub raw_read {
-	my ($s, $buf, $len) = @_;
-	my $got = '';
-
-	while (length($buf) < $len && IO::Select->new($s)->can_read(1))  {
-		$s->sysread($got, 16384) or last;
-		log_in($got);
-		$buf .= $got;
-	}
-	return $buf;
-}
-
-sub raw_write {
-	my ($s, $message) = @_;
-
-	local $SIG{PIPE} = 'IGNORE';
-
-	while (IO::Select->new($s)->can_write(0.4)) {
-		log_out($message);
-		my $n = $s->syswrite($message);
-		last unless $n;
-		$message = substr($message, $n);
-		last unless length $message;
-	}
-}
-
-sub new_session {
-	my ($port, %extra) = @_;
-
-	my $s = new_socket($port, %extra);
-	my $preface = $extra{preface}
-		|| 'PRI * HTTP/2.0' . CRLF . CRLF . 'SM' . CRLF . CRLF;
-
-	if ($extra{proxy}) {
-		raw_write($s, $extra{proxy});
-	}
-
-	# preface
-
-	raw_write($s, $preface);
-
-	my $ctx = { socket => $s, last_stream => -1,
-		dynamic_encode => [ static_table() ],
-		dynamic_decode => [ static_table() ],
-		static_table_size => scalar @{[static_table()]},
-		iws => 65535, conn_window => 65535, streams => {}};
-
-	return $ctx if $extra{pure};
-
-	# update windows, if any
-
-	h2_read($ctx, all => [
-		{ type => 'WINDOW_UPDATE' },
-		{ type => 'SETTINGS'}
-	]);
-
-	return $ctx;
-}
-
-sub new_socket {
-	my ($port, %extra) = @_;
-	my $npn = $extra{'npn'};
-	my $alpn = $extra{'alpn'};
-	my $s;
-
-	$port = 8080 unless defined $port;
-
-	eval {
-		local $SIG{ALRM} = sub { die "timeout\n" };
-		local $SIG{PIPE} = sub { die "sigpipe\n" };
-		alarm(2);
-		$s = IO::Socket::INET->new(
-			Proto => 'tcp',
-			PeerAddr => "127.0.0.1:$port",
-		);
-		IO::Socket::SSL->start_SSL($s,
-			SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
-			SSL_npn_protocols => $npn ? [ $npn ] : undef,
-			SSL_alpn_protocols => $alpn ? [ $alpn ] : undef,
-			SSL_error_trap => sub { die $_[1] }
-		) if $extra{'SSL'};
-		alarm(0);
-	};
-	alarm(0);
-
-	if ($@) {
-		log_in("died: $@");
-		return undef;
-	}
-
-	return $s;
-}
-
-sub static_table {
-	[ '',			''		], # unused
-	[ ':authority',		''		],
-	[ ':method',		'GET'		],
-	[ ':method',		'POST'		],
-	[ ':path',		'/'		],
-	[ ':path',		'/index.html'	],
-	[ ':scheme',		'http'		],
-	[ ':scheme',		'https'		],
-	[ ':status',		'200'		],
-	[ ':status',		'204'		],
-	[ ':status',		'206'		],
-	[ ':status',		'304'		],
-	[ ':status',		'400'		],
-	[ ':status',		'404'		],
-	[ ':status',		'500'		],
-	[ 'accept-charset',	''		],
-	[ 'accept-encoding',	'gzip, deflate'	],
-	[ 'accept-language',	''		],
-	[ 'accept-ranges',	''		],
-	[ 'accept',		''		],
-	[ 'access-control-allow-origin',
-				''		],
-	[ 'age',		''		],
-	[ 'allow',		''		],
-	[ 'authorization', 	''		],
-	[ 'cache-control', 	''		],
-	[ 'content-disposition',
-				''		],
-	[ 'content-encoding',	''		],
-	[ 'content-language',	''		],
-	[ 'content-length',	''		],
-	[ 'content-location',	''		],
-	[ 'content-range',	''		],
-	[ 'content-type',	''		],
-	[ 'cookie',		''		],
-	[ 'date',		''		],
-	[ 'etag',		''		],
-	[ 'expect',		''		],
-	[ 'expires',		''		],
-	[ 'from',		''		],
-	[ 'host',		''		],
-	[ 'if-match',		''		],
-	[ 'if-modified-since',	''		],
-	[ 'if-none-match',	''		],
-	[ 'if-range',		''		],
-	[ 'if-unmodified-since',
-				''		],
-	[ 'last-modified',	''		],
-	[ 'link',		''		],
-	[ 'location',		''		],
-	[ 'max-forwards',	''		],
-	[ 'proxy-authenticate',	''		],
-	[ 'proxy-authorization',
-				''		],
-	[ 'range',		''		],
-	[ 'referer',		''		],
-	[ 'refresh',		''		],
-	[ 'retry-after',	''		],
-	[ 'server',		''		],
-	[ 'set-cookie',		''		],
-	[ 'strict-transport-security',
-				''		],
-	[ 'transfer-encoding',	''		],
-	[ 'user-agent',		''		],
-	[ 'vary',		''		],
-	[ 'via',		''		],
-	[ 'www-authenticate',	''		],
-}
-
-# RFC 7541, 5.1.  Integer Representation
-
-sub ipack {
-	my ($base, $d) = @_;
-	return sprintf("%.*b", $base, $d) if $d < 2**$base - 1;
-
-	my $o = sprintf("%${base}b", 2**$base - 1);
-	$d -= 2**$base - 1;
-	while ($d >= 128) {
-		$o .= sprintf("%8b", $d % 128 + 128);
-		$d /= 128;
-	}
-	$o .= sprintf("%08b", $d);
-	return $o;
-}
-
-sub iunpack {
-	my ($base, $b, $s) = @_;
-
-	my $len = unpack("\@$s B8", $b); $s++;
-	my $prefix = substr($len, 0, 8 - $base);
-	$len = '0' x (8 - $base) . substr($len, 8 - $base);
-	$len = unpack("C", pack("B8", $len));
-
-	return ($len, $s, $prefix) if $len < 2**$base - 1;
-
-	my $m = 0;
-	my $d;
-
-	do {
-		$d = unpack("\@$s C", $b); $s++;
-		$len += ($d & 127) * 2**$m;
-		$m += $base;
-	} while (($d & 128) == 128);
-
-	return ($len, $s, $prefix);
-}
-
-sub hpack {
-	my ($ctx, $name, $value, %extra) = @_;
-	my $table = $ctx->{dynamic_encode};
-	my $mode = defined $extra{mode} ? $extra{mode} : 1;
-	my $huff = $extra{huff};
-
-	my ($index, $buf) = 0;
-
-	# 6.1.  Indexed Header Field Representation
-
-	if ($mode == 0) {
-		++$index until $index > $#$table
-			or $table->[$index][0] eq $name
-			and $table->[$index][1] eq $value;
-		$buf = pack('B*', '1' . ipack(7, $index));
-	}
-
-	# 6.2.1.  Literal Header Field with Incremental Indexing
-
-	if ($mode == 1) {
-		splice @$table, $ctx->{static_table_size}, 0, [ $name, $value ];
-
-		++$index until $index > $#$table
-			or $table->[$index][0] eq $name;
-		my $value = $huff ? huff($value) : $value;
-
-		$buf = pack('B*', '01' . ipack(6, $index)
-			. ($huff ? '1' : '0') . ipack(7, length($value)));
-		$buf .= $value;
-	}
-
-	# 6.2.1.  Literal Header Field with Incremental Indexing -- New Name
-
-	if ($mode == 2) {
-		splice @$table, $ctx->{static_table_size}, 0, [ $name, $value ];
-
-		my $name = $huff ? huff($name) : $name;
-		my $value = $huff ? huff($value) : $value;
-		my $hbit = ($huff ? '1' : '0');
-
-		$buf = pack('B*', '01000000');
-		$buf .= pack('B*', $hbit . ipack(7, length($name)));
-		$buf .= $name;
-		$buf .= pack('B*', $hbit . ipack(7, length($value)));
-		$buf .= $value;
-	}
-
-	# 6.2.2.  Literal Header Field without Indexing
-
-	if ($mode == 3) {
-		++$index until $index > $#$table
-			or $table->[$index][0] eq $name;
-		my $value = $huff ? huff($value) : $value;
-
-		$buf = pack('B*', '0000' . ipack(4, $index)
-			. ($huff ? '1' : '0') . ipack(7, length($value)));
-		$buf .= $value;
-	}
-
-	# 6.2.2.  Literal Header Field without Indexing -- New Name
-
-	if ($mode == 4) {
-		my $name = $huff ? huff($name) : $name;
-		my $value = $huff ? huff($value) : $value;
-		my $hbit = ($huff ? '1' : '0');
-
-		$buf = pack('B*', '00000000');
-		$buf .= pack('B*', $hbit . ipack(7, length($name)));
-		$buf .= $name;
-		$buf .= pack('B*', $hbit . ipack(7, length($value)));
-		$buf .= $value;
-	}
-
-	# 6.2.3.  Literal Header Field Never Indexed
-
-	if ($mode == 5) {
-		++$index until $index > $#$table
-			or $table->[$index][0] eq $name;
-		my $value = $huff ? huff($value) : $value;
-
-		$buf = pack('B*', '0001' . ipack(4, $index)
-			. ($huff ? '1' : '0') . ipack(7, length($value)));
-		$buf .= $value;
-	}
-
-	# 6.2.3.  Literal Header Field Never Indexed -- New Name
-
-	if ($mode == 6) {
-		my $name = $huff ? huff($name) : $name;
-		my $value = $huff ? huff($value) : $value;
-		my $hbit = ($huff ? '1' : '0');
-
-		$buf = pack('B*', '00010000');
-		$buf .= pack('B*', $hbit . ipack(7, length($name)));
-		$buf .= $name;
-		$buf .= pack('B*', $hbit . ipack(7, length($value)));
-		$buf .= $value;
-	}
-
-	return $buf;
-}
-
-sub hunpack {
-	my ($ctx, $data, $length) = @_;
-	my $table = $ctx->{dynamic_decode};
-	my %headers;
-	my $skip = 0;
-	my ($index, $name, $value);
-
-	my $field = sub {
-		my ($b) = @_;
-		my ($len, $s, $huff) = iunpack(7, @_);
-
-		my $field = substr($b, $s, $len);
-		$field = $huff ? dehuff($field) : $field;
-		$s += $len;
-		return ($field, $s);
-	};
-
-	my $add = sub {
-		my ($h, $n, $v) = @_;
-		return $h->{$n} = $v unless exists $h->{$n};
-		$h->{$n} = [ $h->{$n} ] unless ref $h->{$n};
-		push @{$h->{$n}}, $v;
-	};
-
-	while ($skip < $length) {
-		my $ib = unpack("\@$skip B8", $data);
-
-		if (substr($ib, 0, 1) eq '1') {
-			($index, $skip) = iunpack(7, $data, $skip);
-			$add->(\%headers,
-				$table->[$index][0], $table->[$index][1]);
-			next;
-		}
-
-		if (substr($ib, 0, 2) eq '01') {
-			($index, $skip) = iunpack(6, $data, $skip);
-			$name = $table->[$index][0];
-
-			($name, $skip) = $field->($data, $skip) unless $name;
-			($value, $skip) = $field->($data, $skip);
-
-			splice @$table,
-				$ctx->{static_table_size}, 0, [ $name, $value ];
-			$add->(\%headers, $name, $value);
-			next;
-		}
-
-		if (substr($ib, 0, 4) eq '0000') {
-			($index, $skip) = iunpack(4, $data, $skip);
-			$name = $table->[$index][0];
-
-			($name, $skip) = $field->($data, $skip) unless $name;
-			($value, $skip) = $field->($data, $skip);
-
-			$add->(\%headers, $name, $value);
-			next;
-		}
-		last;
-	}
-
-	return \%headers;
-}
-
-sub huff_code { scalar {
-	pack('C', 0)	=> '1111111111000',
-	pack('C', 1)	=> '11111111111111111011000',
-	pack('C', 2)	=> '1111111111111111111111100010',
-	pack('C', 3)	=> '1111111111111111111111100011',
-	pack('C', 4)	=> '1111111111111111111111100100',
-	pack('C', 5)	=> '1111111111111111111111100101',
-	pack('C', 6)	=> '1111111111111111111111100110',
-	pack('C', 7)	=> '1111111111111111111111100111',
-	pack('C', 8)	=> '1111111111111111111111101000',
-	pack('C', 9)	=> '111111111111111111101010',
-	pack('C', 10)	=> '111111111111111111111111111100',
-	pack('C', 11)	=> '1111111111111111111111101001',
-	pack('C', 12)	=> '1111111111111111111111101010',
-	pack('C', 13)	=> '111111111111111111111111111101',
-	pack('C', 14)	=> '1111111111111111111111101011',
-	pack('C', 15)	=> '1111111111111111111111101100',
-	pack('C', 16)	=> '1111111111111111111111101101',
-	pack('C', 17)	=> '1111111111111111111111101110',
-	pack('C', 18)	=> '1111111111111111111111101111',
-	pack('C', 19)	=> '1111111111111111111111110000',
-	pack('C', 20)	=> '1111111111111111111111110001',
-	pack('C', 21)	=> '1111111111111111111111110010',
-	pack('C', 22)	=> '111111111111111111111111111110',
-	pack('C', 23)	=> '1111111111111111111111110011',
-	pack('C', 24)	=> '1111111111111111111111110100',
-	pack('C', 25)	=> '1111111111111111111111110101',
-	pack('C', 26)	=> '1111111111111111111111110110',
-	pack('C', 27)	=> '1111111111111111111111110111',
-	pack('C', 28)	=> '1111111111111111111111111000',
-	pack('C', 29)	=> '1111111111111111111111111001',
-	pack('C', 30)	=> '1111111111111111111111111010',
-	pack('C', 31)	=> '1111111111111111111111111011',
-	pack('C', 32)	=> '010100',
-	pack('C', 33)	=> '1111111000',
-	pack('C', 34)	=> '1111111001',
-	pack('C', 35)	=> '111111111010',
-	pack('C', 36)	=> '1111111111001',
-	pack('C', 37)	=> '010101',
-	pack('C', 38)	=> '11111000',
-	pack('C', 39)	=> '11111111010',
-	pack('C', 40)	=> '1111111010',
-	pack('C', 41)	=> '1111111011',
-	pack('C', 42)	=> '11111001',
-	pack('C', 43)	=> '11111111011',
-	pack('C', 44)	=> '11111010',
-	pack('C', 45)	=> '010110',
-	pack('C', 46)	=> '010111',
-	pack('C', 47)	=> '011000',
-	pack('C', 48)	=> '00000',
-	pack('C', 49)	=> '00001',
-	pack('C', 50)	=> '00010',
-	pack('C', 51)	=> '011001',
-	pack('C', 52)	=> '011010',
-	pack('C', 53)	=> '011011',
-	pack('C', 54)	=> '011100',
-	pack('C', 55)	=> '011101',
-	pack('C', 56)	=> '011110',
-	pack('C', 57)	=> '011111',
-	pack('C', 58)	=> '1011100',
-	pack('C', 59)	=> '11111011',
-	pack('C', 60)	=> '111111111111100',
-	pack('C', 61)	=> '100000',
-	pack('C', 62)	=> '111111111011',
-	pack('C', 63)	=> '1111111100',
-	pack('C', 64)	=> '1111111111010',
-	pack('C', 65)	=> '100001',
-	pack('C', 66)	=> '1011101',
-	pack('C', 67)	=> '1011110',
-	pack('C', 68)	=> '1011111',
-	pack('C', 69)	=> '1100000',
-	pack('C', 70)	=> '1100001',
-	pack('C', 71)	=> '1100010',
-	pack('C', 72)	=> '1100011',
-	pack('C', 73)	=> '1100100',
-	pack('C', 74)	=> '1100101',
-	pack('C', 75)	=> '1100110',
-	pack('C', 76)	=> '1100111',
-	pack('C', 77)	=> '1101000',
-	pack('C', 78)	=> '1101001',
-	pack('C', 79)	=> '1101010',
-	pack('C', 80)	=> '1101011',
-	pack('C', 81)	=> '1101100',
-	pack('C', 82)	=> '1101101',
-	pack('C', 83)	=> '1101110',
-	pack('C', 84)	=> '1101111',
-	pack('C', 85)	=> '1110000',
-	pack('C', 86)	=> '1110001',
-	pack('C', 87)	=> '1110010',
-	pack('C', 88)	=> '11111100',
-	pack('C', 89)	=> '1110011',
-	pack('C', 90)	=> '11111101',
-	pack('C', 91)	=> '1111111111011',
-	pack('C', 92)	=> '1111111111111110000',
-	pack('C', 93)	=> '1111111111100',
-	pack('C', 94)	=> '11111111111100',
-	pack('C', 95)	=> '100010',
-	pack('C', 96)	=> '111111111111101',
-	pack('C', 97)	=> '00011',
-	pack('C', 98)	=> '100011',
-	pack('C', 99)	=> '00100',
-	pack('C', 100)	=> '100100',
-	pack('C', 101)	=> '00101',
-	pack('C', 102)	=> '100101',
-	pack('C', 103)	=> '100110',
-	pack('C', 104)	=> '100111',
-	pack('C', 105)	=> '00110',
-	pack('C', 106)	=> '1110100',
-	pack('C', 107)	=> '1110101',
-	pack('C', 108)	=> '101000',
-	pack('C', 109)	=> '101001',
-	pack('C', 110)	=> '101010',
-	pack('C', 111)	=> '00111',
-	pack('C', 112)	=> '101011',
-	pack('C', 113)	=> '1110110',
-	pack('C', 114)	=> '101100',
-	pack('C', 115)	=> '01000',
-	pack('C', 116)	=> '01001',
-	pack('C', 117)	=> '101101',
-	pack('C', 118)	=> '1110111',
-	pack('C', 119)	=> '1111000',
-	pack('C', 120)	=> '1111001',
-	pack('C', 121)	=> '1111010',
-	pack('C', 122)	=> '1111011',
-	pack('C', 123)	=> '111111111111110',
-	pack('C', 124)	=> '11111111100',
-	pack('C', 125)	=> '11111111111101',
-	pack('C', 126)	=> '1111111111101',
-	pack('C', 127)	=> '1111111111111111111111111100',
-	pack('C', 128)	=> '11111111111111100110',
-	pack('C', 129)	=> '1111111111111111010010',
-	pack('C', 130)	=> '11111111111111100111',
-	pack('C', 131)	=> '11111111111111101000',
-	pack('C', 132)	=> '1111111111111111010011',
-	pack('C', 133)	=> '1111111111111111010100',
-	pack('C', 134)	=> '1111111111111111010101',
-	pack('C', 135)	=> '11111111111111111011001',
-	pack('C', 136)	=> '1111111111111111010110',
-	pack('C', 137)	=> '11111111111111111011010',
-	pack('C', 138)	=> '11111111111111111011011',
-	pack('C', 139)	=> '11111111111111111011100',
-	pack('C', 140)	=> '11111111111111111011101',
-	pack('C', 141)	=> '11111111111111111011110',
-	pack('C', 142)	=> '111111111111111111101011',
-	pack('C', 143)	=> '11111111111111111011111',
-	pack('C', 144)	=> '111111111111111111101100',
-	pack('C', 145)	=> '111111111111111111101101',
-	pack('C', 146)	=> '1111111111111111010111',
-	pack('C', 147)	=> '11111111111111111100000',
-	pack('C', 148)	=> '111111111111111111101110',
-	pack('C', 149)	=> '11111111111111111100001',
-	pack('C', 150)	=> '11111111111111111100010',
-	pack('C', 151)	=> '11111111111111111100011',
-	pack('C', 152)	=> '11111111111111111100100',
-	pack('C', 153)	=> '111111111111111011100',
-	pack('C', 154)	=> '1111111111111111011000',
-	pack('C', 155)	=> '11111111111111111100101',
-	pack('C', 156)	=> '1111111111111111011001',
-	pack('C', 157)	=> '11111111111111111100110',
-	pack('C', 158)	=> '11111111111111111100111',
-	pack('C', 159)	=> '111111111111111111101111',
-	pack('C', 160)	=> '1111111111111111011010',
-	pack('C', 161)	=> '111111111111111011101',
-	pack('C', 162)	=> '11111111111111101001',
-	pack('C', 163)	=> '1111111111111111011011',
-	pack('C', 164)	=> '1111111111111111011100',
-	pack('C', 165)	=> '11111111111111111101000',
-	pack('C', 166)	=> '11111111111111111101001',
-	pack('C', 167)	=> '111111111111111011110',
-	pack('C', 168)	=> '11111111111111111101010',
-	pack('C', 169)	=> '1111111111111111011101',
-	pack('C', 170)	=> '1111111111111111011110',
-	pack('C', 171)	=> '111111111111111111110000',
-	pack('C', 172)	=> '111111111111111011111',
-	pack('C', 173)	=> '1111111111111111011111',
-	pack('C', 174)	=> '11111111111111111101011',
-	pack('C', 175)	=> '11111111111111111101100',
-	pack('C', 176)	=> '111111111111111100000',
-	pack('C', 177)	=> '111111111111111100001',
-	pack('C', 178)	=> '1111111111111111100000',
-	pack('C', 179)	=> '111111111111111100010',
-	pack('C', 180)	=> '11111111111111111101101',
-	pack('C', 181)	=> '1111111111111111100001',
-	pack('C', 182)	=> '11111111111111111101110',
-	pack('C', 183)	=> '11111111111111111101111',
-	pack('C', 184)	=> '11111111111111101010',
-	pack('C', 185)	=> '1111111111111111100010',
-	pack('C', 186)	=> '1111111111111111100011',
-	pack('C', 187)	=> '1111111111111111100100',
-	pack('C', 188)	=> '11111111111111111110000',
-	pack('C', 189)	=> '1111111111111111100101',
-	pack('C', 190)	=> '1111111111111111100110',
-	pack('C', 191)	=> '11111111111111111110001',
-	pack('C', 192)	=> '11111111111111111111100000',
-	pack('C', 193)	=> '11111111111111111111100001',
-	pack('C', 194)	=> '11111111111111101011',
-	pack('C', 195)	=> '1111111111111110001',
-	pack('C', 196)	=> '1111111111111111100111',
-	pack('C', 197)	=> '11111111111111111110010',
-	pack('C', 198)	=> '1111111111111111101000',
-	pack('C', 199)	=> '1111111111111111111101100',
-	pack('C', 200)	=> '11111111111111111111100010',
-	pack('C', 201)	=> '11111111111111111111100011',
-	pack('C', 202)	=> '11111111111111111111100100',
-	pack('C', 203)	=> '111111111111111111111011110',
-	pack('C', 204)	=> '111111111111111111111011111',
-	pack('C', 205)	=> '11111111111111111111100101',
-	pack('C', 206)	=> '111111111111111111110001',
-	pack('C', 207)	=> '1111111111111111111101101',
-	pack('C', 208)	=> '1111111111111110010',
-	pack('C', 209)	=> '111111111111111100011',
-	pack('C', 210)	=> '11111111111111111111100110',
-	pack('C', 211)	=> '111111111111111111111100000',
-	pack('C', 212)	=> '111111111111111111111100001',
-	pack('C', 213)	=> '11111111111111111111100111',
-	pack('C', 214)	=> '111111111111111111111100010',
-	pack('C', 215)	=> '111111111111111111110010',
-	pack('C', 216)	=> '111111111111111100100',
-	pack('C', 217)	=> '111111111111111100101',
-	pack('C', 218)	=> '11111111111111111111101000',
-	pack('C', 219)	=> '11111111111111111111101001',
-	pack('C', 220)	=> '1111111111111111111111111101',
-	pack('C', 221)	=> '111111111111111111111100011',
-	pack('C', 222)	=> '111111111111111111111100100',
-	pack('C', 223)	=> '111111111111111111111100101',
-	pack('C', 224)	=> '11111111111111101100',
-	pack('C', 225)	=> '111111111111111111110011',
-	pack('C', 226)	=> '11111111111111101101',
-	pack('C', 227)	=> '111111111111111100110',
-	pack('C', 228)	=> '1111111111111111101001',
-	pack('C', 229)	=> '111111111111111100111',
-	pack('C', 230)	=> '111111111111111101000',
-	pack('C', 231)	=> '11111111111111111110011',
-	pack('C', 232)	=> '1111111111111111101010',
-	pack('C', 233)	=> '1111111111111111101011',
-	pack('C', 234)	=> '1111111111111111111101110',
-	pack('C', 235)	=> '1111111111111111111101111',
-	pack('C', 236)	=> '111111111111111111110100',
-	pack('C', 237)	=> '111111111111111111110101',
-	pack('C', 238)	=> '11111111111111111111101010',
-	pack('C', 239)	=> '11111111111111111110100',
-	pack('C', 240)	=> '11111111111111111111101011',
-	pack('C', 241)	=> '111111111111111111111100110',
-	pack('C', 242)	=> '11111111111111111111101100',
-	pack('C', 243)	=> '11111111111111111111101101',
-	pack('C', 244)	=> '111111111111111111111100111',
-	pack('C', 245)	=> '111111111111111111111101000',
-	pack('C', 246)	=> '111111111111111111111101001',
-	pack('C', 247)	=> '111111111111111111111101010',
-	pack('C', 248)	=> '111111111111111111111101011',
-	pack('C', 249)	=> '1111111111111111111111111110',
-	pack('C', 250)	=> '111111111111111111111101100',
-	pack('C', 251)	=> '111111111111111111111101101',
-	pack('C', 252)	=> '111111111111111111111101110',
-	pack('C', 253)	=> '111111111111111111111101111',
-	pack('C', 254)	=> '111111111111111111111110000',
-	pack('C', 255)	=> '11111111111111111111101110',
-	'_eos'		=> '111111111111111111111111111111',
-}};
-
-sub huff {
-	my ($string) = @_;
-	my $code = &huff_code;
-
-	my $ret = join '', map { $code->{$_} } (split //, $string);
-	my $len = length($ret) + (8 - length($ret) % 8);
-	$ret .= $code->{_eos};
-
-	return pack("B$len", $ret);
-}
-
-sub dehuff {
-	my ($string) = @_;
-	my $code = &huff_code;
-	my %decode = reverse %$code;
-
-	my $ret = ''; my $c = '';
-	for (split //, unpack('B*', $string)) {
-		$c .= $_;
-		next unless exists $decode{$c};
-		last if $decode{$c} eq '_eos';
-
-		$ret .= $decode{$c};
-		$c = '';
-	}
-
-	return $ret;
-}
-
-###############################################################################
-
-sub read_body_file {
-	my ($path) = @_;
-	open FILE, $path or return "$!";
-	local $/;
-	my $content = <FILE>;
-	close FILE;
-	return $content;
-}
 
 sub gunzip_like {
 	my ($in, $re, $name) = @_;
@@ -4296,69 +1135,17 @@ sub gunzip_like {
 	}
 }
 
-###############################################################################
+sub hup {
+	my ($uri, $port, $t) = @_;
 
-# for tests with multiple header fields
+	my $sock = sub { IO::Socket::INET->new('127.0.0.1:' . port(shift)) };
+	my ($pid) = http_get($uri, socket => $sock->($port)) =~ /pid (\d+)/;
 
-sub http_daemon {
-	my $server = IO::Socket::INET->new(
-		Proto => 'tcp',
-		LocalHost => '127.0.0.1',
-		LocalPort => 8083,
-		Listen => 5,
-		Reuse => 1
-	)
-		or die "Can't create listening socket: $!\n";
+	kill 'HUP', $t->read_file('nginx.pid');
 
-	local $SIG{PIPE} = 'IGNORE';
-
-	while (my $client = $server->accept()) {
-		$client->autoflush(1);
-
-		my $headers = '';
-		my $uri = '';
-
-		while (<$client>) {
-			$headers .= $_;
-			last if (/^\x0d?\x0a?$/);
-		}
-
-		next if $headers eq '';
-		$uri = $1 if $headers =~ /^\S+\s+([^ ]+)\s+HTTP/i;
-
-		if ($uri eq '/cookie') {
-
-			my ($cookie, $cookie2) = $headers =~ /Cookie: (.+)/ig;
-			$cookie2 = '' unless defined $cookie2;
-
-			my ($cookie_a, $cookie_c) = ('', '');
-			$cookie_a = $1 if $headers =~ /X-Cookie-a: (.+)/i;
-			$cookie_c = $1 if $headers =~ /X-Cookie-c: (.+)/i;
-
-			print $client <<EOF;
-HTTP/1.1 200 OK
-Connection: close
-X-Sent-Cookie: $cookie
-X-Sent-Cookie2: $cookie2
-X-Sent-Cookie-a: $cookie_a
-X-Sent-Cookie-c: $cookie_c
-
-EOF
-
-		} elsif ($uri eq '/set-cookie') {
-
-			print $client <<EOF;
-HTTP/1.1 200 OK
-Connection: close
-Set-Cookie: a=b
-Set-Cookie: c=d
-
-EOF
-
-		}
-
-	} continue {
-		close $client;
+	for (1 .. 20) {
+		last if http_get($uri, socket => $sock->($port)) !~ /pid $pid/;
+		select undef, undef, undef, 0.2;
 	}
 }
 


### PR DESCRIPTION
Tested with the **latest** h2.t test in nginx-tests 

```
All tests successful.
Test Summary Report
-------------------
h2.t (Wstat: 0 Tests: 143 Failed: 0)
TODO passed:   137-138
Files=1, Tests=143, 16 wallclock secs ( 0.12 usr  0.01 sys +  1.67 cusr  0.24 csys =  2.04 CPU)
Result: PASS
```


credits:
@VBart, @PiotrSikora, @mdounin, Sergey Kandaurov, Ruslan Ermilov

Origin commits and their authors:
nginx/nginx@6917d29d409b187d440d8e5012a1353398e3a365 HTTP/2: flow control debugging. by Sergey Kandaurov
nginx/nginx@5a273f2e9042b74467ba217800b9c7b2fe3b4a31 HTTP/2: slightly improved debugging. by Ruslan Ermilov
nginx/nginx@df9b2b9011b89614b143808f983ace8ced0f8873 HTTP/2: limited maximum number of requests in connection. by Valentin Bartenev
nginx/nginx@70d0530f8844205cfd78d71f4f0bf20843af778e HTTP/2: graceful shutdown of active connections (closes #1106). by Valentin Bartenev
nginx/nginx@a7f80ec354dd470a1da09585f8a74dd73d3ce883 Modules compatibility: http2. by Maxim Dounin
nginx/nginx@a85edfeef6cdf4094e6e12b663b7371271cb610f HTTP/2: flushing of the SSL buffer in transition to the idle state. by Valentin Bartenev
nginx/nginx@3c81c08ceae2c22cf5d2ba1b637d685e397a68f2 HTTP/2: refactored ngx_http_v2_send_output_queue(). by Valentin Bartenev
nginx/nginx@3b2f54bc2ea0d9d34b3e181f1221a050824e1c1a HTTP/2: fixed send timer handling. by Valentin Bartenev
nginx/nginx@ce6eb33d15f1efd3c418ce7688ed6de3af81cae9 HTTP/2: avoid sending output queue if there's nothing to send. by Valentin Bartenev
nginx/nginx@da852aa468db80f9e5138aea81a1bebb90e0be51 HTTP/2: always handle streams in error state. by Valentin Bartenev
nginx/nginx@19de85a4d75e7eada6afb8f59ce6d5de0ec10d5c HTTP/2: prevented output of the HEADERS frame for canceled streams. by Valentin Bartenev
nginx/nginx@ab5401d204f9cd638204dcabf45152e32920d021 HTTP/2: always send GOAWAY while worker is shutting down. by Valentin Bartenev
nginx/nginx@586ef968f98c379153fea0e7e80119b149380dc8 HTTP/2: avoid left-shifting signed integer into the sign bit. by Sergey Kandaurov
nginx/nginx@e0b0fa6bf55df8c9de0f89dceff0e1b32860a348 HTTP/2: style. by Piotr Sikora
nginx/nginx@6e38998bacb77b1bcaa16a999a722c0c4f961b8e HTTP/2: fixed the "http request count is zero" alert. by Valentin Bartenev
nginx/nginx@bf5f915a019018f914c3f7c59d4a8baf27b93d67 HTTP/2: avoid adding Content-Length for requests without body. by Valentin Bartenev
nginx/nginx@cd2085be0c497153f9311f0a1986c6be6a18cff4 HTTP/2: prevented double termination of a stream. by Valentin Bartenev
nginx/nginx@24d9b98900a5318778dcab3f765e85a8bed5d136 HTTP/2: fixed a segfault while processing unbuffered upload. by Valentin Bartenev
nginx/nginx@b6e423b7c0360cfd4b37431773cc8311129e1e4d HTTP/2: unbreak build on MSVC. by Valentin Bartenev
nginx/nginx@5429140c018726e8b28c724b06daaf0fe33d2205 HTTP/2: implemented preread buffer for request body (closes #959). by Valentin Bartenev
nginx/nginx@f7673bb50f758cb421ca3a5186c49292a85d08ae HTTP/2: the "421 Misdirected Request" response (closes #848). by Valentin Bartenev
nginx/nginx@22285687c9abac86b91a76b22ef03380f647b29a HTTP/2: send the output queue after emitting WINDOW_UPDATE. by Valentin Bartenev
nginx/nginx@7458f6667530aef24272e5b5dc8815c27b35b05f HTTP/2: skip data frames in case of internal errors. by Valentin Bartenev
nginx/nginx@f4df08b19d5e2e9f5454b3850a0c01bc4f356125 HTTP/2: don't send WINDOW_UPDATE for an empty request body. by Valentin Bartenev
nginx/nginx@eb38cbda2fcf318b9e1f2e463705658c286ec04e HTTP/2: write logs when refusing streams with data. by Maxim Dounin
nginx/nginx@7691b9750e0d3a2137e9d9188db65f7e39624b97 HTTP/2: send WINDOW_UPDATE instead of RST_STREAM with NO_ERROR. by Valentin Bartenev
nginx/nginx@536b5510d1051281bd9411723102333e6d1dbdf2 HTTP/2: refuse streams with data until SETTINGS is acknowledged. by Valentin Bartenev
nginx/nginx@60f0960ab6cb35a6fffc57f32c311c93c28181af HTTP/2: deduplicated some code in ngx_http_v2_state_headers(). by Valentin Bartenev
nginx/nginx@74ee55ec1b49266865646d488026f3e6802e1b85 HTTP/2: support for unbuffered upload of request body. by Valentin Bartenev
nginx/nginx@948eeca222c67dc6954ec0e68bf5c18e97e1a784 HTTP/2: rewritten handling of request body. by Valentin Bartenev
nginx/nginx@cedba685a1eb18ca960b2eab3fafdc2afdbd624a HTTP/2: sending RST_STREAM with NO_ERROR to discard request body. by Valentin Bartenev
nginx/nginx@ae5e76ea06380be3b9191a3ce11f3e86e8878019 HTTP/2: improved debugging of sending control frames. by Valentin Bartenev
nginx/nginx@f72bcf8285bceb07bdf2ce5736f10645a75619f7 HTTP/2: implemented per request timeouts (closes #626). by Valentin Bartenev
nginx/nginx@4e6a490fa7ecb227296e277e2c3b7664441e5b40 HTTP/2: always use temporary pool for processing headers. by Valentin Bartenev
nginx/nginx@8b40f1eaec90be72e791904b345db15f536dca45 HTTP/2: cleaned up state while closing stream. by Valentin Bartenev
nginx/nginx@b5d7d3f024f587682e320d891e52e693939a5f14 HTTP/2: added debug logging of response headers. by Valentin Bartenev
nginx/nginx@fcfe4832927557087365bb5d2e2a296336966317 HTTP/2: use local pointer instead of r->connection. by Valentin Bartenev
nginx/nginx@822fc91b093b85a94ca54fc8c7e2d85fc5a4daf8 HTTP/2: fixed undefined behavior in ngx_http_v2_huff_encode(). by Valentin Bartenev
nginx/nginx@531e6fbfd6c785a7b42c285c12d3f0721cc989c7 HTTP/2: implemented HPACK Huffman encoding for response headers. by Valentin Bartenev
nginx/nginx@9add42c71e71c2af8e67eceeeb773d22a9cab760 HTTP/2: fixed possible buffer overrun (ticket #893). by Valentin Bartenev
nginx/nginx@cb173ff6722635188546ce7dd8f2a737050d82d5 HTTP/2: fixed padding handling in HEADERS frame with CONTINUATION. by Valentin Bartenev
nginx/nginx@8050277acf9d87ac72fe4c5547838a7ba425999a HTTP/2: fixed request length accounting. by Valentin Bartenev
nginx/nginx@405f4f99b4471a3073304f9ce689000dcb592ee4 HTTP/2: fixed excessive memory allocation for pool cleanup. by Valentin Bartenev
nginx/nginx@3351fbe48124b0e56f1478536089073db8fd2d7d HTTP/2: removed unused field from ngx_http_v2_stream_t. by Valentin Bartenev