### PR TITLE
Feature:  add local dns cache

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -955,3 +955,6 @@ END
     done
 
 fi
+
+have=T_NGX_DNS_RESOLVE_BACKUP . auto/have
+have=T_NGX_MASTER_ENV . auto/have

--- a/docs/core.md
+++ b/docs/core.md
@@ -32,6 +32,19 @@ Set the number of worker processes.
 When set to 'auto', which is also the default behavior, Tengine will create the same number of worker processes as your CPUs.
 
 
+### master_env
+
+Syntax: **master_env** variable[=value];
+
+Default: -
+
+Context: main
+
+If use `master_env` directive to set `NGX_DNS_RESOLVE_BACKUP_PATH` environment variable and dns cache will be enabled.
+When the dns server is unavailable, it's will use the last dns cache.
+
+For example `master_env NGX_DNS_RESOLVE_BACKUP_PATH=/home/tengine/worker/dnscache/path`, the domain A record results will be saved to the file and path depends on  `NGX_DNS_RESOLVE_BACKUP_PATH`.
+
 ### worker_cpu_affinity
 
 Syntax: **worker_cpu_affinity** [mask1 mask2 mask3 ... | auto | off]

--- a/docs/core_cn.md
+++ b/docs/core_cn.md
@@ -30,6 +30,19 @@ Context: core
 为worker_processes增加参数auto。当设置成auto，tengine将自动启动与cpu数量相同的worker进程。
 
 
+
+### master_env
+
+Syntax: **master_env** variable[=value];
+
+Default: -
+
+Context: core
+
+当使用`master_env`指令设置`NGX_DNS_RESOLVE_BACKUP_PATH`环境变量后将会开启dns缓存容灾逻辑。即当dns服务器不可用时，使用上次dns缓存的A记录。
+比如设置`master_env NGX_DNS_RESOLVE_BACKUP_PATH=/home/tengine/worker/dnscache/path;`将会把配置中的域名解析结果缓存到`NGX_DNS_RESOLVE_BACKUP_PATH`所设置的路径下。
+
+
 ### worker_cpu_affinity
 
 Syntax: **worker_cpu_affinity** [mask1 mask2 mask3 ... | auto | off ]

--- a/src/core/ngx_inet.h
+++ b/src/core/ngx_inet.h
@@ -39,6 +39,9 @@
 #define NGX_SOCKADDRLEN       512
 #endif
 
+#if (T_NGX_DNS_RESOLVE_BACKUP)
+#define NGX_DNS_RESOLVE_BACKUP_PATH             "NGX_DNS_RESOLVE_BACKUP_PATH"
+#endif
 
 typedef struct {
     in_addr_t                 addr;


### PR DESCRIPTION
Add local dns cache, for avoid the tengine reload、start or stop etc failed when the DNS server is unavailable. described as follows:

### master_env    
Syntax: **master_env** variable[=value];   
Default: -   
Context: main   

If use `master_env` directive to set `NGX_DNS_RESOLVE_BACKUP_PATH` environment variable and dns cache will be enabled. When the dns server is unavailable, it's will use the last dns cache.

For example `master_env NGX_DNS_RESOLVE_BACKUP_PATH=/home/tengine/worker/dnscache/path`, and the domain A record results will be saved to the file and path depends on  `NGX_DNS_RESOLVE_BACKUP_PATH`.

