### PR TITLE
configure: delete $NGX_SYSLOG variable

### DIFF
--- a/configure
+++ b/configure
@@ -23,10 +23,6 @@ if [ $NGX_DEBUG = YES ]; then
     have=NGX_DEBUG . auto/have
 fi
 
-if [ $NGX_SYSLOG = YES ]; then
-    have=NGX_SYSLOG . auto/have
-fi
-
 if test -z "$NGX_PLATFORM"; then
     echo "checking for OS"
 


### PR DESCRIPTION
fixed configure error:

```
./configure: line 26: [: =: unary operator expected
```