### PR TITLE
Restore the functionality of the ssl_verify_client_exception directive.

### DIFF
--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -38,6 +38,7 @@ static ngx_int_t ngx_http_ssl_variable(ngx_http_request_t *r,
 
 static ngx_int_t ngx_http_ssl_add_variables(ngx_conf_t *cf);
 static void *ngx_http_ssl_create_srv_conf(ngx_conf_t *cf);
+static void *ngx_http_ssl_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf,
     void *parent, void *child);
 
@@ -142,6 +143,13 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_ssl_srv_conf_t, verify),
       &ngx_http_ssl_verify },
+
+    { ngx_string("ssl_verify_client_exception"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_ssl_loc_conf_t, verify_exception),
+      NULL },
 
     { ngx_string("ssl_verify_depth"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
@@ -255,7 +263,7 @@ static ngx_http_module_t  ngx_http_ssl_module_ctx = {
     ngx_http_ssl_create_srv_conf,          /* create server configuration */
     ngx_http_ssl_merge_srv_conf,           /* merge server configuration */
 
-    NULL,                                  /* create location configuration */
+    ngx_http_ssl_create_loc_conf,          /* create location configuration */
     NULL                                   /* merge location configuration */
 };
 
@@ -565,6 +573,22 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
     sscf->early_data = NGX_CONF_UNSET;
 
     return sscf;
+}
+
+
+static void *
+ngx_http_ssl_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_http_ssl_loc_conf_t *slcf;
+
+    slcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_ssl_loc_conf_t));
+    if (slcf == NULL) {
+        return NULL;
+    }
+
+    slcf->verify_exception = NGX_CONF_UNSET;
+
+    return slcf;
 }
 
 

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -61,6 +61,10 @@ typedef struct {
     ngx_uint_t                      line;
 } ngx_http_ssl_srv_conf_t;
 
+typedef struct {
+    ngx_flag_t                      verify_exception;
+} ngx_http_ssl_loc_conf_t;
+
 
 extern ngx_module_t  ngx_http_ssl_module;
 

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1023,7 +1023,7 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
         return NGX_OK;
     }
 
-#if 0 && (NGX_HTTP_SSL)
+#if (NGX_HTTP_SSL)
     ngx_connection_t  *c;
     c = r->connection;
 

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -1868,7 +1868,7 @@ ngx_http_process_request(ngx_http_request_t *r)
 
     c = r->connection;
 
-#if (NGX_HTTP_SSL)
+#if 0 && (NGX_HTTP_SSL)
 
     if (r->http_connection->ssl) {
         long                      rc;


### PR DESCRIPTION
The function of the ssl_verify_client_exception directive is covered by another
person(lhanjian)

ssl_verify_client_exception directive's pr: 
https://github.com/alibaba/tengine/pull/612