### PR TITLE
Added T_UPSTREAM_KEEPALIVE_TIMEOUT for keepalive_timeout in upstream block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Makefile
 objs/
+tags

--- a/auto/modules
+++ b/auto/modules
@@ -964,3 +964,4 @@ have=T_NGX_INPUT_BODY_FILTER . auto/have
 have=T_NGX_GZIP_CLEAR_ETAG . auto/have
 have=T_NGX_RESOLVER_FILE . auto/have
 have=T_DEPRECATED . auto/have
+have=T_UPSTREAM_KEEPALIVE_TIMEOUT . auto/have

--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -12,7 +12,10 @@
 
 typedef struct {
     ngx_uint_t                         max_cached;
+
+#if (T_UPSTREAM_KEEPALIVE_TIMEOUT)
     ngx_msec_t                         keepalive_timeout;
+#endif
 
     ngx_queue_t                        cache;
     ngx_queue_t                        free;
@@ -75,8 +78,11 @@ static void ngx_http_upstream_keepalive_save_session(ngx_peer_connection_t *pc,
 static void *ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf);
 static char *ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+
+#if (T_UPSTREAM_KEEPALIVE_TIMEOUT)
 static char *ngx_http_upstream_keepalive_timeout(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
+#endif
 
 
 static ngx_command_t  ngx_http_upstream_keepalive_commands[] = {
@@ -88,12 +94,16 @@ static ngx_command_t  ngx_http_upstream_keepalive_commands[] = {
       0,
       NULL },
 
+#if (T_UPSTREAM_KEEPALIVE_TIMEOUT)
+
     { ngx_string("keepalive_timeout"),
       NGX_HTTP_UPS_CONF|NGX_CONF_TAKE1,
       ngx_http_upstream_keepalive_timeout,
       0,
       0,
       NULL },
+
+#endif
 
       ngx_null_command
 };
@@ -348,11 +358,15 @@ ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
         ngx_del_timer(c->write);
     }
 
+#if (T_UPSTREAM_KEEPALIVE_TIMEOUT)
+
     if (kp->conf->keepalive_timeout != NGX_CONF_UNSET_MSEC &&
         kp->conf->keepalive_timeout != 0)
     {
         ngx_add_timer(c->read, kp->conf->keepalive_timeout);
     }
+
+#endif
 
     c->write->handler = ngx_http_upstream_keepalive_dummy_handler;
     c->read->handler = ngx_http_upstream_keepalive_close_handler;
@@ -499,7 +513,10 @@ ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf)
      */
 
     conf->max_cached = 1;
+
+#if (T_UPSTREAM_KEEPALIVE_TIMEOUT)
     conf->keepalive_timeout = NGX_CONF_UNSET_MSEC;
+#endif
 
     return conf;
 }
@@ -564,6 +581,8 @@ invalid:
 }
 
 
+#if (T_UPSTREAM_KEEPALIVE_TIMEOUT)
+
 static char *
 ngx_http_upstream_keepalive_timeout(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf)
@@ -595,3 +614,4 @@ ngx_http_upstream_keepalive_timeout(ngx_conf_t *cf, ngx_command_t *cmd,
     return NGX_CONF_OK;
 }
 
+#endif


### PR DESCRIPTION

Added `T_UPSTREAM_KEEPALIVE_TIMEOUT` macro for `keepalive_timeout` directive  in upstream block.