### PR TITLE
fixed ngx_slab_sizes_init() function lost, which will result in consuming a new page every ngx_slab_allc

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -368,6 +368,12 @@ main(int argc, char *const *argv)
         return 1;
     }
 
+    /*
+     * ngx_slab_sizes_init() requires ngx_pagesize set in ngx_os_init()
+     */
+
+    ngx_slab_sizes_init();
+
     if (ngx_add_inherited_sockets(&init_cycle) != NGX_OK) {
         return 1;
     }


### PR DESCRIPTION
ngx_slab_sizes_init() function will initialize ngx_slab_max_size and ngx_slab_exact_size, which will be used when allocing memory.