### PR TITLE
Fix: set r->us_tries to 1, avoid try again one more than proxy_upstream_tries for lua subrequest

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -959,3 +959,4 @@ fi
 have=T_NGX_DNS_RESOLVE_BACKUP . auto/have
 have=T_NGX_MASTER_ENV . auto/have
 have=T_PIPES . auto/have
+have=T_TENGINE_FIX . auto/have

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -3917,6 +3917,13 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
 
     if (status) {
         u->state->status = status;
+#if (T_TENGINE_FIX)
+        /* set r->us_tries = 1 for lua subrequest */
+        if (r->us_tries == 0) {
+            r->us_tries = 1;
+        }
+#endif
+
         timeout = u->conf->next_upstream_timeout;
 
         if (u->conf->upstream_tries != NGX_CONF_UNSET_UINT


### PR DESCRIPTION
In the lua subrequest scenario, the number of retries backend is more than the proxy_upstream_tries.