### PR TITLE
Fix HTTP/1.1 upstream health check Host header missing error.

### DIFF
--- a/docs/modules/ngx_http_upstream_check_module.md
+++ b/docs/modules/ngx_http_upstream_check_module.md
@@ -26,7 +26,7 @@ This module is not built by default, it should be enabled with the `--with-http_
 
 			check interval=3000 rise=2 fall=5 timeout=1000 type=http;
 			check_keepalive_requests 100;
-			check_http_send "HEAD / HTTP/1.1\r\nConnection: keep-alive\r\n\r\n";
+			check_http_send "HEAD / HTTP/1.1\r\nConnection: keep-alive\r\nHost: foo.bar.com\r\n\r\n";
 			check_http_expect_alive http_2xx http_3xx;
 		}
 

--- a/docs/modules/ngx_http_upstream_check_module_cn.md
+++ b/docs/modules/ngx_http_upstream_check_module_cn.md
@@ -26,7 +26,7 @@
 
 			check interval=3000 rise=2 fall=5 timeout=1000 type=http;
 			check_keepalive_requests 100;
-			check_http_send "HEAD / HTTP/1.1\r\nConnection: keep-alive\r\n\r\n";
+			check_http_send "HEAD / HTTP/1.1\r\nConnection: keep-alive\r\nHost: foo.bar.com\r\n\r\n";
 			check_http_expect_alive http_2xx http_3xx;
 		}
 


### PR DESCRIPTION
```
A client MUST include a Host header field in all HTTP/1.1 request messages
```

[Reference rfc2616](https://tools.ietf.org/html/rfc2616#section-14.23)