### PR TITLE
OpenSSL-1.1.0 asynchronous SSL/TLS mode support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,6 +7,7 @@
  * Copyright (C) 2011-2013 Weibin Yao
  * Copyright (C) 2012-2013 Sogou, Inc.
  * Copyright (C) 2012-2013 NetEase, Inc.
+ * Copyright (C) 2014-2017 Intel, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/auto/cc/gcc
+++ b/auto/cc/gcc
@@ -48,9 +48,9 @@ esac
 
 # optimizations
 
-#NGX_GCC_OPT="-O2"
+NGX_GCC_OPT="-O2 -D_FORTIFY_SOURCE=2"
 #NGX_GCC_OPT="-Os"
-NGX_GCC_OPT="-O"
+#NGX_GCC_OPT="-O"
 
 #CFLAGS="$CFLAGS -fomit-frame-pointer"
 
@@ -180,6 +180,9 @@ CFLAGS="$CFLAGS -g"
 
 # DragonFly's gcc3 generates DWARF
 #CFLAGS="$CFLAGS -g -gstabs"
+
+CFLAGS="$CFLAGS -fstack-protector -fPIE -fPIC -Wformat -Wformat-security"
+CORE_LINK="-z noexecstack -z relro -z now -pie"
 
 if [ ".$CPP" = "." ]; then
     CPP="$CC -E"

--- a/docs/modules/ngx_http_ssl_asynchronous_mode.md
+++ b/docs/modules/ngx_http_ssl_asynchronous_mode.md
@@ -1,0 +1,69 @@
+Name
+====
+
+* Nginx SSL/TLS asynchronous mode
+
+Description
+===========
+
+Provide information about how to enable SSL/TLS asynchronous in Nginx.
+* SSL/TLS asynchronous mode is provided by OpenSSL 1.1.0+ version
+
+Compilation
+===========
+
+Build Nginx with configuration item '--with-http_ssl_module'
+
+Directives
+===========
+
+**Syntax**:     ssl_asynch on | off;
+
+**Default**:  ssl_asynch off;
+
+**Context**:    http, server
+
+Enables SSL/TLS asynchronous mode for the given virtual server.
+
+Example
+==========
+
+file: conf/nginx.conf
+'''
+    http {
+        ssl_asynch  on;
+        server {
+            ...
+            }
+        }
+    }
+'''
+OR
+'''
+    http {
+        server {
+            ssl_asynch  on;
+            }
+        }
+    }
+'''
+
+Note
+========================
+To demostrate the asynchronous mode of SSL/TLS, it needs an asynchronous enabled
+engine support. As a reference implementation, OpenSSL 1.1.0+ version provides
+an 'dasync' engine which support the asynchronous working flow.
+'dasync' engine will be built as a shared library 'dasync.so' in engines/
+Please use below reference openssl.cnf file to enable it for RSA offloading.
+
+    openssl_conf = openssl_def
+    [openssl_def]
+    engines = engine_section
+    [engine_section]
+    dasync = dasync_section
+    [dasync_section]
+    engine_id = dasync
+    dynamic_path = /path/to/openssl/source/engines/dasync.so
+    default_algorithms = RSA
+
+For more details information, please refer to https://www.openssl.org

--- a/docs/modules/ngx_http_ssl_asynchronous_mode_cn.md
+++ b/docs/modules/ngx_http_ssl_asynchronous_mode_cn.md
@@ -1,0 +1,68 @@
+名称
+====
+
+* Nginx SSL/TLS 异步模式
+
+Description
+===========
+
+本文档提供关于如何在Nginx开启异步SSL/TLS支持的说明.
+* 异步SSL/TLS模式是OpenSSL 1.1.0版本之后引入的新的模式
+
+编译支持
+===========
+
+启用--with-http_ssl_module编译选项
+
+配置项
+===========
+
+**语法**:     ssl_asynch on | off;
+
+**默认值**:  ssl_asynch off;
+
+**作用域**:    http, server
+
+在给定的http块或者虚拟server块中配置启用异步SSL/TLS模式
+
+配置示例
+==========
+
+配置文件: conf/nginx.conf
+'''
+    http {
+        ssl_asynch  on;
+        server {
+            ...
+            }
+        }
+    }
+'''
+或
+'''
+    http {
+        server {
+            ssl_asynch  on;
+            }
+        }
+    }
+'''
+
+说明
+========================
+为了展示Nginx启用异步SSL/TLS的效果，需要OpenSSL在算法层提供支持异步的引擎模块
+在OpenSSL 1.1.0之后的版本中，默认提供了名为'dasync'的参考异步引擎
+在完成OpenSSL编译后,异步引擎'dasync'会以共享库'dasync.so'的形式出现在engines/
+目录下,使用如下openssl.cnf配置文件中的配置可以使能'dasync'异步引擎用于RSA算法
+
+    openssl_conf = openssl_def
+    [openssl_def]
+    engines = engine_section
+    [engine_section]
+    dasync = dasync_section
+    [dasync_section]
+    engine_id = dasync
+    dynamic_path = /path/to/openssl/source/engines/dasync.so
+    default_algorithms = RSA
+
+更多详细信息请参考https://www.openssl.org

--- a/src/core/ngx_buf.h
+++ b/src/core/ngx_buf.h
@@ -143,7 +143,7 @@ typedef struct {
      && !ngx_buf_in_memory(b) && !b->in_file && !b->flush && !b->last_buf)
 
 #define ngx_buf_size(b)                                                      \
-    (ngx_buf_in_memory(b) ? (off_t) (b->last - b->pos):                      \
+    (ngx_buf_in_memory(b) ? (off_t) (unsigned) (b->last - b->pos):           \
                             (b->file_last - b->file_pos))
 
 ngx_buf_t *ngx_create_temp_buf(ngx_pool_t *pool, size_t size);

--- a/src/core/ngx_conf_file.h
+++ b/src/core/ngx_conf_file.h
@@ -173,6 +173,7 @@ struct ngx_conf_s {
 
     ngx_conf_handler_pt   handler;
     char                 *handler_conf;
+    ngx_flag_t            no_ssl_init;
 };
 
 

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -887,7 +887,14 @@ ngx_close_listening_sockets(ngx_cycle_t *cycle)
                      * for closed shared listening sockets unless
                      * the events was explicitly deleted
                      */
-
+#if (NGX_SSL)
+                    if (c->asynch && ngx_del_async_conn) {
+                        if (c->num_async_fds) {
+                            ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                            c->num_async_fds--;
+                        }
+                    }
+#endif
                     ngx_del_event(c->read, NGX_READ_EVENT, 0);
 
                 } else {
@@ -936,6 +943,9 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
 {
     ngx_uint_t         instance;
     ngx_event_t       *rev, *wev;
+#if (NGX_SSL)
+    ngx_event_t       *aev;
+#endif
     ngx_connection_t  *c;
 
     /* disable warning: Win32 SOCKET is u_int while UNIX socket is int */
@@ -972,11 +982,18 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
 
     rev = c->read;
     wev = c->write;
+#if (NGX_SSL)
+    aev = c->async;
+#endif
 
     ngx_memzero(c, sizeof(ngx_connection_t));
 
     c->read = rev;
     c->write = wev;
+#if (NGX_SSL)
+    c->async = aev;
+#endif
+
     c->fd = s;
     c->log = log;
 
@@ -984,17 +1001,32 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
 
     ngx_memzero(rev, sizeof(ngx_event_t));
     ngx_memzero(wev, sizeof(ngx_event_t));
+#if (NGX_SSL)
+    ngx_memzero(aev, sizeof(ngx_event_t));
+#endif
 
     rev->instance = !instance;
     wev->instance = !instance;
+#if (NGX_SSL)
+    aev->instance = !instance;
+#endif
 
     rev->index = NGX_INVALID_INDEX;
     wev->index = NGX_INVALID_INDEX;
+#if (NGX_SSL)
+    aev->index = NGX_INVALID_INDEX;
+#endif
 
     rev->data = c;
     wev->data = c;
+#if (NGX_SSL)
+    aev->data = c;
+#endif
 
     wev->write = 1;
+#if (NGX_SSL)
+    aev->async = 1;
+#endif
 
     return c;
 }
@@ -1033,10 +1065,31 @@ ngx_close_connection(ngx_connection_t *c)
         ngx_del_timer(c->write);
     }
 
+#if (NGX_SSL)
+    if (c->async->timer_set) {
+        ngx_del_timer(c->async);
+    }
+
+    if (c->asynch && ngx_del_async_conn) {
+        if (c->num_async_fds) {
+            ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+            c->num_async_fds--;
+        }
+    }
+#endif
+
     if (ngx_del_conn) {
         ngx_del_conn(c, NGX_CLOSE_EVENT);
 
     } else {
+#if (NGX_SSL)
+        if (c->asynch && ngx_del_async_conn) {
+            if (c->num_async_fds) {
+                ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                c->num_async_fds--;
+            }
+        }
+#endif
         if (c->read->active || c->read->disabled) {
             ngx_del_event(c->read, NGX_READ_EVENT, NGX_CLOSE_EVENT);
         }
@@ -1054,8 +1107,17 @@ ngx_close_connection(ngx_connection_t *c)
         ngx_delete_posted_event(c->write);
     }
 
+#if (NGX_SSL)
+    if (c->async->posted) {
+        ngx_delete_posted_event(c->async);
+    }
+#endif
+
     c->read->closed = 1;
     c->write->closed = 1;
+#if (NGX_SSL)
+    c->async->closed = 1;
+#endif
 
     ngx_reusable_connection(c, 0);
 
@@ -1065,6 +1127,9 @@ ngx_close_connection(ngx_connection_t *c)
 
     fd = c->fd;
     c->fd = (ngx_socket_t) -1;
+#if (NGX_SSL)
+    c->async_fd = (ngx_socket_t) -1;
+#endif
 
     if (ngx_close_socket(fd) == -1) {
 

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -125,9 +125,14 @@ struct ngx_connection_s {
     void               *data;
     ngx_event_t        *read;
     ngx_event_t        *write;
+#if (NGX_SSL)
+    ngx_event_t        *async;
+#endif
 
     ngx_socket_t        fd;
-
+#if (NGX_SSL)
+    ngx_socket_t        async_fd;
+#endif
     ngx_recv_pt         recv;
     ngx_send_pt         send;
     ngx_recv_chain_pt   recv_chain;
@@ -150,6 +155,7 @@ struct ngx_connection_s {
 
 #if (NGX_SSL)
     ngx_ssl_connection_t  *ssl;
+    ngx_flag_t          asynch;
 #endif
 
     struct sockaddr    *local_sockaddr;
@@ -182,7 +188,9 @@ struct ngx_connection_s {
     unsigned            tcp_nopush:2;    /* ngx_connection_tcp_nopush_e */
 
     unsigned            need_last_buf:1;
-
+#if (NGX_SSL)
+    unsigned            num_async_fds:8;
+#endif
 #if (NGX_HAVE_IOCP)
     unsigned            accept_context_updated:1;
 #endif

--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -97,6 +97,7 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
     cycle->pool = pool;
     cycle->log = log;
     cycle->old_cycle = old_cycle;
+    cycle->no_ssl_init = old_cycle->no_ssl_init;
 
     cycle->conf_prefix.len = old_cycle->conf_prefix.len;
     cycle->conf_prefix.data = ngx_pstrdup(pool, &old_cycle->conf_prefix);
@@ -265,6 +266,7 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
     conf.log = log;
     conf.module_type = NGX_CORE_MODULE;
     conf.cmd_type = NGX_MAIN_CONF;
+    conf.no_ssl_init = cycle->no_ssl_init;
 
 #if 0
     log->log_level = NGX_LOG_DEBUG_ALL;
@@ -1039,6 +1041,7 @@ ngx_create_pidfile(ngx_str_t *name, ngx_log_t *log)
         len = ngx_snprintf(pid, NGX_INT64_LEN + 2, "%P%N", ngx_pid) - pid;
 
         if (ngx_write_file(&file, pid, len, 0) == NGX_ERROR) {
+            ngx_close_file(file.fd);
             return NGX_ERROR;
         }
     }

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -60,6 +60,9 @@ struct ngx_cycle_s {
     ngx_connection_t         *connections;
     ngx_event_t              *read_events;
     ngx_event_t              *write_events;
+#if (NGX_SSL)
+    ngx_event_t              *async_events;
+#endif
 
     ngx_cycle_t              *old_cycle;
 
@@ -69,6 +72,7 @@ struct ngx_cycle_s {
     ngx_str_t                 prefix;
     ngx_str_t                 lock_file;
     ngx_str_t                 hostname;
+    ngx_flag_t                no_ssl_init;
 };
 
 

--- a/src/core/ngx_string.h
+++ b/src/core/ngx_string.h
@@ -94,6 +94,16 @@ void *ngx_memcpy(void *dst, const void *src, size_t n);
 
 #else
 
+#if (NGX_SECURE_MEM)
+
+#define _MIN_(a,b) (((a)<(b))?(a):(b))
+#define MEMCPY_S(dest, src, dest_sz, src_sz) \
+            memcpy((void *)(dest), (void *) (src), (size_t)_MIN_(dest_sz, src_sz))
+#define ngx_memcpy(dst, src, n)   (void) MEMCPY_S(dst, src, n, n)
+#define ngx_cpymem(dst, src, n)   (((u_char *) MEMCPY_S(dst, src, n, n)) + (n))
+
+#else
+
 /*
  * gcc3, msvc, and icc7 compile memcpy() to the inline "rep movs".
  * gcc3 compiles memcpy(d, s, 4) to the inline "mov"es.
@@ -102,8 +112,9 @@ void *ngx_memcpy(void *dst, const void *src, size_t n);
 #define ngx_memcpy(dst, src, n)   (void) memcpy(dst, src, n)
 #define ngx_cpymem(dst, src, n)   (((u_char *) memcpy(dst, src, n)) + (n))
 
-#endif
+#endif /* NGX_SECURE_MEM */
 
+#endif /* NGX_MEMCPY_LIMIT */
 
 #if ( __INTEL_COMPILER >= 800 )
 

--- a/src/event/modules/ngx_devpoll_module.c
+++ b/src/event/modules/ngx_devpoll_module.c
@@ -92,6 +92,8 @@ ngx_event_module_t  ngx_devpoll_module_ctx = {
         ngx_devpoll_process_events,        /* process the events */
         ngx_devpoll_init,                  /* init the events */
         ngx_devpoll_done,                  /* done the events */
+        NULL,                              /* add an async conn */
+        NULL                               /* del an async conn */
     }
 
 };

--- a/src/event/modules/ngx_epoll_module.c
+++ b/src/event/modules/ngx_epoll_module.c
@@ -118,6 +118,11 @@ static ngx_int_t ngx_epoll_notify(ngx_event_handler_pt handler);
 #endif
 static ngx_int_t ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer,
     ngx_uint_t flags);
+#if (NGX_SSL)
+static ngx_int_t ngx_epoll_add_async_connection(ngx_connection_t *c);
+static ngx_int_t ngx_epoll_del_async_connection(ngx_connection_t *c,
+    ngx_uint_t flags);
+#endif
 
 #if (NGX_HAVE_FILE_AIO)
 static void ngx_epoll_eventfd_handler(ngx_event_t *ev);
@@ -188,6 +193,13 @@ ngx_event_module_t  ngx_epoll_module_ctx = {
         ngx_epoll_process_events,        /* process the events */
         ngx_epoll_init,                  /* init the events */
         ngx_epoll_done,                  /* done the events */
+#if (NGX_SSL)
+        ngx_epoll_add_async_connection,  /* add an async conn */
+        ngx_epoll_del_async_connection   /* del an async conn */
+#else
+        NULL,                            /* add an async conn */
+        NULL                             /* del an async conn */
+#endif
     }
 };
 
@@ -540,13 +552,11 @@ ngx_epoll_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags)
     ngx_log_debug3(NGX_LOG_DEBUG_EVENT, ev->log, 0,
                    "epoll add event: fd:%d op:%d ev:%08XD",
                    c->fd, op, ee.events);
-
     if (epoll_ctl(ep, op, c->fd, &ee) == -1) {
         ngx_log_error(NGX_LOG_ALERT, ev->log, ngx_errno,
-                      "epoll_ctl(%d, %d) failed", op, c->fd);
+                      "socket add event epoll_ctl(%d, %d) failed", op, c->fd);
         return NGX_ERROR;
     }
-
     ev->active = 1;
 #if 0
     ev->oneshot = (flags & NGX_ONESHOT_EVENT) ? 1 : 0;
@@ -601,13 +611,11 @@ ngx_epoll_del_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags)
     ngx_log_debug3(NGX_LOG_DEBUG_EVENT, ev->log, 0,
                    "epoll del event: fd:%d op:%d ev:%08XD",
                    c->fd, op, ee.events);
-
     if (epoll_ctl(ep, op, c->fd, &ee) == -1) {
         ngx_log_error(NGX_LOG_ALERT, ev->log, ngx_errno,
-                      "epoll_ctl(%d, %d) failed", op, c->fd);
+                      "socket del event epoll_ctl(%d, %d) failed", op, c->fd);
         return NGX_ERROR;
     }
-
     ev->active = 0;
 
     return NGX_OK;
@@ -624,13 +632,11 @@ ngx_epoll_add_connection(ngx_connection_t *c)
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
                    "epoll add connection: fd:%d ev:%08XD", c->fd, ee.events);
-
     if (epoll_ctl(ep, EPOLL_CTL_ADD, c->fd, &ee) == -1) {
         ngx_log_error(NGX_LOG_ALERT, c->log, ngx_errno,
-                      "epoll_ctl(EPOLL_CTL_ADD, %d) failed", c->fd);
+                      "socket add_conn epoll_ctl(EPOLL_CTL_ADD, %d) failed", c->fd);
         return NGX_ERROR;
     }
-
     c->read->active = 1;
     c->write->active = 1;
 
@@ -665,7 +671,7 @@ ngx_epoll_del_connection(ngx_connection_t *c, ngx_uint_t flags)
 
     if (epoll_ctl(ep, op, c->fd, &ee) == -1) {
         ngx_log_error(NGX_LOG_ALERT, c->log, ngx_errno,
-                      "epoll_ctl(%d, %d) failed", op, c->fd);
+                     "socket del conn epoll_ctl(%d, %d) failed", op, c->fd);
         return NGX_ERROR;
     }
 
@@ -675,6 +681,53 @@ ngx_epoll_del_connection(ngx_connection_t *c, ngx_uint_t flags)
     return NGX_OK;
 }
 
+#if (NGX_SSL)
+static ngx_int_t
+ngx_epoll_add_async_connection(ngx_connection_t *c)
+{
+    struct epoll_event  ee;
+
+    ee.events = EPOLLIN|EPOLLOUT|EPOLLET|EPOLLRDHUP;
+    ee.data.ptr = (void *) ((uintptr_t) c | (c->async->async << 1) | c->async->instance);
+
+    ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "epoll add async connection: fd:%d ev:%08XD", c->async_fd, ee.events);
+    if (epoll_ctl(ep, EPOLL_CTL_ADD, c->async_fd, &ee) == -1) {
+        ngx_log_error(NGX_LOG_ALERT, c->log, ngx_errno,
+                      "async add conn epoll_ctl(EPOLL_CTL_ADD, %d) failed", c->async_fd);
+        return NGX_ERROR;
+    }
+
+    c->async->active = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_epoll_del_async_connection(ngx_connection_t *c, ngx_uint_t flags)
+{
+    int                 op;
+    struct epoll_event  ee;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "epoll del async connection: fd:%d", c->async_fd);
+
+    op = EPOLL_CTL_DEL;
+    ee.events = 0;
+    ee.data.ptr = NULL;
+    if (epoll_ctl(ep, op, c->async_fd, &ee) == -1) {
+        ngx_log_error(NGX_LOG_ALERT, c->log, ngx_errno,
+                      "async del conn epoll_ctl(%d, %d) failed", op, c->async_fd);
+        c->async_fd = -1;
+        return NGX_ERROR;
+    }
+    c->async_fd = -1;
+    c->async->active = 0;
+
+    return NGX_OK;
+}
+#endif
 
 #if (NGX_HAVE_EVENTFD)
 
@@ -708,6 +761,10 @@ ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
     ngx_event_t       *rev, *wev;
     ngx_queue_t       *queue;
     ngx_connection_t  *c;
+#if (NGX_SSL)
+    ngx_int_t          async;
+    ngx_event_t       *aev;
+#endif
 
     /* NGX_TIMER_INFINITE == INFTIM */
 
@@ -754,7 +811,12 @@ ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
         c = event_list[i].data.ptr;
 
         instance = (uintptr_t) c & 1;
+#if (NGX_SSL)
+        async = ((uintptr_t) c & 2) >> 1;
+        c = (ngx_connection_t *) ((uintptr_t) c & (uintptr_t) ~3);
+#else
         c = (ngx_connection_t *) ((uintptr_t) c & (uintptr_t) ~1);
+#endif
 
         rev = c->read;
 
@@ -802,7 +864,11 @@ ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
             revents |= EPOLLIN|EPOLLOUT;
         }
 
+#if (NGX_SSL)
+        if ((revents & EPOLLIN) && rev->active && !async) {
+#else
         if ((revents & EPOLLIN) && rev->active) {
+#endif
 
 #if (NGX_HAVE_EPOLLRDHUP)
             if (revents & EPOLLRDHUP) {
@@ -825,7 +891,11 @@ ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
 
         wev = c->write;
 
+#if (NGX_SSL)
+        if ((revents & EPOLLOUT) && wev->active && !async) {
+#else
         if ((revents & EPOLLOUT) && wev->active) {
+#endif
 
             if (c->fd == -1 || wev->instance != instance) {
 
@@ -848,6 +918,33 @@ ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
                 wev->handler(wev);
             }
         }
+
+#if (NGX_SSL)
+        aev = c->async;
+
+        if ((revents & EPOLLIN) && aev->active && async) {
+
+            if (c->async_fd == -1 || aev->instance!= instance) {
+                /*
+                 * the stale event from a file descriptor
+                 * that was just closed in this iteration
+                 */
+
+                ngx_log_debug1(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
+                               "epoll: stale event %p", c);
+                continue;
+            }
+
+            aev->ready = 1;
+
+            if (flags & NGX_POST_EVENTS) {
+                ngx_post_event(aev, &ngx_posted_events);
+
+            } else {
+                aev->handler(aev);
+            }
+        }
+#endif
     }
 
     return NGX_OK;

--- a/src/event/modules/ngx_eventport_module.c
+++ b/src/event/modules/ngx_eventport_module.c
@@ -185,6 +185,8 @@ ngx_event_module_t  ngx_eventport_module_ctx = {
         ngx_eventport_process_events,      /* process the events */
         ngx_eventport_init,                /* init the events */
         ngx_eventport_done,                /* done the events */
+        NULL,                              /* add an async conn */
+        NULL                               /* del an async conn */
     }
 
 };

--- a/src/event/modules/ngx_kqueue_module.c
+++ b/src/event/modules/ngx_kqueue_module.c
@@ -92,7 +92,9 @@ ngx_event_module_t  ngx_kqueue_module_ctx = {
 #endif
         ngx_kqueue_process_events,         /* process the events */
         ngx_kqueue_init,                   /* init the events */
-        ngx_kqueue_done                    /* done the events */
+        ngx_kqueue_done,                   /* done the events */
+        NULL,                              /* add an async conn */
+        NULL                               /* del an async conn */
     }
 
 };

--- a/src/event/modules/ngx_poll_module.c
+++ b/src/event/modules/ngx_poll_module.c
@@ -42,7 +42,9 @@ ngx_event_module_t  ngx_poll_module_ctx = {
         NULL,                              /* trigger a notify */
         ngx_poll_process_events,           /* process the events */
         ngx_poll_init,                     /* init the events */
-        ngx_poll_done                      /* done the events */
+        ngx_poll_done,                     /* done the events */
+        NULL,                              /* add an async conn */
+        NULL                               /* del an async conn */
     }
 
 };

--- a/src/event/modules/ngx_select_module.c
+++ b/src/event/modules/ngx_select_module.c
@@ -50,7 +50,9 @@ ngx_event_module_t  ngx_select_module_ctx = {
         NULL,                              /* trigger a notify */
         ngx_select_process_events,         /* process the events */
         ngx_select_init,                   /* init the events */
-        ngx_select_done                    /* done the events */
+        ngx_select_done,                   /* done the events */
+        NULL,                              /* add an async conn */
+        NULL                               /* del an async conn */
     }
 
 };

--- a/src/event/modules/ngx_win32_select_module.c
+++ b/src/event/modules/ngx_win32_select_module.c
@@ -51,7 +51,9 @@ ngx_event_module_t  ngx_select_module_ctx = {
         NULL,                              /* trigger a notify */
         ngx_select_process_events,         /* process the events */
         ngx_select_init,                   /* init the events */
-        ngx_select_done                    /* done the events */
+        ngx_select_done,                   /* done the events */
+        NULL,                              /* add an async conn */
+        NULL                               /* del an async conn */
     }
 
 };

--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -191,7 +191,7 @@ ngx_event_module_t  ngx_event_core_module_ctx = {
     ngx_event_core_create_conf,            /* create configuration */
     ngx_event_core_init_conf,              /* init configuration */
 
-    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
+    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
 
 
@@ -594,6 +594,9 @@ ngx_event_process_init(ngx_cycle_t *cycle)
 {
     ngx_uint_t           m, i;
     ngx_event_t         *rev, *wev;
+#if (NGX_SSL)
+    ngx_event_t         *aev;
+#endif
     ngx_listening_t     *ls;
     ngx_connection_t    *c, *next, *old;
     ngx_core_conf_t     *ccf;
@@ -732,6 +735,20 @@ ngx_event_process_init(ngx_cycle_t *cycle)
         wev[i].closed = 1;
     }
 
+#if (NGX_SSL)
+    cycle->async_events = ngx_alloc(sizeof(ngx_event_t) * cycle->connection_n,
+                                    cycle->log);
+    if (cycle->async_events == NULL) {
+        return NGX_ERROR;
+    }
+
+    aev = cycle->async_events;
+    for (i = 0; i < cycle->connection_n; i++) {
+        aev[i].closed = 1;
+        aev[i].instance = 1;
+    }
+#endif
+
     i = cycle->connection_n;
     next = NULL;
 
@@ -742,6 +759,10 @@ ngx_event_process_init(ngx_cycle_t *cycle)
         c[i].read = &cycle->read_events[i];
         c[i].write = &cycle->write_events[i];
         c[i].fd = (ngx_socket_t) -1;
+#if (NGX_SSL)
+        c[i].async = &cycle->async_events[i];
+        c[i].async_fd = (ngx_socket_t) -1;
+#endif
 
         next = &c[i];
     } while (i);

--- a/src/event/ngx_event.h
+++ b/src/event/ngx_event.h
@@ -32,6 +32,10 @@ struct ngx_event_s {
 
     unsigned         write:1;
 
+#if (NGX_SSL)
+    unsigned         async:1;
+#endif
+
     unsigned         accept:1;
 
     /* used to detect the stale events in kqueue, rtsig, and epoll */
@@ -101,6 +105,9 @@ struct ngx_event_s {
 #endif
 
     ngx_event_handler_pt  handler;
+#if (NGX_SSL)
+    ngx_event_handler_pt  saved_handler;
+#endif
 
 
 #if (NGX_HAVE_AIO)
@@ -199,6 +206,9 @@ typedef struct {
 
     ngx_int_t  (*init)(ngx_cycle_t *cycle, ngx_msec_t timer);
     void       (*done)(ngx_cycle_t *cycle);
+
+    ngx_int_t  (*add_async_conn)(ngx_connection_t *c);
+    ngx_int_t  (*del_async_conn)(ngx_connection_t *c, ngx_uint_t flags);
 } ngx_event_actions_t;
 
 
@@ -413,6 +423,8 @@ extern ngx_event_actions_t   ngx_event_actions;
 #define ngx_del_event        ngx_event_actions.del
 #define ngx_add_conn         ngx_event_actions.add_conn
 #define ngx_del_conn         ngx_event_actions.del_conn
+#define ngx_add_async_conn   ngx_event_actions.add_async_conn
+#define ngx_del_async_conn   ngx_event_actions.del_async_conn
 
 #define ngx_notify           ngx_event_actions.notify
 

--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -246,6 +246,9 @@ ngx_event_accept(ngx_event_t *ev)
 
         rev->log = log;
         wev->log = log;
+#if (NGX_SSL)
+        c->async->log = log;
+#endif
 
         /*
          * TODO: MT: - ngx_atomic_fetch_add()
@@ -470,6 +473,14 @@ ngx_disable_accept_events(ngx_cycle_t *cycle, ngx_uint_t all)
 
 #endif
 
+#if (NGX_SSL)
+        if (c->asynch && ngx_del_async_conn) {
+            if (c->num_async_fds) {
+                ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                c->num_async_fds--;
+            }
+        }
+#endif
 
         if (ngx_event_flags & NGX_USE_RTSIG_EVENT) {
             if (ngx_del_conn(c, NGX_DISABLE_EVENT) == NGX_ERROR) {

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -39,6 +39,9 @@ ngx_int_t ngx_ssl_session_cache_init(ngx_shm_zone_t *shm_zone, void *data);
 static int ngx_ssl_new_session(ngx_ssl_conn_t *ssl_conn,
     ngx_ssl_session_t *sess);
 static ngx_ssl_session_t *ngx_ssl_get_cached_session(ngx_ssl_conn_t *ssl_conn,
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    const
+#endif
     u_char *id, int len, int *copy);
 static void ngx_ssl_remove_session(SSL_CTX *ssl, ngx_ssl_session_t *sess);
 static void ngx_ssl_expire_sessions(ngx_ssl_session_cache_t *cache,
@@ -60,6 +63,10 @@ static void *ngx_openssl_create_conf(ngx_cycle_t *cycle);
 static char *ngx_openssl_engine(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static void ngx_openssl_exit(ngx_cycle_t *cycle);
 
+static void ngx_ssl_handshake_async_handler(ngx_event_t * aev);
+static void ngx_ssl_read_async_handler(ngx_event_t * aev);
+static void ngx_ssl_write_async_handler(ngx_event_t * aev);
+static void ngx_ssl_shutdown_async_handler(ngx_event_t *aev);
 
 static ngx_command_t  ngx_openssl_commands[] = {
 
@@ -105,9 +112,24 @@ int  ngx_ssl_certificate_index;
 int  ngx_ssl_stapling_index;
 
 
+static void
+ngx_ssl_empty_handler(ngx_event_t *aev)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, aev->log, 0, "ssl empty handler");
+
+    return;
+}
+
+
 ngx_int_t
 ngx_ssl_init(ngx_log_t *log)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+
+    OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+#else
+
 #ifndef OPENSSL_IS_BORINGSSL
     OPENSSL_config(NULL);
 #endif
@@ -116,6 +138,8 @@ ngx_ssl_init(ngx_log_t *log)
     SSL_load_error_strings();
 
     OpenSSL_add_all_algorithms();
+
+#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x0090800fL
 #ifndef SSL_OP_NO_COMPRESSION
@@ -288,6 +312,10 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
 #ifdef SSL_MODE_NO_AUTO_CHAIN
     SSL_CTX_set_mode(ssl->ctx, SSL_MODE_NO_AUTO_CHAIN);
 #endif
+
+    if(ssl->asynch) {
+        SSL_CTX_set_mode(ssl->ctx, SSL_MODE_ASYNC);
+    }
 
     SSL_CTX_set_read_ahead(ssl->ctx, 1);
 
@@ -747,7 +775,7 @@ ngx_ssl_rsa512_key_callback(ngx_ssl_conn_t *ssl_conn, int is_export,
         return NULL;
     }
 
-#ifndef OPENSSL_NO_DEPRECATED
+#if (OPENSSL_VERSION_NUMBER < 0x10100003L && !defined OPENSSL_NO_DEPRECATED)
 
     if (key == NULL) {
         key = RSA_generate_key(512, RSA_F4, NULL, NULL);
@@ -940,6 +968,8 @@ ngx_ssl_dhparam(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *file)
             return NGX_ERROR;
         }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100005L
+
         dh->p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
         dh->g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL);
 
@@ -948,6 +978,23 @@ ngx_ssl_dhparam(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *file)
             DH_free(dh);
             return NGX_ERROR;
         }
+
+#else
+        {
+        BIGNUM  *p, *g;
+
+        p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
+        g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL);
+
+        if (p == NULL || g == NULL || !DH_set0_pqg(dh, p, NULL, g)) {
+            ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0, "BN_bin2bn() failed");
+            DH_free(dh);
+            BN_free(p);
+            BN_free(g);
+            return NGX_ERROR;
+        }
+        }
+#endif
 
         SSL_CTX_set_tmp_dh(ssl->ctx, dh);
 
@@ -1065,6 +1112,7 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
     }
 
     c->ssl = sc;
+    c->asynch = ssl->asynch;
 
     return NGX_OK;
 }
@@ -1083,6 +1131,79 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
     return NGX_OK;
 }
 
+ngx_int_t
+ngx_ssl_async_process_fds(ngx_connection_t *c)
+{
+    OSSL_ASYNC_FD *add_fds = NULL;
+    OSSL_ASYNC_FD *del_fds = NULL;
+    size_t        num_add_fds = 0;
+    size_t        num_del_fds = 0;
+    unsigned      loop = 0;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "ngx_ssl_async_process_fds called");
+
+    if (!ngx_del_async_conn || !ngx_add_async_conn) {
+        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
+                      "Async notifications not supported");
+        return 0;
+    }
+
+    SSL_get_changed_async_fds(c->ssl->connection, NULL, &num_add_fds,
+                              NULL, &num_del_fds);
+
+    if (num_add_fds) {
+        add_fds = ngx_alloc(num_add_fds * sizeof(OSSL_ASYNC_FD), c->log);
+        if (add_fds == NULL) {
+            ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
+                          "Memory Allocation Error");
+            return 0;
+        }
+    }
+
+    if (num_del_fds) {
+        del_fds = ngx_alloc(num_del_fds * sizeof(OSSL_ASYNC_FD), c->log);
+        if (del_fds == NULL) {
+            ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
+                          "Memory Allocation Error");
+            if (add_fds)
+                ngx_free(add_fds);
+            return 0;
+        }
+    }
+
+    SSL_get_changed_async_fds(c->ssl->connection, add_fds, &num_add_fds,
+                              del_fds, &num_del_fds);
+
+    if (num_del_fds) {
+        for (loop = 0; loop < num_del_fds; loop++) {
+            c->async_fd = del_fds[loop];
+            if (c->num_async_fds) {
+                ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0, "%s: deleting fd = %d", __func__, c->async_fd);
+                ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                c->num_async_fds--;
+            }
+        }
+    }
+    if (num_add_fds) {
+        for (loop = 0; loop < num_add_fds; loop++) {
+            if (c->num_async_fds == 0) {
+                c->num_async_fds++;
+                c->async_fd = add_fds[loop];
+                ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0, "%s: adding fd = %d", __func__, c->async_fd);
+                ngx_add_async_conn(c);
+            }
+        }
+    }
+
+    if (add_fds)
+        ngx_free(add_fds);
+    if (del_fds)
+        ngx_free(del_fds);
+
+    return 1;
+}
+
 
 ngx_int_t
 ngx_ssl_handshake(ngx_connection_t *c)
@@ -1097,6 +1218,10 @@ ngx_ssl_handshake(ngx_connection_t *c)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
 
     if (n == 1) {
+
+        if(c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
             return NGX_ERROR;
@@ -1160,6 +1285,7 @@ ngx_ssl_handshake(ngx_connection_t *c)
         c->recv_chain = ngx_ssl_recv_chain;
         c->send_chain = ngx_ssl_send_chain;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #ifdef SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS
 
         /* initial handshake done, disable renegotiation (CVE-2009-3555) */
@@ -1167,6 +1293,7 @@ ngx_ssl_handshake(ngx_connection_t *c)
             c->ssl->connection->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
         }
 
+#endif
 #endif
 
         return NGX_OK;
@@ -1177,6 +1304,10 @@ ngx_ssl_handshake(ngx_connection_t *c)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_get_error: %d", sslerr);
 
     if (sslerr == SSL_ERROR_WANT_READ) {
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
+
         c->read->ready = 0;
         c->read->handler = ngx_ssl_handshake_handler;
         c->write->handler = ngx_ssl_handshake_handler;
@@ -1193,6 +1324,9 @@ ngx_ssl_handshake(ngx_connection_t *c)
     }
 
     if (sslerr == SSL_ERROR_WANT_WRITE) {
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
         c->write->ready = 0;
         c->read->handler = ngx_ssl_handshake_handler;
         c->write->handler = ngx_ssl_handshake_handler;
@@ -1202,6 +1336,22 @@ ngx_ssl_handshake(ngx_connection_t *c)
         }
 
         if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        return NGX_AGAIN;
+    }
+
+    if (c->asynch && sslerr == SSL_ERROR_WANT_ASYNC)
+    {
+        c->async->handler = ngx_ssl_handshake_async_handler;
+        c->read->saved_handler = c->read->handler;
+        c->read->handler = ngx_ssl_empty_handler;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "SSL ASYNC WANT recieved: \"%s\"", __func__);
+
+        if (ngx_ssl_async_process_fds(c) == 0) {
             return NGX_ERROR;
         }
 
@@ -1228,6 +1378,27 @@ ngx_ssl_handshake(ngx_connection_t *c)
     return NGX_ERROR;
 }
 
+static void
+ngx_ssl_handshake_async_handler(ngx_event_t *aev)
+{
+    ngx_connection_t  *c;
+
+    c = aev->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "SSL handshake async handler");
+
+    aev->ready = 0;
+    aev->handler = ngx_ssl_empty_handler;
+    c->read->handler = c->read->saved_handler;
+
+    if (ngx_ssl_handshake(c) == NGX_AGAIN) {
+        return;
+    }
+
+    c->ssl->handler(c);
+}
+
 
 static void
 ngx_ssl_handshake_handler(ngx_event_t *ev)
@@ -1248,6 +1419,11 @@ ngx_ssl_handshake_handler(ngx_event_t *ev)
         return;
     }
 
+    /*
+     * empty the handler of async event to avoid
+     * going back to previous ssl handshake state
+     */
+    c->async->handler = ngx_ssl_empty_handler;
     c->ssl->handler(c);
 }
 
@@ -1419,6 +1595,10 @@ ngx_ssl_handle_recv(ngx_connection_t *c, int n)
 
     if (n > 0) {
 
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
+
         if (c->ssl->saved_write_handler) {
 
             c->write->handler = c->ssl->saved_write_handler;
@@ -1442,6 +1622,9 @@ ngx_ssl_handle_recv(ngx_connection_t *c, int n)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_get_error: %d", sslerr);
 
     if (sslerr == SSL_ERROR_WANT_READ) {
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
         c->read->ready = 0;
         return NGX_AGAIN;
     }
@@ -1450,6 +1633,10 @@ ngx_ssl_handle_recv(ngx_connection_t *c, int n)
 
         ngx_log_error(NGX_LOG_INFO, c->log, 0,
                       "peer started SSL renegotiation");
+
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
 
         c->write->ready = 0;
 
@@ -1469,6 +1656,21 @@ ngx_ssl_handle_recv(ngx_connection_t *c, int n)
         return NGX_AGAIN;
     }
 
+    if (c->asynch && sslerr == SSL_ERROR_WANT_ASYNC) {
+        c->async->handler = ngx_ssl_read_async_handler;
+        c->read->saved_handler = c->read->handler;
+        c->read->handler = ngx_ssl_empty_handler;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "SSL ASYNC WANT recieved: \"%s\"", __func__);
+
+        if (ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
+
+        return NGX_AGAIN;
+    }
+
     c->ssl->no_wait_shutdown = 1;
     c->ssl->no_send_shutdown = 1;
 
@@ -1481,6 +1683,24 @@ ngx_ssl_handle_recv(ngx_connection_t *c, int n)
     ngx_ssl_connection_error(c, sslerr, err, "SSL_read() failed");
 
     return NGX_ERROR;
+}
+
+
+static void
+ngx_ssl_read_async_handler(ngx_event_t *aev)
+{
+    ngx_connection_t  *c;
+
+    c = aev->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "SSL read async handler");
+
+    aev->ready = 0;
+    aev->handler = ngx_ssl_empty_handler;
+    c->read->handler = c->read->saved_handler;
+
+    c->read->handler(c->read);
 }
 
 
@@ -1674,6 +1894,10 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
 
     if (n > 0) {
 
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
+
         if (c->ssl->saved_read_handler) {
 
             c->read->handler = c->ssl->saved_read_handler;
@@ -1699,6 +1923,9 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_get_error: %d", sslerr);
 
     if (sslerr == SSL_ERROR_WANT_WRITE) {
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
         c->write->ready = 0;
         return NGX_AGAIN;
     }
@@ -1708,6 +1935,9 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
         ngx_log_error(NGX_LOG_INFO, c->log, 0,
                       "peer started SSL renegotiation");
 
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
         c->read->ready = 0;
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
@@ -1727,6 +1957,21 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
         return NGX_AGAIN;
     }
 
+    if(c->asynch && sslerr == SSL_ERROR_WANT_ASYNC) {
+        c->async->handler = ngx_ssl_write_async_handler;
+        c->read->saved_handler = c->read->handler;
+        c->read->handler = ngx_ssl_empty_handler;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "SSL ASYNC WANT recieved: \"%s\"", __func__);
+
+        if (ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
+
+        return NGX_AGAIN;
+    }
+
     c->ssl->no_wait_shutdown = 1;
     c->ssl->no_send_shutdown = 1;
     c->write->error = 1;
@@ -1734,6 +1979,24 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
     ngx_ssl_connection_error(c, sslerr, err, "SSL_write() failed");
 
     return NGX_ERROR;
+}
+
+
+static void
+ngx_ssl_write_async_handler(ngx_event_t *aev)
+{
+    ngx_connection_t  *c;
+
+    c = aev->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "SSL write async handler");
+
+    aev->ready = 0;
+    aev->handler = ngx_ssl_empty_handler;
+    c->read->handler = c->read->saved_handler;
+
+    c->write->handler(c->write);
 }
 
 
@@ -1765,12 +2028,38 @@ ngx_ssl_shutdown(ngx_connection_t *c)
     int        n, sslerr, mode;
     ngx_err_t  err;
 
+    if(!c->ssl) {
+        return NGX_OK;
+    }
+
     if (SSL_in_init(c->ssl->connection)) {
         /*
          * OpenSSL 1.0.2f complains if SSL_shutdown() is called during
          * an SSL handshake, while previous versions always return 0.
          * Avoid calling SSL_shutdown() if handshake wasn't completed.
          */
+
+        if(c->asynch) {
+            /* Check if there is inflight request */
+            if (SSL_want_async(c->ssl->connection) && !c->timedout) {
+                c->async->handler = ngx_ssl_shutdown_async_handler;
+                ngx_ssl_async_process_fds(c);
+                ngx_add_timer(c->async, 300);
+                return NGX_AGAIN;
+            }
+
+            /* Ignore errors from ngx_ssl_async_process_fds as
+               we want to carry on and close the SSL connection
+               anyway. */
+            ngx_ssl_async_process_fds(c);
+            if (ngx_del_async_conn) {
+                if (c->num_async_fds) {
+                    ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                    c->num_async_fds--;
+                }
+            }
+            ngx_del_conn(c, NGX_DISABLE_EVENT);
+        }
 
         SSL_free(c->ssl->connection);
         c->ssl = NULL;
@@ -1811,13 +2100,34 @@ ngx_ssl_shutdown(ngx_connection_t *c)
     /* SSL_shutdown() never returns -1, on error it returns 0 */
 
     if (n != 1 && ERR_peek_error()) {
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
         sslerr = SSL_get_error(c->ssl->connection, n);
 
         ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
                        "SSL_get_error: %d", sslerr);
     }
+    else if (c->asynch && n == -1) {
+        sslerr = SSL_get_error(c->ssl->connection, n);
+        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "SSL_get_error async: %d", sslerr);
+    }
 
     if (n == 1 || sslerr == 0 || sslerr == SSL_ERROR_ZERO_RETURN) {
+        if(c->asynch) {
+            /* Ignore errors from ngx_ssl_async_process_fds as
+               we want to carry on and close the SSL connection
+               anyway. */
+            ngx_ssl_async_process_fds(c);
+            if (ngx_del_async_conn) {
+                if (c->num_async_fds) {
+                    ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                    c->num_async_fds--;
+                }
+            }
+            ngx_del_conn(c, NGX_DISABLE_EVENT);
+        }
         SSL_free(c->ssl->connection);
         c->ssl = NULL;
 
@@ -1825,8 +2135,15 @@ ngx_ssl_shutdown(ngx_connection_t *c)
     }
 
     if (sslerr == SSL_ERROR_WANT_READ || sslerr == SSL_ERROR_WANT_WRITE) {
+        if (c->asynch && ngx_ssl_async_process_fds(c) == 0) {
+            return NGX_ERROR;
+        }
         c->read->handler = ngx_ssl_shutdown_handler;
         c->write->handler = ngx_ssl_shutdown_handler;
+
+        //Work around: Readd write event on shutdown;
+        c->write->ready = 0;
+        c->write->active = 0;
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
             return NGX_ERROR;
@@ -1840,9 +2157,41 @@ ngx_ssl_shutdown(ngx_connection_t *c)
             ngx_add_timer(c->read, 30000);
         }
 
+        if (sslerr == SSL_ERROR_WANT_WRITE) {
+            ngx_add_timer(c->write, 10000);
+        }
+
         return NGX_AGAIN;
     }
 
+    if(c->asynch) {
+        if (sslerr == SSL_ERROR_WANT_ASYNC) {
+            c->async->handler = ngx_ssl_shutdown_async_handler;
+            c->read->saved_handler = ngx_ssl_shutdown_handler;
+            c->read->handler = ngx_ssl_empty_handler;
+            c->write->handler = ngx_ssl_shutdown_handler;
+
+            ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                           "SSL ASYNC WANT recieved: \"%s\"", __func__);
+
+            /* Ignore errors from ngx_ssl_async_process_fds as
+               we want to carry on anyway */
+            ngx_ssl_async_process_fds(c);
+            return NGX_AGAIN;
+        }
+
+        /* Ignore errors from ngx_ssl_async_process_fds as
+           we want to carry on and close the SSL connection
+           anyway. */
+        ngx_ssl_async_process_fds(c);
+        if (ngx_del_async_conn) {
+            if (c->num_async_fds) {
+                ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                c->num_async_fds--;
+            }
+        }
+        ngx_del_conn(c, NGX_DISABLE_EVENT);
+    }
     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
 
     ngx_ssl_connection_error(c, sslerr, err, "SSL_shutdown() failed");
@@ -1851,6 +2200,34 @@ ngx_ssl_shutdown(ngx_connection_t *c)
     c->ssl = NULL;
 
     return NGX_ERROR;
+}
+
+
+static void
+ngx_ssl_shutdown_async_handler(ngx_event_t *aev)
+{
+    ngx_connection_t           *c;
+    ngx_connection_handler_pt   handler;
+
+    c = aev->data;
+    handler = c->ssl->handler;
+
+    if (aev->timedout) {
+        c->timedout = 1;
+    }
+
+    ngx_log_debug0(NGX_LOG_DEBUG_EVENT, aev->log, 0,
+                   "SSL shutdown async handler");
+
+    aev->ready = 0;
+    aev->handler = ngx_ssl_empty_handler;
+    c->read->handler = c->read->saved_handler;
+
+    if (ngx_ssl_shutdown(c) == NGX_AGAIN) {
+        return;
+    }
+
+    handler(c);
 }
 
 
@@ -1873,6 +2250,11 @@ ngx_ssl_shutdown_handler(ngx_event_t *ev)
         return;
     }
 
+    /*
+     * empty the handler of async event to avoid
+     * going back to previous ssl shutdown state
+     */
+    c->async->handler = ngx_ssl_empty_handler;
     handler(c);
 }
 
@@ -1925,7 +2307,9 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             || n == SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST              /*  151 */
             || n == SSL_R_EXCESSIVE_MESSAGE_SIZE                     /*  152 */
             || n == SSL_R_LENGTH_MISMATCH                            /*  159 */
+#ifdef SSL_R_NO_CIPHERS_PASSED
             || n == SSL_R_NO_CIPHERS_PASSED                          /*  182 */
+#endif
             || n == SSL_R_NO_CIPHERS_SPECIFIED                       /*  183 */
             || n == SSL_R_NO_COMPRESSION_SPECIFIED                   /*  187 */
             || n == SSL_R_NO_SHARED_CIPHER                           /*  193 */
@@ -1954,6 +2338,7 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             || n == SSL_R_INAPPROPRIATE_FALLBACK                     /*  373 */
 #endif
             || n == 1000 /* SSL_R_SSLV3_ALERT_CLOSE_NOTIFY */
+#ifdef SSL_R_SSLV3_ALERT_UNEXPECTED_MESSAGE
             || n == SSL_R_SSLV3_ALERT_UNEXPECTED_MESSAGE             /* 1010 */
             || n == SSL_R_SSLV3_ALERT_BAD_RECORD_MAC                 /* 1020 */
             || n == SSL_R_TLSV1_ALERT_DECRYPTION_FAILED              /* 1021 */
@@ -1976,7 +2361,9 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             || n == SSL_R_TLSV1_ALERT_INSUFFICIENT_SECURITY          /* 1071 */
             || n == SSL_R_TLSV1_ALERT_INTERNAL_ERROR                 /* 1080 */
             || n == SSL_R_TLSV1_ALERT_USER_CANCELLED                 /* 1090 */
-            || n == SSL_R_TLSV1_ALERT_NO_RENEGOTIATION)              /* 1100 */
+            || n == SSL_R_TLSV1_ALERT_NO_RENEGOTIATION               /* 1100 */
+#endif
+            )
         {
             switch (c->log_error) {
 
@@ -1997,7 +2384,6 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 
     ngx_ssl_error(level, c->log, err, text);
 }
-
 
 static void
 ngx_ssl_clear_error(ngx_log_t *log)
@@ -2141,7 +2527,7 @@ ngx_ssl_session_id_context(ngx_ssl_t *ssl, ngx_str_t *sess_ctx)
     int                   n, i;
     X509                 *cert;
     X509_NAME            *name;
-    EVP_MD_CTX            md;
+    EVP_MD_CTX           *md;
     unsigned int          len;
     STACK_OF(X509_NAME)  *list;
     u_char                buf[EVP_MAX_MD_SIZE];
@@ -2151,15 +2537,18 @@ ngx_ssl_session_id_context(ngx_ssl_t *ssl, ngx_str_t *sess_ctx)
      * the server certificate, and the client CA list.
      */
 
-    EVP_MD_CTX_init(&md);
+    md = EVP_MD_CTX_create();
+    if (md == NULL) {
+        return NGX_ERROR;
+    }
 
-    if (EVP_DigestInit_ex(&md, EVP_sha1(), NULL) == 0) {
+    if (EVP_DigestInit_ex(md, EVP_sha1(), NULL) == 0) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
                       "EVP_DigestInit_ex() failed");
         goto failed;
     }
 
-    if (EVP_DigestUpdate(&md, sess_ctx->data, sess_ctx->len) == 0) {
+    if (EVP_DigestUpdate(md, sess_ctx->data, sess_ctx->len) == 0) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
                       "EVP_DigestUpdate() failed");
         goto failed;
@@ -2173,7 +2562,7 @@ ngx_ssl_session_id_context(ngx_ssl_t *ssl, ngx_str_t *sess_ctx)
         goto failed;
     }
 
-    if (EVP_DigestUpdate(&md, buf, len) == 0) {
+    if (EVP_DigestUpdate(md, buf, len) == 0) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
                       "EVP_DigestUpdate() failed");
         goto failed;
@@ -2193,7 +2582,7 @@ ngx_ssl_session_id_context(ngx_ssl_t *ssl, ngx_str_t *sess_ctx)
                 goto failed;
             }
 
-            if (EVP_DigestUpdate(&md, buf, len) == 0) {
+            if (EVP_DigestUpdate(md, buf, len) == 0) {
                 ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
                               "EVP_DigestUpdate() failed");
                 goto failed;
@@ -2201,13 +2590,13 @@ ngx_ssl_session_id_context(ngx_ssl_t *ssl, ngx_str_t *sess_ctx)
         }
     }
 
-    if (EVP_DigestFinal_ex(&md, buf, &len) == 0) {
+    if (EVP_DigestFinal_ex(md, buf, &len) == 0) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
                       "EVP_DigestUpdate() failed");
         goto failed;
     }
 
-    EVP_MD_CTX_cleanup(&md);
+    EVP_MD_CTX_destroy(md);
 
     if (SSL_CTX_set_session_id_context(ssl->ctx, buf, len) == 0) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
@@ -2219,11 +2608,10 @@ ngx_ssl_session_id_context(ngx_ssl_t *ssl, ngx_str_t *sess_ctx)
 
 failed:
 
-    EVP_MD_CTX_cleanup(&md);
+    EVP_MD_CTX_destroy(md);
 
     return NGX_ERROR;
 }
-
 
 ngx_int_t
 ngx_ssl_session_cache_init(ngx_shm_zone_t *shm_zone, void *data)
@@ -2440,8 +2828,11 @@ failed:
 
 
 static ngx_ssl_session_t *
-ngx_ssl_get_cached_session(ngx_ssl_conn_t *ssl_conn, u_char *id, int len,
-    int *copy)
+ngx_ssl_get_cached_session(ngx_ssl_conn_t *ssl_conn,
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    const
+#endif
+    u_char *id, int len, int *copy)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x0090707fL
     const
@@ -2458,7 +2849,7 @@ ngx_ssl_get_cached_session(ngx_ssl_conn_t *ssl_conn, u_char *id, int len,
     u_char                    buf[NGX_SSL_MAX_SESSION_SIZE];
     ngx_connection_t         *c;
 
-    hash = ngx_crc32_short(id, (size_t) len);
+    hash = ngx_crc32_short((u_char *) (uintptr_t) id, (size_t) len);
     *copy = 0;
 
     c = ngx_ssl_get_connection(ssl_conn);
@@ -2496,7 +2887,8 @@ ngx_ssl_get_cached_session(ngx_ssl_conn_t *ssl_conn, u_char *id, int len,
 
         sess_id = (ngx_ssl_sess_id_t *) node;
 
-        rc = ngx_memn2cmp(id, sess_id->id, (size_t) len, (size_t) node->data);
+        rc = ngx_memn2cmp((u_char *) (uintptr_t) id, sess_id->id,
+                          (size_t) len, (size_t) node->data);
 
         if (rc == 0) {
 
@@ -2869,13 +3261,13 @@ ngx_ssl_session_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
                        ngx_hex_dump(buf, key[0].name, 16) - buf, buf,
                        SSL_session_reused(ssl_conn) ? "reused" : "new");
 
-        RAND_pseudo_bytes(iv, 16);
+        RAND_bytes(iv, 16);
         EVP_EncryptInit_ex(ectx, EVP_aes_128_cbc(), NULL, key[0].aes_key, iv);
         HMAC_Init_ex(hctx, key[0].hmac_key, 16,
                      ngx_ssl_session_ticket_md(), NULL);
         ngx_memcpy(name, key[0].name, 16);
 
-        return 0;
+        return 1;
 
     } else {
         /* decrypt session ticket */
@@ -3500,6 +3892,10 @@ ngx_openssl_engine(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     oscf->engine = 1;
+
+    if(cf->no_ssl_init) {
+        return NGX_CONF_OK;
+    }
 
     value = cf->args->elts;
 

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -41,6 +41,7 @@ typedef struct {
     SSL_CTX                    *ctx;
     ngx_log_t                  *log;
     size_t                      buffer_size;
+    ngx_flag_t                  asynch;
 } ngx_ssl_t;
 
 
@@ -165,6 +166,7 @@ ngx_int_t ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session);
 
 ngx_int_t ngx_ssl_check_host(ngx_connection_t *c, ngx_str_t *name);
 
+#define ngx_ssl_waiting_for_async(c) SSL_waiting_for_async(c->ssl->connection)
 
 ngx_int_t ngx_ssl_get_protocol(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
@@ -203,7 +205,7 @@ ngx_int_t ngx_ssl_shutdown(ngx_connection_t *c);
 void ngx_cdecl ngx_ssl_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
     char *fmt, ...);
 void ngx_ssl_cleanup_ctx(void *data);
-
+ngx_int_t ngx_ssl_async_process_fds(ngx_connection_t *c) ;
 
 extern int  ngx_ssl_connection_index;
 extern int  ngx_ssl_server_conf_index;

--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -281,7 +281,11 @@ ngx_ssl_stapling_issuer(ngx_conf_t *cf, ngx_ssl_t *ssl)
     for (i = 0; i < n; i++) {
         issuer = sk_X509_value(chain, i);
         if (X509_check_issued(issuer, cert) == X509_V_OK) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100001L
+            X509_up_ref(issuer);
+#else
             CRYPTO_add(&issuer->references, 1, CRYPTO_LOCK_X509);
+#endif
 
             ngx_log_debug1(NGX_LOG_DEBUG_EVENT, ssl->log, 0,
                            "SSL get issuer: found %p in extra certs", issuer);

--- a/src/http/modules/ngx_http_memcached_module.c
+++ b/src/http/modules/ngx_http_memcached_module.c
@@ -540,7 +540,7 @@ ngx_http_memcached_filter(void *data, ssize_t bytes)
 
     last += (size_t) (u->length - NGX_HTTP_MEMCACHED_END);
 
-    if (ngx_strncmp(last, ngx_http_memcached_end, b->last - last) != 0) {
+    if (ngx_strncmp(last, ngx_http_memcached_end,(unsigned)(b->last - last)) != 0) {
         ngx_log_error(NGX_LOG_ERR, ctx->request->connection->log, 0,
                       "memcached sent invalid trailer");
 

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -47,6 +47,8 @@ static char *ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf,
 
 static char *ngx_http_ssl_enable(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+static char *ngx_http_ssl_enable_asynch(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
 static char *ngx_http_ssl_password_file(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_ssl_session_cache(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -88,6 +90,13 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       ngx_conf_set_str_slot,
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_ssl_srv_conf_t, pass_phrase_dialog),
+      NULL },
+
+    { ngx_string("ssl_asynch"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_http_ssl_enable_asynch,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_ssl_srv_conf_t, enable_asynch),
       NULL },
 
     { ngx_string("ssl_certificate"),
@@ -539,6 +548,7 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
      */
 
     sscf->enable = NGX_CONF_UNSET;
+    sscf->enable_asynch = NGX_CONF_UNSET;
     sscf->prefer_server_ciphers = NGX_CONF_UNSET;
     sscf->buffer_size = NGX_CONF_UNSET_SIZE;
     sscf->verify = NGX_CONF_UNSET_UINT;
@@ -583,6 +593,17 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
         } else {
             conf->enable = prev->enable;
+            conf->file = prev->file;
+            conf->line = prev->line;
+        }
+    }
+
+    if (conf->enable_asynch == NGX_CONF_UNSET) {
+        if (prev->enable_asynch == NGX_CONF_UNSET) {
+            conf->enable_asynch = 0;
+
+        } else {
+            conf->enable_asynch = prev->enable_asynch;
             conf->file = prev->file;
             conf->line = prev->line;
         }
@@ -651,6 +672,7 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
             return NGX_CONF_ERROR;
         }
 
+        conf->ssl.asynch = conf->enable_asynch;
     } else {
 
         if (conf->certificate.len == 0) {
@@ -823,6 +845,37 @@ ngx_http_ssl_enable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (rv != NGX_CONF_OK) {
         return rv;
+    }
+
+    sscf->file = cf->conf_file->file.name.data;
+    sscf->line = cf->conf_file->line;
+
+    return NGX_CONF_OK;
+}
+
+static char *
+ngx_http_ssl_enable_asynch(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_ssl_srv_conf_t *sscf = conf;
+
+    char  *rv;
+
+    ngx_flag_t       *pssl, *pssl_asynch;
+
+    rv = ngx_conf_set_flag_slot(cf, cmd, conf);
+
+    if (rv != NGX_CONF_OK) {
+        return rv;
+    }
+
+    /* If ssl_asynch on is configured, then ssl on is configured by default
+     * This will align 'ssl_asynch on;' and 'listen port ssl' diretives
+     * */
+    pssl = (ngx_flag_t *) ((char *)conf + offsetof(ngx_http_ssl_srv_conf_t, enable));
+    pssl_asynch = (ngx_flag_t *) ((char *)conf + cmd->offset);
+
+    if(*pssl_asynch && *pssl != 1) {
+        *pssl = *pssl_asynch;
     }
 
     sscf->file = cf->conf_file->file.name.data;

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -17,6 +17,8 @@
 typedef struct {
     ngx_flag_t                      enable;
 
+    ngx_flag_t                      enable_asynch;
+
     ngx_ssl_t                       ssl;
 
     ngx_flag_t                      prefer_server_ciphers;

--- a/src/http/modules/ngx_http_upstream_consistent_hash_module.c
+++ b/src/http/modules/ngx_http_upstream_consistent_hash_module.c
@@ -611,10 +611,16 @@ ngx_http_upstream_chash_set_peer_session(ngx_peer_connection_t *pc, void *data)
     ssl_session = uchpd->ssl_session;
     rc = ngx_ssl_set_session(pc->connection, ssl_session);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    /* Since OpenSSL 1.1.0, 'references' as an internal parameter of
+     * SSL_SESSION is not exposed directly */
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "set session: %p", ssl_session);
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "set session: %p:%d",
                    ssl_session, ssl_session ? ssl_session->references : 0);
-
+#endif
     return rc;
 }
 
@@ -632,17 +638,29 @@ ngx_http_upstream_chash_save_peer_session(ngx_peer_connection_t *pc, void *data)
         return;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    /* Since OpenSSL 1.1.0, 'references' as an internal parameter of
+     * SSL_SESSION is not exposed directly */
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "set session: %p", ssl_session);
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "save session: %p:%d", ssl_session, ssl_session->references);
-
+#endif
     old_ssl_session = uchpd->ssl_session;
     uchpd->ssl_session = ssl_session;
 
     if (old_ssl_session) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        /* Since OpenSSL 1.1.0, 'references' as an internal parameter of
+        * SSL_SESSION is not exposed directly */
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "set session: %p", old_ssl_session);
+#else
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                        "old session: %p:%d",
                        old_ssl_session, old_ssl_session->references);
-
+#endif
         ngx_ssl_free_session(old_ssl_session);
     }
 }

--- a/src/http/modules/ngx_http_upstream_session_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_session_sticky_module.c
@@ -1421,10 +1421,16 @@ ngx_http_upstream_session_sticky_set_peer_session(ngx_peer_connection_t *pc,
     ssl_session = sspd->ssl_session;
     rc = ngx_ssl_set_session(pc->connection, ssl_session);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    /* Since OpenSSL 1.1.0, 'references' as an internal parameter of
+     * SSL_SESSION is not exposed directly */
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "set session: %p", ssl_session);
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "set session: %p:%d",
                    ssl_session, ssl_session ? ssl_session->references : 0);
-
+#endif
     return rc;
 }
 
@@ -1443,17 +1449,29 @@ ngx_http_upstream_session_sticky_save_peer_session(ngx_peer_connection_t *pc,
         return;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    /* Since OpenSSL 1.1.0, 'references' as an internal parameter of
+     * SSL_SESSION is not exposed directly */
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "set session: %p", ssl_session);
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "save session: %p:%d", ssl_session, ssl_session->references);
-
+#endif
     old_ssl_session = sspd->ssl_session;
     sspd->ssl_session = ssl_session;
 
     if (old_ssl_session) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        /* Since OpenSSL 1.1.0, 'references' as an internal parameter of
+         * SSL_SESSION is not exposed directly */
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "set session: %p", old_ssl_session);
+#else
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                        "old session: %p:%d",
                        old_ssl_session, old_ssl_session->references);
-
+#endif
         ngx_ssl_free_session(old_ssl_session);
     }
 }

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -904,7 +904,8 @@ ngx_http_upstream_cache(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     case NGX_DECLINED:
 
-        if ((size_t) (u->buffer.end - u->buffer.start) < u->conf->buffer_size) {
+        if ((size_t) (unsigned) (u->buffer.end - u->buffer.start) \
+            < u->conf->buffer_size) {
             u->buffer.start = NULL;
 
         } else {
@@ -1181,7 +1182,14 @@ ngx_http_upstream_check_broken_connection(ngx_http_request_t *r,
         if ((ngx_event_flags & NGX_USE_LEVEL_EVENT) && ev->active) {
 
             event = ev->write ? NGX_WRITE_EVENT : NGX_READ_EVENT;
-
+#if (NGX_HTTP_SSL)
+            if (c->asynch && ngx_del_async_conn) {
+                if (c->num_async_fds) {
+                    ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                    c->num_async_fds--;
+                }
+            }
+#endif
             if (ngx_del_event(ev, event, 0) != NGX_OK) {
                 ngx_http_upstream_finalize_request(r, u,
                                                NGX_HTTP_INTERNAL_SERVER_ERROR);
@@ -1304,7 +1312,14 @@ ngx_http_upstream_check_broken_connection(ngx_http_request_t *r,
     if ((ngx_event_flags & NGX_USE_LEVEL_EVENT) && ev->active) {
 
         event = ev->write ? NGX_WRITE_EVENT : NGX_READ_EVENT;
-
+#if (NGX_HTTP_SSL)
+        if (c->asynch && ngx_del_async_conn) {
+            if (c->num_async_fds) {
+                ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                c->num_async_fds--;
+            }
+        }
+#endif
         if (ngx_del_event(ev, event, 0) != NGX_OK) {
             ngx_http_upstream_finalize_request(r, u,
                                                NGX_HTTP_INTERNAL_SERVER_ERROR);
@@ -4118,7 +4133,8 @@ ngx_http_upstream_finalize_request(ngx_http_request_t *r,
             }
         }
 
-        ngx_http_file_cache_free(r->cache, u->pipe->temp_file);
+        if (u->pipe)
+            ngx_http_file_cache_free(r->cache, u->pipe->temp_file);
     }
 
 #endif

--- a/src/os/unix/ngx_daemon.c
+++ b/src/os/unix/ngx_daemon.c
@@ -10,26 +10,27 @@
 
 
 ngx_int_t
-ngx_daemon(ngx_log_t *log)
+ngx_daemon(ngx_cycle_t *cycle)
 {
     int  fd;
 
     switch (fork()) {
     case -1:
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno, "fork() failed");
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "fork() failed");
         return NGX_ERROR;
 
     case 0:
         break;
 
     default:
+        ngx_destroy_pool(cycle->pool);
         exit(0);
     }
 
     ngx_pid = ngx_getpid();
 
     if (setsid() == -1) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno, "setsid() failed");
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "setsid() failed");
         return NGX_ERROR;
     }
 
@@ -37,31 +38,31 @@ ngx_daemon(ngx_log_t *log)
 
     fd = open("/dev/null", O_RDWR);
     if (fd == -1) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno,
                       "open(\"/dev/null\") failed");
         return NGX_ERROR;
     }
 
     if (dup2(fd, STDIN_FILENO) == -1) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno, "dup2(STDIN) failed");
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "dup2(STDIN) failed");
         return NGX_ERROR;
     }
 
     if (dup2(fd, STDOUT_FILENO) == -1) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno, "dup2(STDOUT) failed");
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "dup2(STDOUT) failed");
         return NGX_ERROR;
     }
 
 #if 0
     if (dup2(fd, STDERR_FILENO) == -1) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno, "dup2(STDERR) failed");
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "dup2(STDERR) failed");
         return NGX_ERROR;
     }
 #endif
 
     if (fd > STDERR_FILENO) {
         if (close(fd) == -1) {
-            ngx_log_error(NGX_LOG_EMERG, log, ngx_errno, "close() failed");
+            ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "close() failed");
             return NGX_ERROR;
         }
     }

--- a/src/os/unix/ngx_os.h
+++ b/src/os/unix/ngx_os.h
@@ -37,7 +37,7 @@ ngx_int_t ngx_os_init(ngx_log_t *log);
 void ngx_os_status(ngx_log_t *log);
 ngx_int_t ngx_os_specific_init(ngx_log_t *log);
 void ngx_os_specific_status(ngx_log_t *log);
-ngx_int_t ngx_daemon(ngx_log_t *log);
+ngx_int_t ngx_daemon(ngx_cycle_t *cycle);
 ngx_int_t ngx_os_signal_process(ngx_cycle_t *cycle, char *sig, ngx_int_t pid);
 
 

--- a/tests/nginx-tests/nginx-tests/http_ssl_asynchronous_mode.t
+++ b/tests/nginx-tests/nginx-tests/http_ssl_asynchronous_mode.t
@@ -1,0 +1,151 @@
+#!/usr/bin/perl
+
+# (C) Intel, Inc.
+
+# Tests for http ssl asynchronous mode.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval {
+    require IO::Socket::SSL;
+};
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl/)
+    ->has_daemon('openssl');
+
+$t->plan(2)->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+user root;
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    ssl_buffer_size 64k;
+    ssl_asynch on;
+
+    server {
+        listen       127.0.0.1:8080 ssl;
+        server_name  localhost;
+
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+
+        location / {
+            index index.html index.htm;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('localhost') {
+    system('openssl req -x509 -new '
+        . "-config '$d/openssl.conf' -subj '/CN=$name/' "
+        . "-out '$d/$name.crt' -keyout '$d/$name.key' "
+        . ">>$d/openssl.out 2>&1") == 0
+        or die "Can't create certificate for $name: $!\n";
+}
+
+$t->write_file('index.html', <<EOF);
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
+EOF
+
+$t->run();
+sleep 20;
+
+my $COUNT_RSA = '2';
+my $COUNT_ECDHE_RSA = '2';
+my $aes = get_file_aes128_sha($t->testdir());
+
+ok( $aes == $COUNT_RSA,'Test AES128-SHA fail!
+    **Note**: Please make sure build Nginx using "--with-debug"');
+sleep 10;
+
+my $ecdhe_rsa = get_file_ecdhe_rsa_aes128_sha($t->testdir());
+ok( $ecdhe_rsa == $COUNT_ECDHE_RSA,'Test ECDHE-RSA-AES128-SHA fail!
+    **Note**: Please make sure build Nginx using "--with-debug"');
+
+$t->stop();
+################################################################################
+
+sub get_file_aes128_sha {
+    my ($nginx) = @_;
+    system('echo "GET /index.html" | openssl s_client -connect localhost:8080 '
+        .'-cipher AES128-SHA -ign_eof') == 0
+        or die "Can't get the index.html via the cipher AES128-SHA\n";
+    my $result=0;
+    $result=`grep -c 'SSL ASYNC WANT' $nginx/error.log`;
+    return $result;
+}
+
+sub get_file_ecdhe_rsa_aes128_sha {
+    my ($nginx) = @_;
+    my $openssl_version=`openssl version|cut -d" " -f2`;
+    $openssl_version ge "1.0.1" or die "Openssl version too low\n";
+
+    `echo " " >$nginx/error.log`;
+    system('echo "GET /index.html" | openssl s_client -connect localhost:8080 '
+        .'-cipher ECDHE-RSA-AES128-SHA -ign_eof') == 0
+        or die "Can't get the index.html via the cipher ECDHE-RSA-AES128-SHA\n";
+    my $result=0;
+    $result=`grep -c 'SSL ASYNC WANT' $nginx/error.log`;
+    return $result;
+}
+
+###############################################################################


### PR DESCRIPTION
OpenSSL provide asynchronous SSL/TLS mode since 1.1.0 version. This commit improve Tengine SSL layer to support the asynchronous mode based on OpenSSL-1.1.0f release. Docs and basic test case are also provided.