### PR TITLE
enabled include inside http upstreams

### DIFF
--- a/src/core/ngx_conf_file.h
+++ b/src/core/ngx_conf_file.h
@@ -50,7 +50,7 @@
 #define NGX_DIRECT_CONF      0x00010000
 
 #define NGX_MAIN_CONF        0x01000000
-#define NGX_ANY_CONF         0x0F000000
+#define NGX_ANY_CONF         0x1F000000
 
 
 #define NGX_CONF_UNSET       -1


### PR DESCRIPTION
Enabled include inside http upstream, Forexample:
```
upstream beta_ups {
    include  ups/general.conf;  # keepalive, balance method etc ...
    include  ups/beta_backend_servers.conf;
}
```