### PR TITLE
Add http2 directive and $ssl_handshake_time variable

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -964,3 +964,5 @@ have=T_NGX_INPUT_BODY_FILTER . auto/have
 have=T_NGX_GZIP_CLEAR_ETAG . auto/have
 have=T_NGX_RESOLVER_FILE . auto/have
 have=T_DEPRECATED . auto/have
+have=T_NGX_HTTP2_SRV_ENABLE . auto/have
+have=T_NGX_HTTP_SSL_HANDSHAKE_TIME . auto/have

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -4697,6 +4697,7 @@ ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
     if (c->ssl->handshake_end_msec == 0) {
         ms = tp->sec * 1000 + tp->sec - c->ssl->handshake_start_msec;
+
     } else {
         ms = c->ssl->handshake_end_msec - c->ssl->handshake_start_msec;
     }

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1450,7 +1450,9 @@ ngx_ssl_handshake(ngx_connection_t *c)
 {
     int         n, sslerr;
     ngx_err_t   err;
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
     ngx_time_t *tp;
+#endif
 
     ngx_ssl_clear_error(c->log);
 
@@ -1537,8 +1539,10 @@ ngx_ssl_handshake(ngx_connection_t *c)
 
         c->ssl->handshaked = 1;
 
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
         tp = ngx_timeofday();
         c->ssl->handshake_end_msec = tp->sec * 1000 + tp->msec;
+#endif
 
         c->recv = ngx_ssl_recv;
         c->send = ngx_ssl_write;
@@ -4675,6 +4679,7 @@ ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 }
 
 
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
 ngx_int_t
 ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {
@@ -4708,6 +4713,7 @@ ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
     return NGX_OK;
 }
+#endif
 
 
 static time_t

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -85,8 +85,10 @@ struct ngx_ssl_connection_s {
     ngx_event_handler_pt        saved_read_handler;
     ngx_event_handler_pt        saved_write_handler;
 
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
     ngx_msec_t                  handshake_start_msec;
     ngx_msec_t                  handshake_end_msec;
+#endif
 
     unsigned                    handshaked:1;
     unsigned                    renegotiation:1;
@@ -248,8 +250,10 @@ ngx_int_t ngx_ssl_get_client_v_end(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
 ngx_int_t ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+#endif
 
 
 ngx_int_t ngx_ssl_handshake(ngx_connection_t *c);

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -85,6 +85,9 @@ struct ngx_ssl_connection_s {
     ngx_event_handler_pt        saved_read_handler;
     ngx_event_handler_pt        saved_write_handler;
 
+    ngx_msec_t                  handshake_start_msec;
+    ngx_msec_t                  handshake_end_msec;
+
     unsigned                    handshaked:1;
     unsigned                    renegotiation:1;
     unsigned                    buffer:1;
@@ -244,6 +247,8 @@ ngx_int_t ngx_ssl_get_client_v_start(ngx_connection_t *c, ngx_pool_t *pool,
 ngx_int_t ngx_ssl_get_client_v_end(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
+ngx_int_t ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 
 

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -357,6 +357,9 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_client_v_remain"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_client_v_remain, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_handshakd_time"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_handshake_time, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
     { ngx_null_string, NULL, NULL, 0, 0, 0 }
 };
 

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -9,6 +9,9 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 
+#if (NGX_HTTP_V2 && T_NGX_HTTP2_SRV_ENABLE)
+#include <ngx_http_v2_module.h>
+#endif
 
 typedef ngx_int_t (*ngx_ssl_variable_handler_pt)(ngx_connection_t *c,
     ngx_pool_t *pool, ngx_str_t *s);
@@ -357,8 +360,10 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_client_v_remain"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_client_v_remain, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
     { ngx_string("ssl_handshakd_time"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_handshake_time, NGX_HTTP_VAR_CHANGEABLE, 0 },
+#endif
 
     { ngx_null_string, NULL, NULL, 0, 0, 0 }
 };
@@ -381,6 +386,9 @@ ngx_http_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn, const unsigned char **out,
 #endif
 #if (NGX_HTTP_V2)
     ngx_http_connection_t  *hc;
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    ngx_http_v2_srv_conf_t *h2scf;
+#endif
 #endif
 #if (NGX_HTTP_V2 || NGX_DEBUG)
     ngx_connection_t       *c;
@@ -399,7 +407,20 @@ ngx_http_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn, const unsigned char **out,
 #if (NGX_HTTP_V2)
     hc = c->data;
 
-    if (hc->addr_conf->http2) {
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+#endif
+
+    if (
+#if (T_NGX_HTTP2_SRV_ENABLE)
+        (
+#endif
+        hc->addr_conf->http2
+#if (T_NGX_HTTP2_SRV_ENABLE)
+        && h2scf->enable != 0) || h2scf->enable == 1
+#endif
+        )
+    {
         srv =
            (unsigned char *) NGX_HTTP_V2_ALPN_ADVERTISE NGX_HTTP_NPN_ADVERTISE;
         srvlen = sizeof(NGX_HTTP_V2_ALPN_ADVERTISE NGX_HTTP_NPN_ADVERTISE) - 1;
@@ -443,10 +464,26 @@ ngx_http_ssl_npn_advertised(ngx_ssl_conn_t *ssl_conn,
 #if (NGX_HTTP_V2)
     {
     ngx_http_connection_t  *hc;
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    ngx_http_v2_srv_conf_t *h2scf;
+#endif
 
     hc = c->data;
 
-    if (hc->addr_conf->http2) {
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+#endif
+
+    if (
+#if (T_NGX_HTTP2_SRV_ENABLE)
+        (
+#endif
+        hc->addr_conf->http2
+#if (T_NGX_HTTP2_SRV_ENABLE)
+        && h2scf->enable != 0) || h2scf->enable == 1
+#endif
+        )
+    {
         *out =
             (unsigned char *) NGX_HTTP_V2_NPN_ADVERTISE NGX_HTTP_NPN_ADVERTISE;
         *outlen = sizeof(NGX_HTTP_V2_NPN_ADVERTISE NGX_HTTP_NPN_ADVERTISE) - 1;

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -645,6 +645,7 @@ ngx_http_ssl_handshake(ngx_event_t *rev)
     ssize_t                   n;
     ngx_err_t                 err;
     ngx_int_t                 rc;
+    ngx_time_t               *tp;
     ngx_connection_t         *c;
     ngx_http_connection_t    *hc;
     ngx_http_ssl_srv_conf_t  *sscf;
@@ -747,6 +748,10 @@ ngx_http_ssl_handshake(ngx_event_t *rev)
                 ngx_http_close_connection(c);
                 return;
             }
+
+            /* ssl handshake start time */
+            tp = ngx_timeofday();
+            c->ssl->handshake_start_msec = tp->sec * 1000 + tp->msec;
 
             c->ssl->enable_early_data = sscf->early_data;
 

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -9,6 +9,10 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 
+#if (NGX_HTTP_V2 && T_NGX_HTTP2_SRV_ENABLE)
+#include <ngx_http_v2_module.h>
+#endif
+
 
 static void ngx_http_wait_request_handler(ngx_event_t *ev);
 static void ngx_http_process_request_line(ngx_event_t *rev);
@@ -205,6 +209,10 @@ ngx_http_init_connection(ngx_connection_t *c)
     struct sockaddr_in6    *sin6;
     ngx_http_in6_addr_t    *addr6;
 #endif
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    ngx_http_v2_srv_conf_t *h2scf;
+#endif
+
 
     hc = ngx_pcalloc(c->pool, sizeof(ngx_http_connection_t));
     if (hc == NULL) {
@@ -312,8 +320,21 @@ ngx_http_init_connection(ngx_connection_t *c)
     rev->handler = ngx_http_wait_request_handler;
     c->write->handler = ngx_http_empty_handler;
 
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+#endif
+
 #if (NGX_HTTP_V2)
-    if (hc->addr_conf->http2) {
+    if (
+#if (T_NGX_HTTP2_SRV_ENABLE)
+        (
+#endif
+         hc->addr_conf->http2
+#if (T_NGX_HTTP2_SRV_ENABLE)
+         && h2scf->enable != 0) || h2scf->enable == 1
+#endif
+       )
+    {
         rev->handler = ngx_http_v2_init;
     }
 #endif
@@ -645,7 +666,9 @@ ngx_http_ssl_handshake(ngx_event_t *rev)
     ssize_t                   n;
     ngx_err_t                 err;
     ngx_int_t                 rc;
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
     ngx_time_t               *tp;
+#endif
     ngx_connection_t         *c;
     ngx_http_connection_t    *hc;
     ngx_http_ssl_srv_conf_t  *sscf;
@@ -749,9 +772,11 @@ ngx_http_ssl_handshake(ngx_event_t *rev)
                 return;
             }
 
+#if (T_NGX_HTTP_SSL_HANDSHAKE_TIME)
             /* ssl handshake start time */
             tp = ngx_timeofday();
             c->ssl->handshake_start_msec = tp->sec * 1000 + tp->msec;
+#endif
 
             c->ssl->enable_early_data = sscf->early_data;
 
@@ -812,9 +837,25 @@ ngx_http_ssl_handshake_handler(ngx_connection_t *c)
         const unsigned char    *data;
         ngx_http_connection_t  *hc;
 
+#if (T_NGX_HTTP2_SRV_ENABLE)
+        ngx_http_v2_srv_conf_t *h2scf;
+#endif
         hc = c->data;
 
-        if (hc->addr_conf->http2) {
+#if (T_NGX_HTTP2_SRV_ENABLE)
+        h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+#endif
+
+        if (
+#if (T_NGX_HTTP2_SRV_ENABLE)
+            (
+#endif
+             hc->addr_conf->http2
+#if (T_NGX_HTTP2_SRV_ENABLE)
+             && h2scf->enable != 0) || h2scf->enable == 1
+#endif
+           )
+        {
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
             SSL_get0_alpn_selected(c->ssl->connection, &data, &len);

--- a/src/http/v2/ngx_http_v2_module.c
+++ b/src/http/v2/ngx_http_v2_module.c
@@ -185,6 +185,15 @@ static ngx_command_t  ngx_http_v2_commands[] = {
       0,
       NULL },
 
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    { ngx_string("http2"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v2_srv_conf_t, enable),
+      NULL },
+#endif
+
       ngx_null_command
 };
 
@@ -341,6 +350,10 @@ ngx_http_v2_create_srv_conf(ngx_conf_t *cf)
     h2scf->recv_timeout = NGX_CONF_UNSET_MSEC;
     h2scf->idle_timeout = NGX_CONF_UNSET_MSEC;
 
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    h2scf->enable = NGX_CONF_UNSET;
+#endif
+
     return h2scf;
 }
 
@@ -371,6 +384,12 @@ ngx_http_v2_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                               prev->recv_timeout, 30000);
     ngx_conf_merge_msec_value(conf->idle_timeout,
                               prev->idle_timeout, 180000);
+
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    if (conf->enable == NGX_CONF_UNSET) {
+        conf->enable = prev->enable;
+    }
+#endif
 
     return NGX_CONF_OK;
 }

--- a/src/http/v2/ngx_http_v2_module.h
+++ b/src/http/v2/ngx_http_v2_module.h
@@ -30,6 +30,9 @@ typedef struct {
     ngx_uint_t                      streams_index_mask;
     ngx_msec_t                      recv_timeout;
     ngx_msec_t                      idle_timeout;
+#if (T_NGX_HTTP2_SRV_ENABLE)
+    ngx_flag_t                      enable;
+#endif
 } ngx_http_v2_srv_conf_t;
 
 


### PR DESCRIPTION
1. http2 directive
This directive is used to enable or disable http2 in the server block.
2. $ssl_handshake_time
This variable is used to output the SSL handshake time in the access log.