### PR TITLE
修复 nginx -t 导致 connection reset by peer 的问题

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -457,7 +457,7 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
 
 #if (NGX_HAVE_REUSEPORT)
 
-            if (ls[i].reuseport) {
+            if (ls[i].reuseport && !ngx_test_config) {
                 int  reuseport;
 
                 reuseport = 1;

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -570,9 +570,19 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
 #endif
 
             if (listen(s, ls[i].backlog) == -1) {
-                ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
-                              "listen() to %V, backlog %d failed",
-                              &ls[i].addr_text, ls[i].backlog);
+                err = ngx_socket_errno;
+
+                /*
+                 * on OpenVZ after suspend/resume EADDRINUSE
+                 * may be returned by listen() instead of bind(), see
+                 * https://bugzilla.openvz.org/show_bug.cgi?id=2470
+                 */
+
+                if (err != NGX_EADDRINUSE || !ngx_test_config) {
+                    ngx_log_error(NGX_LOG_EMERG, log, err,
+                                  "listen() to %V, backlog %d failed",
+                                  &ls[i].addr_text, ls[i].backlog);
+                }
 
                 if (ngx_close_socket(s) == -1) {
                     ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
@@ -580,7 +590,15 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                                   &ls[i].addr_text);
                 }
 
-                return NGX_ERROR;
+                if (err != NGX_EADDRINUSE) {
+                    return NGX_ERROR;
+                }
+
+                if (!ngx_test_config) {
+                    failed = 1;
+                }
+
+                continue;
             }
 
             ls[i].listen = 1;


### PR DESCRIPTION
两个问题：
1. 启用 reuseport 的时候 nginx -t 导致 connection reset（linux 平台）
2. nginx 启动时 nginx -t 报端口占用错误且反回码非零

https://github.com/nginx/nginx/commit/da165aae88601628cef8db1646cd0ce3f0ee661f
https://github.com/nginx/nginx/commit/97741382b6f22352413ed5bfb4787cfa74148bdf