### PR TITLE
Reload cpu 100% bugfix

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -1151,6 +1151,24 @@ ngx_drain_connections(void)
 }
 
 
+void
+ngx_close_idle_connections(ngx_cycle_t *cycle)
+{
+    ngx_uint_t         i;
+    ngx_connection_t  *c;
+
+    c = cycle->connections;
+
+    for (i = 0; i < cycle->connection_n; i++) {
+        /* THREAD: lock */
+        if (c[i].fd != -1 && c[i].idle) {
+           c[i].close = 1;
+           c[i].read->handler(c[i].read);
+        }
+    }
+}
+
+
 ngx_int_t
 ngx_connection_local_sockaddr(ngx_connection_t *c, ngx_str_t *s,
     ngx_uint_t port)

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -205,6 +205,7 @@ ngx_int_t ngx_open_listening_sockets(ngx_cycle_t *cycle);
 void ngx_configure_listening_sockets(ngx_cycle_t *cycle);
 void ngx_close_listening_sockets(ngx_cycle_t *cycle);
 void ngx_close_connection(ngx_connection_t *c);
+void ngx_close_idle_connections(ngx_cycle_t *cycle);
 ngx_int_t ngx_connection_local_sockaddr(ngx_connection_t *c, ngx_str_t *s,
     ngx_uint_t port);
 ngx_int_t ngx_connection_error(ngx_connection_t *c, ngx_err_t err, char *text);

--- a/src/http/modules/ngx_http_dyups_module.c
+++ b/src/http/modules/ngx_http_dyups_module.c
@@ -1384,7 +1384,6 @@ ngx_dyups_add_server(ngx_http_dyups_srv_conf_t *duscf, ngx_buf_t *buf)
     ngx_http_upstream_init_pt            init;
     ngx_http_upstream_srv_conf_t        *uscf;
     ngx_http_dyups_upstream_srv_conf_t  *dscf;
-    ngx_http_upstream_rr_peers_t        *peers, *backup;
 
     uscf = duscf->upstream;
 
@@ -1425,15 +1424,6 @@ ngx_dyups_add_server(ngx_http_dyups_srv_conf_t *duscf, ngx_buf_t *buf)
 
     if (init(&cf, uscf) != NGX_OK) {
         return NGX_ERROR;
-    }
-    
-    /*add init_number initialization*/
-    peers = uscf->peer.data;
-    peers->init_number = ngx_random() % peers->number;
-
-    backup = peers->next;
-    if (backup) {
-        backup->init_number = ngx_random() % backup->number;
     }
 
     dscf = uscf->srv_conf[ngx_http_dyups_module.ctx_index];

--- a/src/http/modules/ngx_http_dyups_module.c
+++ b/src/http/modules/ngx_http_dyups_module.c
@@ -1384,6 +1384,7 @@ ngx_dyups_add_server(ngx_http_dyups_srv_conf_t *duscf, ngx_buf_t *buf)
     ngx_http_upstream_init_pt            init;
     ngx_http_upstream_srv_conf_t        *uscf;
     ngx_http_dyups_upstream_srv_conf_t  *dscf;
+    ngx_http_upstream_rr_peers_t        *peers, *backup;
 
     uscf = duscf->upstream;
 
@@ -1424,6 +1425,15 @@ ngx_dyups_add_server(ngx_http_dyups_srv_conf_t *duscf, ngx_buf_t *buf)
 
     if (init(&cf, uscf) != NGX_OK) {
         return NGX_ERROR;
+    }
+    
+    /*add init_number initialization*/
+    peers = uscf->peer.data;
+    peers->init_number = ngx_random() % peers->number;
+
+    backup = peers->next;
+    if (backup) {
+        backup->init_number = ngx_random() % backup->number;
     }
 
     dscf = uscf->srv_conf[ngx_http_dyups_module.ctx_index];

--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -313,6 +313,10 @@ ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
         goto invalid;
     }
 
+    if (ngx_terminate || ngx_exiting) {
+        goto invalid;
+    }
+
     if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
         goto invalid;
     }


### PR DESCRIPTION
[bugfix] when connections exceed 20w or more（our production environment has 38w），iterating idle connection for all times cause cpu 100%。
refer to https://github.com/nginx/nginx/commit/50ff8b3c3a3eba0984ce55c63ab8ac07dcb65265