### PR TITLE
added C macros for Tengine feature

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -963,4 +963,4 @@ have=T_TENGINE_FIX . auto/have
 have=T_NGX_INPUT_BODY_FILTER . auto/have
 have=T_NGX_GZIP_CLEAR_ETAG . auto/have
 have=T_NGX_RESOLVER_FILE . auto/have
-have=T_NGX_CLIENT_BODY_POSTPONE_SIZE . auto/have
+have=T_DEPRECATED . auto/have

--- a/auto/modules
+++ b/auto/modules
@@ -961,3 +961,4 @@ have=T_NGX_MASTER_ENV . auto/have
 have=T_PIPES . auto/have
 have=T_TENGINE_FIX . auto/have
 have=T_NGX_INPUT_BODY_FILTER . auto/have
+have=T_NGX_GZIP_CLEAR_ETAG . auto/have

--- a/auto/modules
+++ b/auto/modules
@@ -962,3 +962,4 @@ have=T_PIPES . auto/have
 have=T_TENGINE_FIX . auto/have
 have=T_NGX_INPUT_BODY_FILTER . auto/have
 have=T_NGX_GZIP_CLEAR_ETAG . auto/have
+have=T_NGX_RESOLVER_FILE . auto/have

--- a/auto/modules
+++ b/auto/modules
@@ -963,3 +963,4 @@ have=T_TENGINE_FIX . auto/have
 have=T_NGX_INPUT_BODY_FILTER . auto/have
 have=T_NGX_GZIP_CLEAR_ETAG . auto/have
 have=T_NGX_RESOLVER_FILE . auto/have
+have=T_NGX_CLIENT_BODY_POSTPONE_SIZE . auto/have

--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -15,7 +15,9 @@
 typedef struct {
     ngx_flag_t           enable;
     ngx_flag_t           no_buffer;
+#if (T_NGX_GZIP_CLEAR_ETAG)
     ngx_flag_t           clear_etag;
+#endif
 
     ngx_hash_t           types;
 
@@ -194,12 +196,14 @@ static ngx_command_t  ngx_http_gzip_filter_commands[] = {
       offsetof(ngx_http_gzip_conf_t, min_length),
       NULL },
 
+#if (T_NGX_GZIP_CLEAR_ETAG)
     { ngx_string("gzip_clear_etag"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_gzip_conf_t, clear_etag),
       NULL },
+#endif
 
       ngx_null_command
 };
@@ -314,12 +318,12 @@ ngx_http_gzip_header_filter(ngx_http_request_t *r)
 
     ngx_http_clear_content_length(r);
     ngx_http_clear_accept_ranges(r);
-
+#if (T_NGX_GZIP_CLEAR_ETAG)
     if (conf->clear_etag) {
         ngx_http_clear_etag(r);
-    } else {
-        ngx_http_weak_etag(r);
-    }
+    } else
+#endif
+    ngx_http_weak_etag(r);
 
     return ngx_http_next_header_filter(r);
 }
@@ -1144,7 +1148,9 @@ ngx_http_gzip_create_conf(ngx_conf_t *cf)
 
     conf->enable = NGX_CONF_UNSET;
     conf->no_buffer = NGX_CONF_UNSET;
+#if (T_NGX_GZIP_CLEAR_ETAG)
     conf->clear_etag = NGX_CONF_UNSET;
+#endif
 
     conf->postpone_gzipping = NGX_CONF_UNSET_SIZE;
     conf->level = NGX_CONF_UNSET;
@@ -1164,7 +1170,9 @@ ngx_http_gzip_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->enable, prev->enable, 0);
     ngx_conf_merge_value(conf->no_buffer, prev->no_buffer, 0);
+#if (T_NGX_GZIP_CLEAR_ETAG)
     ngx_conf_merge_value(conf->clear_etag, prev->clear_etag, 0);
+#endif
 
     ngx_conf_merge_bufs_value(conf->bufs, prev->bufs,
                               (128 * 1024) / ngx_pagesize, ngx_pagesize);

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -383,12 +383,14 @@ static ngx_command_t  ngx_http_core_commands[] = {
       offsetof(ngx_http_core_loc_conf_t, client_body_buffers),
       NULL },
 
+#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     { ngx_string("client_body_postpone_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_core_loc_conf_t, client_body_postpone_size),
       NULL },
+#endif
 
     { ngx_string("client_body_timeout"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
@@ -3804,7 +3806,9 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
     clcf->error_pages = NGX_CONF_UNSET_PTR;
     clcf->client_max_body_size = NGX_CONF_UNSET;
     clcf->client_body_buffer_size = NGX_CONF_UNSET_SIZE;
+#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     clcf->client_body_postpone_size = NGX_CONF_UNSET_SIZE;
+#endif
     clcf->client_body_timeout = NGX_CONF_UNSET_MSEC;
     clcf->satisfy = NGX_CONF_UNSET_UINT;
     clcf->if_modified_since = NGX_CONF_UNSET_UINT;
@@ -4080,9 +4084,11 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                               prev->client_body_buffers,
                               16, ngx_pagesize);
 
+#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     ngx_conf_merge_size_value(conf->client_body_postpone_size,
                               prev->client_body_postpone_size,
                               64 * 1024);
+#endif
 
     if (conf->client_max_body_size &&
          (conf->client_max_body_size <
@@ -4100,6 +4106,7 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                                              conf->client_body_buffers.size);
     }
 
+#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     if ((off_t)conf->client_body_postpone_size > conf->client_max_body_size
          && conf->client_max_body_size != 0)
     {
@@ -4119,6 +4126,7 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->client_body_buffers.num = 1 + (conf->client_body_postpone_size /
                                              conf->client_body_buffers.size);
     }
+#endif
 
     if (conf->client_body_buffers.num < 2) {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -74,8 +74,10 @@ static char *ngx_http_core_internal(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_core_resolver(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+#if (T_NGX_RESOLVER_FILE)
 static char *ngx_http_core_resolver_file(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+#endif
 static char *ngx_http_set_server_tag(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 #if (NGX_HTTP_GZIP)
@@ -764,12 +766,14 @@ static ngx_command_t  ngx_http_core_commands[] = {
       0,
       NULL },
 
+#if (T_NGX_RESOLVER_FILE)
     { ngx_string("resolver_file"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_http_core_resolver_file,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       NULL },
+#endif
 
     { ngx_string("resolver_timeout"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
@@ -5523,6 +5527,7 @@ ngx_http_core_resolver(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 
+#if (T_NGX_RESOLVER_FILE)
 static char *
 ngx_http_core_resolver_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
@@ -5548,6 +5553,7 @@ ngx_http_core_resolver_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     return NGX_CONF_OK;
 }
+#endif
 
 
 #if (NGX_HTTP_GZIP)

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -376,6 +376,7 @@ static ngx_command_t  ngx_http_core_commands[] = {
       offsetof(ngx_http_core_loc_conf_t, client_body_buffer_size),
       NULL },
 
+#if (T_DEPRECATED)
     { ngx_string("client_body_buffers"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
       ngx_conf_set_bufs_slot,
@@ -383,7 +384,6 @@ static ngx_command_t  ngx_http_core_commands[] = {
       offsetof(ngx_http_core_loc_conf_t, client_body_buffers),
       NULL },
 
-#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     { ngx_string("client_body_postpone_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
@@ -3806,7 +3806,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
     clcf->error_pages = NGX_CONF_UNSET_PTR;
     clcf->client_max_body_size = NGX_CONF_UNSET;
     clcf->client_body_buffer_size = NGX_CONF_UNSET_SIZE;
-#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
+#if (T_DEPRECATED)
     clcf->client_body_postpone_size = NGX_CONF_UNSET_SIZE;
 #endif
     clcf->client_body_timeout = NGX_CONF_UNSET_MSEC;
@@ -4080,15 +4080,14 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_size_value(conf->client_body_buffer_size,
                               prev->client_body_buffer_size,
                               (size_t) 2 * ngx_pagesize);
+#if (T_DEPRECATED)
     ngx_conf_merge_bufs_value(conf->client_body_buffers,
                               prev->client_body_buffers,
                               16, ngx_pagesize);
 
-#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     ngx_conf_merge_size_value(conf->client_body_postpone_size,
                               prev->client_body_postpone_size,
                               64 * 1024);
-#endif
 
     if (conf->client_max_body_size &&
          (conf->client_max_body_size <
@@ -4106,7 +4105,6 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                                              conf->client_body_buffers.size);
     }
 
-#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     if ((off_t)conf->client_body_postpone_size > conf->client_max_body_size
          && conf->client_max_body_size != 0)
     {
@@ -4126,13 +4124,13 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->client_body_buffers.num = 1 + (conf->client_body_postpone_size /
                                              conf->client_body_buffers.size);
     }
-#endif
 
     if (conf->client_body_buffers.num < 2) {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                            "there must be at least 2 \"client_body_buffers\"");
         conf->client_body_buffers.num = 2;
     }
+#endif
 
     ngx_conf_merge_msec_value(conf->client_body_timeout,
                               prev->client_body_timeout, 60000);

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -376,8 +376,8 @@ struct ngx_http_core_loc_conf_s {
     off_t         directio;                /* directio */
     off_t         directio_alignment;      /* directio_alignment */
 
+#if (T_DEPRECATED)
     ngx_bufs_t    client_body_buffers;
-#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     size_t        client_body_postpone_size;
 #endif
     size_t        client_body_buffer_size; /* client_body_buffer_size */

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -377,7 +377,9 @@ struct ngx_http_core_loc_conf_s {
     off_t         directio_alignment;      /* directio_alignment */
 
     ngx_bufs_t    client_body_buffers;
+#if (T_NGX_CLIENT_BODY_POSTPONE_SIZE)
     size_t        client_body_postpone_size;
+#endif
     size_t        client_body_buffer_size; /* client_body_buffer_size */
     size_t        send_lowat;              /* send_lowat */
     size_t        postpone_output;         /* postpone_output */


### PR DESCRIPTION
directives of Tengine feature:
* client_body_postpone_size/client_body_buffers -> T_DEPRECATED
* gzip_clear_etag -> T_NGX_GZIP_CLEAR_ETAG
* resolver_file -> T_NGX_RESOLVER_FILE