### PR TITLE
Bugfix: fix reuse_port and accept_mutex conflict

### DIFF
--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -869,7 +869,12 @@ ngx_event_process_init(ngx_cycle_t *cycle)
 
         rev->handler = ngx_event_accept;
 
-        if (ngx_use_accept_mutex) {
+        if (ngx_use_accept_mutex
+#if (NGX_HAVE_REUSEPORT)
+            && !ls[i].reuseport
+#endif
+           )
+        {
             continue;
         }
 


### PR DESCRIPTION
Bugfix: fix reuse_port and accept_mutex conflict in cases where reuse_port of ngx_events_module is set to off while reuse_port of listening socket is on