### PR TITLE
更新ngx_http_dyups_module MD文档

### DIFF
--- a/docs/modules/ngx_http_dyups_module.md
+++ b/docs/modules/ngx_http_dyups_module.md
@@ -8,10 +8,6 @@ Description
 
 This module can be used to update your upstream-list without reloadding Nginx.
 
-TODO:
-
-It can not work with common `nginx_upstream_check_module`.
-
 
 Compilation
 ===========


### PR DESCRIPTION
删除文档中的TODO说明，ngx_http_dyups_module模块已经支持与nginx_upstream_check_module协同工作。
已在生产环境中使用，没有发现问题，该提示留在文档中会令人疑惑。
可参见ngx_http_dyups_module模块说明：https://github.com/yzprofile/ngx_http_dyups_module
