### PR TITLE
当使用"--with-openssl=" 指定openssl路径时，"--with-openssl-async" 选项不生效

### DIFF
--- a/auto/lib/openssl/conf
+++ b/auto/lib/openssl/conf
@@ -74,34 +74,41 @@ with nginx by using --with-openssl=<path> option.
 END
         exit 1
     fi
+fi
 
-    OPENSSL_ASYNC=
-    if [ "$NGX_SSL_ASYNC" != NO ]; then
 
-        OPENSSL_ASYNC=NO
+OPENSSL_ASYNC=
+if [ "$NGX_SSL_ASYNC" != NO ]; then
+    OPENSSL_ASYNC=NO
 
-        ngx_feature="OpenSSL library"
-        ngx_feature_name=
-        ngx_feature_run=no
-        ngx_feature_incs="#include <openssl/ssl.h>"
-        ngx_feature_path=
-        ngx_feature_libs="-lssl -lcrypto"
-        ngx_feature_test="#ifndef SSL_MODE_ASYNC
-        error: not define async
-        #endif
-        "
-        . auto/feature
-        if [ $ngx_found = yes ]; then
-            have=NGX_SSL_ASYNC . auto/have
-            OPENSSL_ASYNC=YES
-        fi
+    ngx_feature="OpenSSL Async Library"
+    ngx_feature_name=
+    ngx_feature_run=no
+    ngx_feature_incs="#include <openssl/ssl.h>"
+
+    if [ $OPENSSL = NONE ]; then
+         ngx_feature_path=
+    else
+         ngx_feature_path=$CORE_INCS
     fi
 
-    if [ -n "$OPENSSL_ASYNC"  -a  "$OPENSSL_ASYNC" != YES  ]; then
+    ngx_feature_libs="-lssl -lcrypto"
+    ngx_feature_test="#ifndef SSL_MODE_ASYNC
+    error: not define async
+    #endif
+    "
+    . auto/feature
+    if [ $ngx_found = yes ]; then
+        have=NGX_SSL_ASYNC . auto/have
+        OPENSSL_ASYNC=YES
+    fi
+fi
+
+if [ -n "$OPENSSL_ASYNC"  -a  "$OPENSSL_ASYNC" != YES  ]; then
 cat << END
 $1: error: For using asynchronous mode, The OpenSSL must be version 1.1.0 or greater.
 
 END
-        exit 1
-    fi
+    exit 1
 fi
+


### PR DESCRIPTION
处理 `--with-openssl-async` 的代码所在的作用域不合理，只对链接系统OpenSSL库或者指定路径的OpenSSL库时才会生效，在带有 `--with-openssl=`编译选项的情况时不生效；  
现在把async判断的代码挪到最后。