### PR TITLE
Add support of variable use for parameter rate in nginx.conf 

### DIFF
--- a/docs/modules/ngx_http_limit_req_module.md
+++ b/docs/modules/ngx_http_limit_req_module.md
@@ -15,7 +15,7 @@ Directives
 limit_req_zone
 -------------
 
-**Syntax**: *limit_req_zone $session_variable1 $session_variable2 ... zone=name_of_zone:size rate=rate|$limit_count*
+**Syntax**: *limit_req_zone $session_variable1 $session_variable2 ... zone=name_of_zone:size rate=rate | rate=$limit_count*
 
 **Default**: *none*
 
@@ -25,10 +25,12 @@ Support more than one limit variables. For example:
 
     limit_req_zone $binary_remote_addr $uri zone=one:3m rate=1r/s;
     limit_req_zone $binary_remote_addr $request_uri zone=two:3m rate=1r/s;
-    limit_req_zone $binary_remote_addr zone=three:3m rate=$limit_count;
     
-The 2nd line of the above example indicates a client can access a specific URI only once in a second.
-And the last line shows how to assign rate with another variable.
+The last line of the above example indicates a client can access a specific URI only once in a second.
+
+Support variable for rate. For example:
+
+    limit_req_zone $binary_remote_addr zone=three:3m rate=$limit_count;
 
 limit_req
 ------------------------
@@ -48,11 +50,20 @@ For example:
     limit_req_zone $binary_remote_addr zone=one:3m rate=1r/s;
     limit_req_zone $binary_remote_addr $uri zone=two:3m rate=1r/s;
     limit_req_zone $binary_remote_addr $request_uri zone=three:3m rate=1r/s;
+	limit_req_zone $binary_remote_addr $request_uri zone=four:3m rate=$limit_count;
 
     location / {
         limit_req zone=one burst=5;
         limit_req zone=two forbid_action=@test1;
         limit_req zone=three burst=3 forbid_action=@test2;
+        set $limit_count "10r/s"
+		if ($http_user_agent ~* "Android") {
+			set $limit_count "1r/s";
+        }
+		if ($http_user_agent ~* "Iphone") {
+			set $limit_count "100r/s";
+        }
+		limit_req zone=four burst=3 forbid_action=@test2;
     }
 
     location /off {

--- a/docs/modules/ngx_http_limit_req_module.md
+++ b/docs/modules/ngx_http_limit_req_module.md
@@ -15,7 +15,7 @@ Directives
 limit_req_zone
 -------------
 
-**Syntax**: *limit_req_zone $session_variable1 $session_variable2 ... zone=name_of_zone:size rate=rate*
+**Syntax**: *limit_req_zone $session_variable1 $session_variable2 ... zone=name_of_zone:size rate=rate|$limit_count*
 
 **Default**: *none*
 
@@ -25,8 +25,10 @@ Support more than one limit variables. For example:
 
     limit_req_zone $binary_remote_addr $uri zone=one:3m rate=1r/s;
     limit_req_zone $binary_remote_addr $request_uri zone=two:3m rate=1r/s;
+    limit_req_zone $binary_remote_addr zone=three:3m rate=$limit_count;
     
-The last line of the above example indicates a client can access a specific URI only once in a second.
+The 2nd line of the above example indicates a client can access a specific URI only once in a second.
+And the last line shows how to assign rate with another variable.
 
 limit_req
 ------------------------

--- a/docs/modules/ngx_http_limit_req_module.md
+++ b/docs/modules/ngx_http_limit_req_module.md
@@ -56,7 +56,7 @@ For example:
         limit_req zone=one burst=5;
         limit_req zone=two forbid_action=@test1;
         limit_req zone=three burst=3 forbid_action=@test2;
-        set $limit_count "10r/s"
+        set $limit_count "10r/s";
         if ($http_user_agent ~* "Android") {
             set $limit_count "1r/s";
         }

--- a/docs/modules/ngx_http_limit_req_module.md
+++ b/docs/modules/ngx_http_limit_req_module.md
@@ -15,7 +15,7 @@ Directives
 limit_req_zone
 -------------
 
-**Syntax**: *limit_req_zone $session_variable1 $session_variable2 ... zone=name_of_zone:size rate=rate | rate=$limit_count*
+**Syntax**: *limit_req_zone $session_variable1 $session_variable2 ... zone=name_of_zone:size rate=rate | rate=$limit_variable*
 
 **Default**: *none*
 
@@ -50,20 +50,20 @@ For example:
     limit_req_zone $binary_remote_addr zone=one:3m rate=1r/s;
     limit_req_zone $binary_remote_addr $uri zone=two:3m rate=1r/s;
     limit_req_zone $binary_remote_addr $request_uri zone=three:3m rate=1r/s;
-	limit_req_zone $binary_remote_addr $request_uri zone=four:3m rate=$limit_count;
+    limit_req_zone $binary_remote_addr $request_uri zone=four:3m rate=$limit_count;
 
     location / {
         limit_req zone=one burst=5;
         limit_req zone=two forbid_action=@test1;
         limit_req zone=three burst=3 forbid_action=@test2;
         set $limit_count "10r/s"
-		if ($http_user_agent ~* "Android") {
-			set $limit_count "1r/s";
+        if ($http_user_agent ~* "Android") {
+            set $limit_count "1r/s";
         }
-		if ($http_user_agent ~* "Iphone") {
-			set $limit_count "100r/s";
+        if ($http_user_agent ~* "Iphone") {
+            set $limit_count "100r/s";
         }
-		limit_req zone=four burst=3 forbid_action=@test2;
+        limit_req zone=four burst=3 forbid_action=@test2;
     }
 
     location /off {

--- a/src/http/modules/ngx_http_limit_req_module.c
+++ b/src/http/modules/ngx_http_limit_req_module.c
@@ -224,6 +224,7 @@ ngx_http_limit_req_copy_variables(ngx_http_request_t *r, uint32_t *hash,
                           "the value of the \"%V\" variable "
                           "for limit rate is wrong",
                           &ctx->rate_var.var);
+            return total_len;
         }
 
         if (vv->len > 65535) {
@@ -231,24 +232,24 @@ ngx_http_limit_req_copy_variables(ngx_http_request_t *r, uint32_t *hash,
                           "the value of the \"%V\" variable "
                           "is more than 65535 bytes: \"%V\"",
                           &ctx->rate_var.var, vv);
+            return total_len;
         }
 
         len = vv->len;
         p = vv->data + len - 3;
 
-        if (ngx_strcmp(p, "r/s", 3) == 0) {
+        if (ngx_strncmp(p, "r/s", 3) == 0) {
             scale = 1;
 
-        } else if (ngx_strcmp(p, "r/m", 3) == 0) {
+        } else if (ngx_strncmp(p, "r/m", 3) == 0) {
             scale = 60;
         }
 
         rate = ngx_atoi(vv->data, vv->len - 3);
         if (rate <= 0) {
-            ngx_log_error(NGX_LOG_ERROR, r->connection->log, 0,
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "the value of rate is wrong",
                           &ctx->rate_var.var);
-            total_len = 0;
             return total_len;
         }
 

--- a/src/http/modules/ngx_http_limit_req_module.c
+++ b/src/http/modules/ngx_http_limit_req_module.c
@@ -219,7 +219,7 @@ ngx_http_limit_req_copy_variables(ngx_http_request_t *r, uint32_t *hash,
 
     if (ctx->rate_var.var.len != 0) {
         vv = ngx_http_get_indexed_variable(r, ctx->rate_var.index);
-        if (vv == NULL || vv->not_found || vv->len == 0) {
+        if (vv == NULL || vv->not_found || vv->len <= 3) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "the value of the \"%V\" variable "
                           "for limit rate is wrong",


### PR DESCRIPTION
Add a variable _rate_var_ in the struct _ngx_http_limit_req_ctx_t_ to store the name of the variable used in statements like` rate=$limit_count`  in nginx.conf.

Modified two functions in _tengine/src/http/modules/ngx_http_limit_req_module.c_.

They are:

**ngx_http_limit_req_copy_variables(...)**
 
```C
if (ctx->rate_var.var.len != 0) {
        vv = ngx_http_get_indexed_variable(r, ctx->rate_var.index);
        if (vv == NULL || vv->not_found || vv->len == 0) {
            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                          "the value of the \"%V\" variable "
                          "for limit rate is wrong",
                          &ctx->rate_var.var);
        }

        if (vv->len > 65535) {
            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                          "the value of the \"%V\" variable "
                          "is more than 65535 bytes: \"%V\"",
                          &ctx->rate_var.var, vv);
        }

        len = vv->len;
        p = vv->data + len - 3;

        if (ngx_strcmp(p, "r/s", 3) == 0) {
            scale = 1;

        } else if (ngx_strcmp(p, "r/m", 3) == 0) {
            scale = 60;
        }

        rate = ngx_atoi(vv->data, vv->len - 3);
        if (rate <= 0) {
            ngx_log_error(NGX_LOG_ERROR, r->connection->log, 0,
                          "the value of rate is wrong",
                          &ctx->rate_var.var);
            total_len = 0;
            return total_len;
        }

        ctx->rate = rate * 1000 / scale;
    }

```


and **ngx_http_limit_req_zone(...)**

```C
if (ngx_strncmp(value[i].data, "rate=", 5) == 0) {

            if (value[i].data[5] == '$') {

                value[i].data += 6;
                value[i].len -= 6;
                rate_var.index = ngx_http_get_variable_index(cf, &value[i]);

                if (rate_var.index == NGX_ERROR) {
                    return NGX_CONF_ERROR;
                }
                rate_var.var = value[i];
            
            } else {
                
                len = value[i].len;
                p = value[i].data + len - 3;

                if (ngx_strncmp(p, "r/s", 3) == 0) {
                    scale = 1;
                    len -= 3;

                } else if (ngx_strncmp(p, "r/m", 3) == 0) {
                    scale = 60;
                    len -= 3;
                }

                rate = ngx_atoi(value[i].data + 5, len - 5);
                if (rate <= 0) {
                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                       "invalid rate \"%V\"", &value[i]);
                    return NGX_CONF_ERROR;
                }
            }

            continue;
        }
```