### PR TITLE
CFLAGS: deprecated system OpenSSL library on OS X

### DIFF
--- a/auto/cc/clang
+++ b/auto/cc/clang
@@ -82,11 +82,16 @@ fi
 # warnings
 
 CFLAGS="$CFLAGS $NGX_CLANG_OPT -Wall -Wextra -Wpointer-arith"
-#CFLAGS="$CFLAGS -Wconditional-uninitialized"
+CFLAGS="$CFLAGS -Wconditional-uninitialized"
 #CFLAGS="$CFLAGS -Wmissing-prototypes"
 
 # we have a lot of unused function arguments
 CFLAGS="$CFLAGS -Wno-unused-parameter"
+
+# deprecated system OpenSSL library on OS X
+if [ "$NGX_SYSTEM" = "Darwin" ]; then
+    CFLAGS="$CFLAGS -Wno-deprecated-declarations"
+fi
 
 # stop on warning
 CFLAGS="$CFLAGS -Werror"

--- a/auto/cc/gcc
+++ b/auto/cc/gcc
@@ -158,6 +158,11 @@ case "$NGX_GCC_VER" in
         CFLAGS="$CFLAGS -Wno-unused-parameter"
         # 4.2.1 shows the warning in wrong places
         #CFLAGS="$CFLAGS -Wunreachable-code"
+
+        # deprecated system OpenSSL library on OS X
+        if [ "$NGX_SYSTEM" = "Darwin" ]; then
+            CFLAGS="$CFLAGS -Wno-deprecated-declarations"
+        fi
     ;;
 
     *)


### PR DESCRIPTION
merged from nginx-1.8.1