### PR TITLE
Fix: when the worker_processes is set to auto, the reuse_port did not work

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -1359,7 +1359,7 @@ ngx_set_worker_processes(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (ngx_strncasecmp((u_char *) "auto", value[1].data, 4) == 0) {
 
-        ccf->worker_processes = 0;
+        ccf->worker_processes = ngx_ncpu;
 
         return NGX_CONF_OK;
     }


### PR DESCRIPTION
 
 Details are described as https://github.com/alibaba/tengine/issues/770 said.