### PR TITLE
add sysguard_cpu direcitve for sysguard module

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -316,6 +316,17 @@ ngx_feature_test='int fd;
 . auto/feature
 
 
+ngx_feature="/proc/stat"
+ngx_feature_name="NGX_HAVE_PROC_STAT"
+ngx_feature_run=yes
+ngx_feature_incs="#include <fcntl.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test='int fd;
+                  if (open("/proc/stat", O_RDONLY) == -1) return 1;'
+. auto/feature
+
+
 ngx_feature="sched_yield()"
 ngx_feature_name="NGX_HAVE_SCHED_YIELD"
 ngx_feature_run=no

--- a/docs/modules/ngx_http_sysguard.md
+++ b/docs/modules/ngx_http_sysguard.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This module monitors memory usage (including the swap partition), load of CPUs and average response time of requests of the system. If any guideline that is monitored exceeds the threshold set by user, the current request will be redirected to a specific url. To be clarified, this module can only be full functional when the system supports sysinfo function and loadavg function. The sysguard module also need to read memory information from /proc file system.
+This module monitors memory usage (including the swap partition), load of CPUs and average response time of requests of the system and cpu usage. If any guideline that is monitored exceeds the threshold set by user, the current request will be redirected to a specific url. To be clarified, this module can only be full functional when the system supports sysinfo function and loadavg function. The sysguard module also need to read memory information from /proc file system.
 
 ## Configuration
 
@@ -30,6 +30,10 @@ This module monitors memory usage (including the swap partition), load of CPUs a
         location /rtlimit {
             return 503;
         }
+        
+        location /cpulimit {
+            return 503;
+        }        
     }
 
 ## Directives
@@ -56,6 +60,28 @@ This directive tells the module to protect the system by monitoring the load of 
 <br/>
 <br/>
 
+**sysguard_cpu** `usage=num [period=time] [action=/url]`
+
+**Default:** `period=3s`
+
+**Context:** `http, server, location`
+
+This directive tells the module to protect the system by monitoring the CPU usage. When the system in the `period` (` units: s `) within the CPU reach to num (` note: ` the num is a integer. such as protection CPU is 50% and could be set the usage = 50), the incoming request will be redirected to the url specified by 'action' parameter. If the action is not configured, tengine will return 503 directly.
+
+
+```
+cpu usage formula：
+    cpu_usage = [(cur.usr + cur.nice + cur.sys) - (pre.usr + pre.nice + pre.sys)]/
+                [(cur.usr + cur.nice + cur.sys + cur.iowait + cur.irq 
+                 + cur.softirq + cur.idle)
+                 - (pre.usr + pre.nice + pre.sys + pre.iowait + pre.irq 
+                 + pre.softirq + pre.idle)] * 100
+```
+
+<br/>
+<br/>
+
+
 **sysguard_mem** `[swapratio=ratio%] [free=size] [action=/url]`
 
 **Default:** `-`
@@ -80,31 +106,31 @@ This directive is used to tell the module to protect the system by monitoring av
 
 **sysguard_mode** `and` | `or`
 
-**Default:**  'sysguard_mode or' 
+**Default:**  `sysguard_mode or` 
 
-**Context** 'http, server, location'
+**Context** `http, server, location`
 
 If there are more than one type of monitor, this directive is used to specified the relations among all the monitors which are: 'and' for all matching and 'or' for any matching.
 
 <br/>
 <br/>
 
-**sysguard_interval** 'time'
+**sysguard_interval** `time`
        
-**Default** 'sysguard_interval 1s'
+**Default** `sysguard_interval 1s`
          
-**Context** 'http, server, location'
+**Context** `http, server, location`
        
 Specify the time interval to update your system information.
 
 <br/>
 <br/>
 
-**sysguard_log_level** '[info | notice | warn | error]'
+**sysguard_log_level** `[info | notice | warn | error]`
        
-**Default** 'sysguard_log_level error'
+**Default** `sysguard_log_level error`
          
-**Context** 'http, server, location'
+**Context** `http, server, location`
        
 Specify the log level of sysguard.
 

--- a/docs/modules/ngx_http_sysguard_cn.md
+++ b/docs/modules/ngx_http_sysguard_cn.md
@@ -11,6 +11,7 @@
         sysguard_mode or;
 
         sysguard_load load=10.5 action=/loadlimit;
+        sysguard_cpu usage=20 period=3s action=/cpulimit;
         sysguard_mem swapratio=20% action=/swaplimit;
         sysguard_mem free=100M action=/freelimit;
         sysguard_rt rt=0.01 period=5s action=/rtlimit;
@@ -28,6 +29,10 @@
         }
 
         location /rtlimit {
+            return 503;
+        }
+
+        location /cpulimit {
             return 503;
         }
     }
@@ -56,6 +61,26 @@
 <br/>
 <br/>
 
+**sysguard_cpu** `usage=num [period=time] [action=/url]`
+
+**默认:** `period=3s`
+
+**上下文:** `http, server, location`
+
+该指令用于配置根据系统的cpu来限制用户的请求，以保护系统。当系统在period(`单位：s`)内的cpu达到num(`注意：` 取值是整数：如cpu保护阀值想设置为50%则可设置usage=50)时，将进来的请求转到action所指定的url。如果action没有配置，则直接返回503错误。
+
+```
+计算公式：
+    cpu_usage = [(cur.usr + cur.nice + cur.sys) - (pre.usr + pre.nice + pre.sys)]/
+                [(cur.usr + cur.nice + cur.sys + cur.iowait + cur.irq 
+                 + cur.softirq + cur.idle)
+                 - (pre.usr + pre.nice + pre.sys + pre.iowait + pre.irq 
+                 + pre.softirq + pre.idle)] * 100
+```
+
+<br/>
+<br/>
+
 **sysguard_mem** `[swapratio=ratio%] [free=size] [action=/url]`
 
 **默认:** `-`
@@ -80,31 +105,31 @@
 
 **sysguard_mode** `and` | `or`
 
-**默认:**  'sysguard_mode or' 
+**默认:**  `sysguard_mode or` 
 
-**上下文** 'http, server, location'
+**上下文** `http, server, location`
 
 如果设置了多个监控指标，此参数用于指定指标间的判断关系，and为全部满足，or为任一满足。
 
 <br/>
 <br/>
 
-**sysguard_interval** 'time'
+**sysguard_interval** `time`
        
-**默认** 'sysguard_interval 1s'
+**默认** `sysguard_interval 1s`
          
-**上下文** 'http, server, location'
+**上下文** `http, server, location`
        
 该指定用于配置获取系统信息时的缓存时间。默认为1s，则表示在这1s内，只调用一次系统函数来获取系统的当前状况。
 
 <br/>
 <br/>
 
-**sysguard_log_level** '[info | notice | warn | error]'
+**sysguard_log_level** `[info | notice | warn | error]`
        
-**默认** 'sysguard_log_level error'
+**默认** `sysguard_log_level error`
          
-**上下文** 'http, server, location'
+**上下文** `http, server, location`
        
 该指令用于配置，当保护系统的操作执行时，记录日志时的日志级别。
 

--- a/src/os/unix/ngx_sysinfo.h
+++ b/src/os/unix/ngx_sysinfo.h
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (C) 2010-2015 Alibaba Group Holding Limited
+ * Copyright (C) 2010-2017 Alibaba Group Holding Limited
  */
 
 
@@ -23,7 +22,21 @@ typedef struct {
 } ngx_meminfo_t;
 
 
+typedef struct {
+    time_t usr;
+    time_t nice;
+    time_t sys;
+    time_t idle;
+    time_t iowait;
+    time_t irq;
+    time_t softirq;    
+}ngx_cpuinfo_t;
+
+
 ngx_int_t ngx_getloadavg(ngx_int_t avg[], ngx_int_t nelem, ngx_log_t *log);
 ngx_int_t ngx_getmeminfo(ngx_meminfo_t *meminfo, ngx_log_t *log);
+ngx_int_t ngx_getcpuinfo(ngx_str_t *cpunumber, ngx_cpuinfo_t *cpuinfo,
+    ngx_log_t *log);
 
 #endif /* _NGX_SYSINFO_H_INCLUDED_ */
+


### PR DESCRIPTION
add sysguard_cpu direcitve for sysguard module, described as follows:

**sysguard_cpu** `usage=num [period=time] [action=/url]`

**Default:** `period=3s`

**Context:** `http, server, location`

This directive tells the module to protect the system by monitoring the CPU usage. When the system in the `period` (` units: s `) within the CPU reach to num (` note: ` the num is a integer. such as protection CPU is 50% and could be set the usage = 50), the incoming request will be redirected to the url specified by 'action' parameter. If the action is not configured, tengine will return 503 directly.
```  
cpu usage formula
    cpu_usage = [(cur.usr + cur.nice + cur.sys) - (pre.usr + pre.nice + pre.sys)]/
                [(cur.usr + cur.nice + cur.sys + cur.iowait + cur.irq 
                 + cur.softirq + cur.idle)
                 - (pre.usr + pre.nice + pre.sys + pre.iowait + pre.irq 
                 + pre.softirq + pre.idle)] * 100
```
```
ok 1 - load_limit
ok 2 - load_unlimit
ok 3 - cpu_limit
ok 4 - cpu_unlimit
ok 5 - free_unlimit
ok 6 - free_limit
ok 7 - mem_load_limit
ok 8 - mem_load_limit1
ok 9 - mem_load_limit2
ok 10 - mem_load_limit3
ok 11 - mem_cpu_limit
ok 12 - mem_cpu_limit1
ok 13 - mem_cpu_limit2
ok 14 - rt_limit
ok 15 - load_and_rt_limit
ok 16 - load_or_rt_limit
ok 17 - load_or_rt_limit1
ok 18 - load_or_rt_limit2
ok 19 - rt_unlimit
ok 20 - load_and_rt_unlimit
ok 21 - load_and_rt_unlimit1
ok 22 - load_and_rt_unlimit2
ok 23 - load_or_rt_unlimit
ok 24 - load_and_mem_and_rt_limit
ok 25 - cpu_and_mem_limit
ok 26 - cpu_and_mem_unlimit
ok 27 - no alerts
ok 28 - no sanitizer errors
ok
All tests successful.
Files=1, Tests=28, 109 wallclock secs ( 0.04 usr  0.01 sys + 422.61 cusr  1.07 csys = 423.73 CPU)
Result: PASS
```

