### PR TITLE
reuse_port: fixed "duplicate listen options" error

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4340,9 +4340,10 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         ecf = ngx_event_get_conf(cf->cycle->conf_ctx, ngx_event_core_module);
 
         if (ecf && ecf->reuse_port == 1) {
+
+            /* set cmcf->ports[].addrs[].lsopt.reuseport */
+
             lsopt.reuseport = 1;
-            lsopt.set = 1;
-            lsopt.bind = 1;
         }
     }
     }


### PR DESCRIPTION
`lsopt->set` is only used for checking duplicate listen options.
If reuseport is enabled globally via `events {reuse_port on'}`, this option checking is unnecessary.
Also, be aware that `lsopt->bind` is of no use in nginx source.