### PR TITLE
FIX: avoid removes the Unix domain socket file when pipe proc close listen socket.

### DIFF
--- a/src/os/unix/ngx_pipe.c
+++ b/src/os/unix/ngx_pipe.c
@@ -434,6 +434,12 @@ ngx_open_pipe(ngx_cycle_t *cycle, ngx_open_pipe_t *op)
             close(op->pfd[1]);
         }
     } else {
+
+       /*
+        * Set correct process type since closing listening Unix domain socket
+        * in a master process also removes the Unix domain socket file.
+        */
+        ngx_process = NGX_PROCESS_PIPE;
         ngx_close_listening_sockets(cycle);
 
         if (op->type == 1) {

--- a/src/os/unix/ngx_process.c
+++ b/src/os/unix/ngx_process.c
@@ -332,6 +332,9 @@ ngx_signal_handler(int signo)
 
     case NGX_PROCESS_MASTER:
     case NGX_PROCESS_SINGLE:
+#if (T_PIPES)
+    case NGX_PROCESS_PIPE:
+#endif
         switch (signo) {
 
         case ngx_signal_value(NGX_SHUTDOWN_SIGNAL):

--- a/src/os/unix/ngx_process_cycle.h
+++ b/src/os/unix/ngx_process_cycle.h
@@ -30,6 +30,10 @@
 #define NGX_PROCESS_HELPER     4
 #define NGX_PROCESS_PROC       5
 
+#if (T_PIPES)
+#define NGX_PROCESS_PIPE       6
+#endif
+
 
 typedef struct {
     ngx_event_handler_pt       handler;


### PR DESCRIPTION
avoid removes the Unix domain socket file when pipe proc close listen socket.

```
void
ngx_close_listening_sockets(ngx_cycle_t *cycle)
{
... ...
    ls = cycle->listening.elts;
    for (i = 0; i < cycle->listening.nelts; i++) {
... ...

#if (NGX_HAVE_UNIX_DOMAIN)

        if (ls[i].sockaddr->sa_family == AF_UNIX
            && ngx_process <= NGX_PROCESS_MASTER
            && ngx_new_binary == 0)
        {
            u_char *name = ls[i].addr_text.data + sizeof("unix:") - 1;

            if (ngx_delete_file(name) == NGX_FILE_ERROR) {
                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
                              ngx_delete_file_n " %s failed", name);
            }
        }

#endif

        ls[i].fd = (ngx_socket_t) -1;
    }

    cycle->listening.nelts = 0;
}
```