### PR TITLE
在一个Server上开启Http/2.0后，其他ssl的Server也会自动开启Http/2.0协议

### DIFF
--- a/src/http/ngx_http_upstream_check_module.c
+++ b/src/http/ngx_http_upstream_check_module.c
@@ -3758,6 +3758,23 @@ ngx_http_upstream_check_http_send(ngx_conf_t *cf, ngx_command_t *cmd,
 
     ucscf = ngx_http_conf_get_module_srv_conf(cf,
                                               ngx_http_upstream_check_module);
+    if (ucscf->check_type_conf == NGX_CONF_UNSET_PTR)
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid check_http_send should set [check] first");
+        return NGX_CONF_ERROR;
+    }
+
+    if (value[1].len
+        && (ucscf->check_type_conf->name.len != 4
+            || ngx_strncmp(ucscf->check_type_conf->name.data,
+                           "http", 4) != 0))
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid check_http_send for type \"%V\"",
+                           &ucscf->check_type_conf->name);
+        return NGX_CONF_ERROR;
+    }
 
     ucscf->send = value[1];
 

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check.t
@@ -538,3 +538,59 @@ GET /
 --- request
 GET /
 --- response_body_like: ^<(.*)>$
+
+=== TEST 19: the http_check with type!=http and check_http_send configured
+--- http_config
+    upstream test{
+        server 127.0.0.1:1970;
+        check_keepalive_requests 10;
+        check interval=3000 rise=1 fall=1 timeout=1000 type=tcp;
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- nginx config test
+nginx -t
+--- response_body_like: nginx: [emerg] invalid check_http_send for type "tcp" in <(.*)>$
+
+=== TEST 20: the http_check with check_http_send configured before check
+--- http_config
+    upstream test{
+        server 127.0.0.1:1970;
+        check_keepalive_requests 10;
+        check_http_send "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+        check interval=3000 rise=1 fall=1 timeout=1000 type=http;
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test;
+    }
+
+--- nginx config test
+nginx -t
+--- response_body_like: nginx: [emerg] invalid check_http_send should set [check] first in <(.*)>$


### PR DESCRIPTION
在一个Server上开启Http/2.0后，其他ssl的Server也会自动开启Http/2.0协议。使用tengine版本为2.1.3。
协议握手时会不会判断Host对应的Server是否支持Http2.0？

