### PR TITLE
updated modules from nginx-1.15.1

### DIFF
--- a/src/http/modules/ngx_http_addition_filter_module.c
+++ b/src/http/modules/ngx_http_addition_filter_module.c
@@ -123,6 +123,8 @@ ngx_http_addition_header_filter(ngx_http_request_t *r)
     ngx_http_clear_accept_ranges(r);
     ngx_http_weak_etag(r);
 
+    r->preserve_body = 1;
+
     return ngx_http_next_header_filter(r);
 }
 
@@ -171,6 +173,7 @@ ngx_http_addition_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     for (cl = in; cl; cl = cl->next) {
         if (cl->buf->last_buf) {
             cl->buf->last_buf = 0;
+            cl->buf->last_in_chain = 1;
             cl->buf->sync = 1;
             last = 1;
         }

--- a/src/http/modules/ngx_http_browser_module.c
+++ b/src/http/modules/ngx_http_browser_module.c
@@ -38,13 +38,6 @@ typedef struct {
 
 
 typedef struct {
-    ngx_str_t                   name;
-    ngx_http_get_variable_pt    handler;
-    uintptr_t                   data;
-} ngx_http_browser_variable_t;
-
-
-typedef struct {
     ngx_array_t                *modern_browsers;
     ngx_array_t                *ancient_browsers;
     ngx_http_variable_value_t  *modern_browser_value;
@@ -63,7 +56,7 @@ static ngx_int_t ngx_http_browser_variable(ngx_http_request_t *r,
 static ngx_uint_t ngx_http_browser(ngx_http_request_t *r,
     ngx_http_browser_conf_t *cf);
 
-static ngx_int_t ngx_http_browser_add_variable(ngx_conf_t *cf);
+static ngx_int_t ngx_http_browser_add_variables(ngx_conf_t *cf);
 static void *ngx_http_browser_create_conf(ngx_conf_t *cf);
 static char *ngx_http_browser_merge_conf(ngx_conf_t *cf, void *parent,
     void *child);
@@ -114,7 +107,7 @@ static ngx_command_t  ngx_http_browser_commands[] = {
 
 
 static ngx_http_module_t  ngx_http_browser_module_ctx = {
-    ngx_http_browser_add_variable,         /* preconfiguration */
+    ngx_http_browser_add_variables,        /* preconfiguration */
     NULL,                                  /* postconfiguration */
 
     NULL,                                  /* create main configuration */
@@ -218,13 +211,18 @@ static ngx_http_modern_browser_mask_t  ngx_http_modern_browser_masks[] = {
 };
 
 
-static ngx_http_browser_variable_t  ngx_http_browsers[] = {
-    { ngx_string("msie"), ngx_http_msie_variable, 0 },
-    { ngx_string("modern_browser"), ngx_http_browser_variable,
-          NGX_HTTP_MODERN_BROWSER },
-    { ngx_string("ancient_browser"), ngx_http_browser_variable,
-          NGX_HTTP_ANCIENT_BROWSER },
-    { ngx_null_string, NULL, 0 }
+static ngx_http_variable_t  ngx_http_browser_vars[] = {
+
+    { ngx_string("msie"), NULL, ngx_http_msie_variable,
+      0, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("modern_browser"), NULL, ngx_http_browser_variable,
+      NGX_HTTP_MODERN_BROWSER, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ancient_browser"), NULL, ngx_http_browser_variable,
+      NGX_HTTP_ANCIENT_BROWSER, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
+      ngx_http_null_variable
 };
 
 
@@ -397,20 +395,19 @@ ngx_http_msie_variable(ngx_http_request_t *r, ngx_http_variable_value_t *v,
 
 
 static ngx_int_t
-ngx_http_browser_add_variable(ngx_conf_t *cf)
+ngx_http_browser_add_variables(ngx_conf_t *cf)
 {
-    ngx_http_browser_variable_t   *var;
-    ngx_http_variable_t           *v;
+    ngx_http_variable_t  *var, *v;
 
-    for (var = ngx_http_browsers; var->name.len; var++) {
+    for (v = ngx_http_browser_vars; v->name.len; v++) {
 
-        v = ngx_http_add_variable(cf, &var->name, NGX_HTTP_VAR_CHANGEABLE);
-        if (v == NULL) {
+        var = ngx_http_add_variable(cf, &v->name, v->flags);
+        if (var == NULL) {
             return NGX_ERROR;
         }
 
-        v->get_handler = var->handler;
-        v->data = var->data;
+        var->get_handler = v->get_handler;
+        var->data = v->data;
     }
 
     return NGX_OK;

--- a/src/http/modules/ngx_http_dav_module.c
+++ b/src/http/modules/ngx_http_dav_module.c
@@ -161,6 +161,12 @@ ngx_http_dav_handler(ngx_http_request_t *r)
             return NGX_HTTP_CONFLICT;
         }
 
+        if (r->headers_in.content_range) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "PUT with range is unsupported");
+            return NGX_HTTP_NOT_IMPLEMENTED;
+        }
+
         r->request_body_in_file_only = 1;
         r->request_body_in_persistent_file = 1;
         r->request_body_in_clean_file = 1;
@@ -207,7 +213,16 @@ ngx_http_dav_put_handler(ngx_http_request_t *r)
     ngx_ext_rename_file_t     ext;
     ngx_http_dav_loc_conf_t  *dlcf;
 
-    if (r->request_body == NULL || r->request_body->temp_file == NULL) {
+    if (r->request_body == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "PUT request body is unavailable");
+        ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    if (r->request_body->temp_file == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "PUT request body must be in a file");
         ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
         return;
     }
@@ -255,7 +270,7 @@ ngx_http_dav_put_handler(ngx_http_request_t *r)
     ext.log = r->connection->log;
 
     if (r->headers_in.date) {
-        date = ngx_http_parse_time(r->headers_in.date->value.data,
+        date = ngx_parse_http_time(r->headers_in.date->value.data,
                                    r->headers_in.date->value.len);
 
         if (date != NGX_ERROR) {
@@ -621,11 +636,11 @@ destination_done:
     if ((r->uri.data[r->uri.len - 1] == '/' && *(last - 1) != '/')
         || (r->uri.data[r->uri.len - 1] != '/' && *(last - 1) == '/'))
     {
-         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                       "both URI \"%V\" and \"Destination\" URI \"%V\" "
-                       "should be either collections or non-collections",
-                       &r->uri, &dest->value);
-         return NGX_HTTP_CONFLICT;
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "both URI \"%V\" and \"Destination\" URI \"%V\" "
+                      "should be either collections or non-collections",
+                      &r->uri, &dest->value);
+        return NGX_HTTP_CONFLICT;
     }
 
     depth = ngx_http_dav_depth(r, NGX_HTTP_DAV_INFINITY_DEPTH);
@@ -1061,7 +1076,7 @@ ngx_http_dav_location(ngx_http_request_t *r, u_char *path)
     u_char                    *location;
     ngx_http_core_loc_conf_t  *clcf;
 
-    r->headers_out.location = ngx_palloc(r->pool, sizeof(ngx_table_elt_t));
+    r->headers_out.location = ngx_list_push(&r->headers_out.headers);
     if (r->headers_out.location == NULL) {
         return NGX_ERROR;
     }
@@ -1074,17 +1089,15 @@ ngx_http_dav_location(ngx_http_request_t *r, u_char *path)
     } else {
         location = ngx_pnalloc(r->pool, r->uri.len);
         if (location == NULL) {
+            ngx_http_clear_location(r);
             return NGX_ERROR;
         }
 
         ngx_memcpy(location, r->uri.data, r->uri.len);
     }
 
-    /*
-     * we do not need to set the r->headers_out.location->hash and
-     * r->headers_out.location->key fields
-     */
-
+    r->headers_out.location->hash = 1;
+    ngx_str_set(&r->headers_out.location->key, "Location");
     r->headers_out.location->value.len = r->uri.len;
     r->headers_out.location->value.data = location;
 

--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -206,10 +206,12 @@ static ngx_conf_bitmask_t  ngx_http_fastcgi_next_upstream_masks[] = {
     { ngx_string("error"), NGX_HTTP_UPSTREAM_FT_ERROR },
     { ngx_string("timeout"), NGX_HTTP_UPSTREAM_FT_TIMEOUT },
     { ngx_string("invalid_header"), NGX_HTTP_UPSTREAM_FT_INVALID_HEADER },
+    { ngx_string("non_idempotent"), NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT },
     { ngx_string("http_500"), NGX_HTTP_UPSTREAM_FT_HTTP_500 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
+    { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },
     { ngx_string("updating"), NGX_HTTP_UPSTREAM_FT_UPDATING },
     { ngx_string("off"), NGX_HTTP_UPSTREAM_FT_OFF },
     { ngx_null_string, 0 }
@@ -278,7 +280,7 @@ static ngx_command_t  ngx_http_fastcgi_commands[] = {
       NULL },
 
     { ngx_string("fastcgi_bind"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE12,
       ngx_http_upstream_bind_set_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_fastcgi_loc_conf_t, upstream.local),
@@ -419,6 +421,13 @@ static ngx_command_t  ngx_http_fastcgi_commands[] = {
       offsetof(ngx_http_fastcgi_loc_conf_t, upstream.cache_min_uses),
       NULL },
 
+    { ngx_string("fastcgi_cache_max_range_offset"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_off_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_fastcgi_loc_conf_t, upstream.cache_max_range_offset),
+      NULL },
+
     { ngx_string("fastcgi_cache_use_stale"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
       ngx_conf_set_bitmask_slot,
@@ -459,6 +468,13 @@ static ngx_command_t  ngx_http_fastcgi_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_fastcgi_loc_conf_t, upstream.cache_revalidate),
+      NULL },
+
+    { ngx_string("fastcgi_cache_background_update"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_fastcgi_loc_conf_t, upstream.cache_background_update),
       NULL },
 
 #endif
@@ -615,7 +631,7 @@ static ngx_http_variable_t  ngx_http_fastcgi_vars[] = {
       ngx_http_fastcgi_path_info_variable, 0,
       NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_NOHASH, 0 },
 
-    { ngx_null_string, NULL, NULL, 0, 0, 0 }
+      ngx_http_null_variable
 };
 
 
@@ -750,7 +766,7 @@ ngx_http_fastcgi_eval(ngx_http_request_t *r, ngx_http_fastcgi_loc_conf_t *flcf)
     url.no_resolve = 1;
 
     if (ngx_parse_url(r->pool, &url) != NGX_OK) {
-         if (url.err) {
+        if (url.err) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "%s in upstream \"%V\"", url.err, &url.url);
         }
@@ -765,17 +781,16 @@ ngx_http_fastcgi_eval(ngx_http_request_t *r, ngx_http_fastcgi_loc_conf_t *flcf)
         return NGX_ERROR;
     }
 
-    if (url.addrs && url.addrs[0].sockaddr) {
+    if (url.addrs) {
         u->resolved->sockaddr = url.addrs[0].sockaddr;
         u->resolved->socklen = url.addrs[0].socklen;
+        u->resolved->name = url.addrs[0].name;
         u->resolved->naddrs = 1;
-        u->resolved->host = url.addrs[0].name;
-
-    } else {
-        u->resolved->host = url.host;
-        u->resolved->port = url.port;
-        u->resolved->no_port = url.no_port;
     }
+
+    u->resolved->host = url.host;
+    u->resolved->port = url.port;
+    u->resolved->no_port = url.no_port;
 
     return NGX_OK;
 }
@@ -1174,6 +1189,11 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
 #endif
 
         while (body) {
+
+            if (ngx_buf_special(body->buf)) {
+                body = body->next;
+                continue;
+            }
 
             if (body->buf->in_file) {
                 file_pos = body->buf->file_pos;
@@ -1651,7 +1671,7 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
                 && f->type != NGX_HTTP_FASTCGI_STDERR)
             {
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                              "upstream sent unexpected FastCGI record: %d",
+                              "upstream sent unexpected FastCGI record: %ui",
                               f->type);
 
                 return NGX_HTTP_UPSTREAM_INVALID_HEADER;
@@ -1770,7 +1790,6 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
 #if (NGX_HTTP_CACHE)
 
         if (f->large_stderr && r->cache) {
-            u_char                     *start;
             ssize_t                     len;
             ngx_http_fastcgi_header_t  *fh;
 
@@ -1799,7 +1818,7 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
 
             } else {
                 r->cache->header_start += u->buffer.pos - start
-                                           - sizeof(ngx_http_fastcgi_header_t);
+                                          - sizeof(ngx_http_fastcgi_header_t);
             }
 
             f->large_stderr = 0;
@@ -1833,7 +1852,7 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
             rc = ngx_http_parse_header_line(r, &u->buffer, 1);
 
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "http fastcgi parser: %d", rc);
+                           "http fastcgi parser: %i", rc);
 
             if (rc == NGX_AGAIN) {
                 break;
@@ -1859,6 +1878,7 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
 
                     p = ngx_pnalloc(r->pool, size);
                     if (p == NULL) {
+                        h->hash = 0;
                         return NGX_ERROR;
                     }
 
@@ -1881,6 +1901,7 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
                         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
                                       "invalid header after joining "
                                       "FastCGI records");
+                        h->hash = 0;
                         return NGX_ERROR;
                     }
 
@@ -1906,6 +1927,7 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
                                               h->key.len + 1 + h->value.len + 1
                                               + h->key.len);
                     if (h->key.data == NULL) {
+                        h->hash = 0;
                         return NGX_ERROR;
                     }
 
@@ -2490,36 +2512,6 @@ ngx_http_fastcgi_non_buffered_filter(void *data, ssize_t bytes)
         break;
     }
 
-    /* provide continuous buffer for subrequests in memory */
-
-    if (r->subrequest_in_memory) {
-
-        cl = u->out_bufs;
-
-        if (cl) {
-            buf->pos = cl->buf->pos;
-        }
-
-        buf->last = buf->pos;
-
-        for (cl = u->out_bufs; cl; cl = cl->next) {
-            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "http fastcgi in memory %p-%p %uz",
-                           cl->buf->pos, cl->buf->last, ngx_buf_size(cl->buf));
-
-            if (buf->last == cl->buf->pos) {
-                buf->last = cl->buf->last;
-                continue;
-            }
-
-            buf->last = ngx_movemem(buf->last, cl->buf->pos,
-                                    cl->buf->last - cl->buf->pos);
-
-            cl->buf->pos = buf->last - (cl->buf->last - cl->buf->pos);
-            cl->buf->last = buf->last;
-        }
-    }
-
     return NGX_OK;
 }
 
@@ -2557,8 +2549,8 @@ ngx_http_fastcgi_process_record(ngx_http_request_t *r,
             case NGX_HTTP_FASTCGI_STDOUT:
             case NGX_HTTP_FASTCGI_STDERR:
             case NGX_HTTP_FASTCGI_END_REQUEST:
-                 f->type = (ngx_uint_t) ch;
-                 break;
+                f->type = (ngx_uint_t) ch;
+                break;
             default:
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                               "upstream sent invalid FastCGI "
@@ -2624,6 +2616,7 @@ ngx_http_fastcgi_process_record(ngx_http_request_t *r,
         }
     }
 
+    f->pos = p;
     f->state = state;
 
     return NGX_AGAIN;
@@ -2653,7 +2646,7 @@ ngx_http_fastcgi_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
 static ngx_int_t
 ngx_http_fastcgi_add_variables(ngx_conf_t *cf)
 {
-   ngx_http_variable_t  *var, *v;
+    ngx_http_variable_t  *var, *v;
 
     for (v = ngx_http_fastcgi_vars; v->name.len; v++) {
         var = ngx_http_add_variable(cf, &v->name, v->flags);
@@ -2713,8 +2706,6 @@ ngx_http_fastcgi_create_loc_conf(ngx_conf_t *cf)
      *     conf->upstream.cache_methods = 0;
      *     conf->upstream.temp_path = NULL;
      *     conf->upstream.hide_headers_hash = { NULL, 0 };
-     *     conf->upstream.uri = { 0, NULL };
-     *     conf->upstream.location = NULL;
      *     conf->upstream.store_lengths = NULL;
      *     conf->upstream.store_values = NULL;
      *
@@ -2750,6 +2741,7 @@ ngx_http_fastcgi_create_loc_conf(ngx_conf_t *cf)
 #if (NGX_HTTP_CACHE)
     conf->upstream.cache = NGX_CONF_UNSET;
     conf->upstream.cache_min_uses = NGX_CONF_UNSET_UINT;
+    conf->upstream.cache_max_range_offset = NGX_CONF_UNSET;
     conf->upstream.cache_bypass = NGX_CONF_UNSET_PTR;
     conf->upstream.no_cache = NGX_CONF_UNSET_PTR;
     conf->upstream.cache_valid = NGX_CONF_UNSET_PTR;
@@ -2757,6 +2749,7 @@ ngx_http_fastcgi_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.cache_lock_timeout = NGX_CONF_UNSET_MSEC;
     conf->upstream.cache_lock_age = NGX_CONF_UNSET_MSEC;
     conf->upstream.cache_revalidate = NGX_CONF_UNSET;
+    conf->upstream.cache_background_update = NGX_CONF_UNSET;
 #endif
 
     conf->upstream.hide_headers = NGX_CONF_UNSET_PTR;
@@ -2995,6 +2988,10 @@ ngx_http_fastcgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_uint_value(conf->upstream.cache_min_uses,
                               prev->upstream.cache_min_uses, 1);
 
+    ngx_conf_merge_off_value(conf->upstream.cache_max_range_offset,
+                              prev->upstream.cache_max_range_offset,
+                              NGX_MAX_OFF_T_VALUE);
+
     ngx_conf_merge_bitmask_value(conf->upstream.cache_use_stale,
                               prev->upstream.cache_use_stale,
                               (NGX_CONF_BITMASK_SET
@@ -3044,6 +3041,9 @@ ngx_http_fastcgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->upstream.cache_revalidate,
                               prev->upstream.cache_revalidate, 0);
+
+    ngx_conf_merge_value(conf->upstream.cache_background_update,
+                              prev->upstream.cache_background_update, 0);
 
 #endif
 
@@ -3120,6 +3120,20 @@ ngx_http_fastcgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
 #endif
+
+    /*
+     * special handling to preserve conf->params in the "http" section
+     * to inherit it to all servers
+     */
+
+    if (prev->params.hash.buckets == NULL
+        && conf->params_source == prev->params_source)
+    {
+        prev->params = conf->params;
+#if (NGX_HTTP_CACHE)
+        prev->params_cache = conf->params_cache;
+#endif
+    }
 
     return NGX_CONF_OK;
 }
@@ -3250,7 +3264,8 @@ ngx_http_fastcgi_init_params(ngx_conf_t *cf, ngx_http_fastcgi_loc_conf_t *conf,
             return NGX_ERROR;
         }
 
-        copy->code = (ngx_http_script_code_pt) ngx_http_script_copy_len_code;
+        copy->code = (ngx_http_script_code_pt) (void *)
+                                                 ngx_http_script_copy_len_code;
         copy->len = src[i].key.len;
 
         copy = ngx_array_push_n(params->lengths,
@@ -3259,7 +3274,8 @@ ngx_http_fastcgi_init_params(ngx_conf_t *cf, ngx_http_fastcgi_loc_conf_t *conf,
             return NGX_ERROR;
         }
 
-        copy->code = (ngx_http_script_code_pt) ngx_http_script_copy_len_code;
+        copy->code = (ngx_http_script_code_pt) (void *)
+                                                 ngx_http_script_copy_len_code;
         copy->len = src[i].skip_empty;
 
 

--- a/src/http/modules/ngx_http_geoip_module.c
+++ b/src/http/modules/ngx_http_geoip_module.c
@@ -262,7 +262,7 @@ static ngx_http_variable_t  ngx_http_geoip_vars[] = {
       ngx_http_geoip_city_int_variable,
       offsetof(GeoIPRecord, area_code), 0, 0 },
 
-    { ngx_null_string, NULL, NULL, 0, 0, 0 }
+      ngx_http_null_variable
 };
 
 

--- a/src/http/modules/ngx_http_memcached_module.c
+++ b/src/http/modules/ngx_http_memcached_module.c
@@ -61,7 +61,7 @@ static ngx_command_t  ngx_http_memcached_commands[] = {
       NULL },
 
     { ngx_string("memcached_bind"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE12,
       ngx_http_upstream_bind_set_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_memcached_loc_conf_t, upstream.local),
@@ -95,6 +95,13 @@ static ngx_command_t  ngx_http_memcached_commands[] = {
       offsetof(ngx_http_memcached_loc_conf_t, upstream.read_timeout),
       NULL },
 
+    { ngx_string("memcached_next_upstream"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+      ngx_conf_set_bitmask_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_memcached_loc_conf_t, upstream.next_upstream),
+      &ngx_http_memcached_next_upstream_masks },
+
     { ngx_string("memcached_next_upstream_tries"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_num_slot,
@@ -108,13 +115,6 @@ static ngx_command_t  ngx_http_memcached_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_memcached_loc_conf_t, upstream.next_upstream_timeout),
       NULL },
-
-    { ngx_string("memcached_next_upstream"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
-      ngx_conf_set_bitmask_slot,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      offsetof(ngx_http_memcached_loc_conf_t, upstream.next_upstream),
-      &ngx_http_memcached_next_upstream_masks },
 
     { ngx_string("memcached_gzip_flag"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
@@ -532,7 +532,7 @@ ngx_http_memcached_filter(void *data, ssize_t bytes)
     cl->buf->tag = u->output.tag;
 
     ngx_log_debug4(NGX_LOG_DEBUG_HTTP, ctx->request->connection->log, 0,
-                   "memcached filter bytes:%z size:%z length:%z rest:%z",
+                   "memcached filter bytes:%z size:%z length:%O rest:%z",
                    bytes, b->last - b->pos, u->length, ctx->rest);
 
     if (bytes <= (ssize_t) (u->length - NGX_HTTP_MEMCACHED_END)) {
@@ -601,8 +601,6 @@ ngx_http_memcached_create_loc_conf(ngx_conf_t *cf)
      *     conf->upstream.bufs.num = 0;
      *     conf->upstream.next_upstream = 0;
      *     conf->upstream.temp_path = NULL;
-     *     conf->upstream.uri = { 0, NULL };
-     *     conf->upstream.location = NULL;
      */
 
     conf->upstream.local = NGX_CONF_UNSET_PTR;
@@ -631,6 +629,7 @@ ngx_http_memcached_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.intercept_404 = 1;
     conf->upstream.pass_request_headers = 0;
     conf->upstream.pass_request_body = 0;
+    conf->upstream.force_ranges = 1;
 
     conf->index = NGX_CONF_UNSET;
     conf->gzip_flag = NGX_CONF_UNSET_UINT;
@@ -727,7 +726,7 @@ ngx_http_memcached_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     clcf->handler = ngx_http_memcached_handler;
 
-    if (clcf->name.data[clcf->name.len - 1] == '/') {
+    if (clcf->name.len && clcf->name.data[clcf->name.len - 1] == '/') {
         clcf->auto_redirect = 1;
     }
 

--- a/src/http/modules/ngx_http_realip_module.c
+++ b/src/http/modules/ngx_http_realip_module.c
@@ -43,7 +43,16 @@ static char *ngx_http_realip(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static void *ngx_http_realip_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_realip_merge_loc_conf(ngx_conf_t *cf,
     void *parent, void *child);
+static ngx_int_t ngx_http_realip_add_variables(ngx_conf_t *cf);
 static ngx_int_t ngx_http_realip_init(ngx_conf_t *cf);
+static ngx_http_realip_ctx_t *ngx_http_realip_get_module_ctx(
+    ngx_http_request_t *r);
+
+
+static ngx_int_t ngx_http_realip_remote_addr_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_realip_remote_port_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
 
 
 static ngx_command_t  ngx_http_realip_commands[] = {
@@ -75,7 +84,7 @@ static ngx_command_t  ngx_http_realip_commands[] = {
 
 
 static ngx_http_module_t  ngx_http_realip_module_ctx = {
-    NULL,                                  /* preconfiguration */
+    ngx_http_realip_add_variables,         /* preconfiguration */
     ngx_http_realip_init,                  /* postconfiguration */
 
     NULL,                                  /* create main configuration */
@@ -105,6 +114,18 @@ ngx_module_t  ngx_http_realip_module = {
 };
 
 
+static ngx_http_variable_t  ngx_http_realip_vars[] = {
+
+    { ngx_string("realip_remote_addr"), NULL,
+      ngx_http_realip_remote_addr_variable, 0, 0, 0 },
+
+    { ngx_string("realip_remote_port"), NULL,
+      ngx_http_realip_remote_port_variable, 0, 0, 0 },
+
+      ngx_http_null_variable
+};
+
+
 static ngx_int_t
 ngx_http_realip_handler(ngx_http_request_t *r)
 {
@@ -120,15 +141,15 @@ ngx_http_realip_handler(ngx_http_request_t *r)
     ngx_http_realip_ctx_t       *ctx;
     ngx_http_realip_loc_conf_t  *rlcf;
 
-    ctx = ngx_http_get_module_ctx(r, ngx_http_realip_module);
-
-    if (ctx) {
-        return NGX_DECLINED;
-    }
-
     rlcf = ngx_http_get_module_loc_conf(r, ngx_http_realip_module);
 
     if (rlcf->from == NULL) {
+        return NGX_DECLINED;
+    }
+
+    ctx = ngx_http_realip_get_module_ctx(r);
+
+    if (ctx) {
         return NGX_DECLINED;
     }
 
@@ -216,6 +237,10 @@ found:
                                     rlcf->recursive)
         != NGX_DECLINED)
     {
+        if (rlcf->type == NGX_HTTP_REALIP_PROXY) {
+            ngx_inet_set_port(addr.sockaddr, c->proxy_protocol_port);
+        }
+
         return ngx_http_realip_set_addr(r, &addr);
     }
 
@@ -239,7 +264,6 @@ ngx_http_realip_set_addr(ngx_http_request_t *r, ngx_addr_t *addr)
     }
 
     ctx = cln->data;
-    ngx_http_set_ctx(r, ctx, ngx_http_realip_module);
 
     c = r->connection;
 
@@ -257,6 +281,7 @@ ngx_http_realip_set_addr(ngx_http_request_t *r, ngx_addr_t *addr)
     ngx_memcpy(p, text, len);
 
     cln->handler = ngx_http_realip_cleanup;
+    ngx_http_set_ctx(r, ctx, ngx_http_realip_module);
 
     ctx->connection = c;
     ctx->sockaddr = c->sockaddr;
@@ -292,9 +317,15 @@ ngx_http_realip_from(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
     ngx_http_realip_loc_conf_t *rlcf = conf;
 
-    ngx_int_t                rc;
-    ngx_str_t               *value;
-    ngx_cidr_t              *cidr;
+    ngx_int_t             rc;
+    ngx_str_t            *value;
+    ngx_url_t             u;
+    ngx_cidr_t            c, *cidr;
+    ngx_uint_t            i;
+    struct sockaddr_in   *sin;
+#if (NGX_HAVE_INET6)
+    struct sockaddr_in6  *sin6;
+#endif
 
     value = cf->args->elts;
 
@@ -306,31 +337,78 @@ ngx_http_realip_from(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
     }
 
-    cidr = ngx_array_push(rlcf->from);
-    if (cidr == NULL) {
-        return NGX_CONF_ERROR;
-    }
-
 #if (NGX_HAVE_UNIX_DOMAIN)
 
     if (ngx_strcmp(value[1].data, "unix:") == 0) {
-         cidr->family = AF_UNIX;
-         return NGX_CONF_OK;
+        cidr = ngx_array_push(rlcf->from);
+        if (cidr == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        cidr->family = AF_UNIX;
+        return NGX_CONF_OK;
     }
 
 #endif
 
-    rc = ngx_ptocidr(&value[1], cidr);
+    rc = ngx_ptocidr(&value[1], &c);
 
-    if (rc == NGX_ERROR) {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "invalid parameter \"%V\"",
-                           &value[1]);
+    if (rc != NGX_ERROR) {
+        if (rc == NGX_DONE) {
+            ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                               "low address bits of %V are meaningless",
+                               &value[1]);
+        }
+
+        cidr = ngx_array_push(rlcf->from);
+        if (cidr == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        *cidr = c;
+
+        return NGX_CONF_OK;
+    }
+
+    ngx_memzero(&u, sizeof(ngx_url_t));
+    u.host = value[1];
+
+    if (ngx_inet_resolve_host(cf->pool, &u) != NGX_OK) {
+        if (u.err) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "%s in set_real_ip_from \"%V\"",
+                               u.err, &u.host);
+        }
+
         return NGX_CONF_ERROR;
     }
 
-    if (rc == NGX_DONE) {
-        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
-                           "low address bits of %V are meaningless", &value[1]);
+    cidr = ngx_array_push_n(rlcf->from, u.naddrs);
+    if (cidr == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_memzero(cidr, u.naddrs * sizeof(ngx_cidr_t));
+
+    for (i = 0; i < u.naddrs; i++) {
+        cidr[i].family = u.addrs[i].sockaddr->sa_family;
+
+        switch (cidr[i].family) {
+
+#if (NGX_HAVE_INET6)
+        case AF_INET6:
+            sin6 = (struct sockaddr_in6 *) u.addrs[i].sockaddr;
+            cidr[i].u.in6.addr = sin6->sin6_addr;
+            ngx_memset(cidr[i].u.in6.mask.s6_addr, 0xff, 16);
+            break;
+#endif
+
+        default: /* AF_INET */
+            sin = (struct sockaddr_in *) u.addrs[i].sockaddr;
+            cidr[i].u.in.addr = sin->sin_addr.s_addr;
+            cidr[i].u.in.mask = 0xffffffff;
+            break;
+        }
     }
 
     return NGX_CONF_OK;
@@ -343,6 +421,10 @@ ngx_http_realip(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_realip_loc_conf_t *rlcf = conf;
 
     ngx_str_t  *value;
+
+    if (rlcf->type != NGX_CONF_UNSET_UINT) {
+        return "is duplicate";
+    }
 
     value = cf->args->elts;
 
@@ -417,6 +499,25 @@ ngx_http_realip_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
 
 static ngx_int_t
+ngx_http_realip_add_variables(ngx_conf_t *cf)
+{
+    ngx_http_variable_t  *var, *v;
+
+    for (v = ngx_http_realip_vars; v->name.len; v++) {
+        var = ngx_http_add_variable(cf, &v->name, v->flags);
+        if (var == NULL) {
+            return NGX_ERROR;
+        }
+
+        var->get_handler = v->get_handler;
+        var->data = v->data;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
 ngx_http_realip_init(ngx_conf_t *cf)
 {
     ngx_http_handler_pt        *h;
@@ -437,6 +538,86 @@ ngx_http_realip_init(ngx_conf_t *cf)
     }
 
     *h = ngx_http_realip_handler;
+
+    return NGX_OK;
+}
+
+
+static ngx_http_realip_ctx_t *
+ngx_http_realip_get_module_ctx(ngx_http_request_t *r)
+{
+    ngx_pool_cleanup_t     *cln;
+    ngx_http_realip_ctx_t  *ctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_realip_module);
+
+    if (ctx == NULL && (r->internal || r->filter_finalize)) {
+
+        /*
+         * if module context was reset, the original address
+         * can still be found in the cleanup handler
+         */
+
+        for (cln = r->pool->cleanup; cln; cln = cln->next) {
+            if (cln->handler == ngx_http_realip_cleanup) {
+                ctx = cln->data;
+                break;
+            }
+        }
+    }
+
+    return ctx;
+}
+
+
+static ngx_int_t
+ngx_http_realip_remote_addr_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_str_t              *addr_text;
+    ngx_http_realip_ctx_t  *ctx;
+
+    ctx = ngx_http_realip_get_module_ctx(r);
+
+    addr_text = ctx ? &ctx->addr_text : &r->connection->addr_text;
+
+    v->len = addr_text->len;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = addr_text->data;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_realip_remote_port_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_uint_t              port;
+    struct sockaddr        *sa;
+    ngx_http_realip_ctx_t  *ctx;
+
+    ctx = ngx_http_realip_get_module_ctx(r);
+
+    sa = ctx ? ctx->sockaddr : r->connection->sockaddr;
+
+    v->len = 0;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    v->data = ngx_pnalloc(r->pool, sizeof("65535") - 1);
+    if (v->data == NULL) {
+        return NGX_ERROR;
+    }
+
+    port = ngx_inet_get_port(sa);
+
+    if (port > 0 && port < 65536) {
+        v->len = ngx_sprintf(v->data, "%ui", port) - v->data;
+    }
 
     return NGX_OK;
 }

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -77,10 +77,12 @@ static ngx_conf_bitmask_t ngx_http_scgi_next_upstream_masks[] = {
     { ngx_string("error"), NGX_HTTP_UPSTREAM_FT_ERROR },
     { ngx_string("timeout"), NGX_HTTP_UPSTREAM_FT_TIMEOUT },
     { ngx_string("invalid_header"), NGX_HTTP_UPSTREAM_FT_INVALID_HEADER },
+    { ngx_string("non_idempotent"), NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT },
     { ngx_string("http_500"), NGX_HTTP_UPSTREAM_FT_HTTP_500 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
+    { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },
     { ngx_string("updating"), NGX_HTTP_UPSTREAM_FT_UPDATING },
     { ngx_string("off"), NGX_HTTP_UPSTREAM_FT_OFF },
     { ngx_null_string, 0 }
@@ -135,7 +137,7 @@ static ngx_command_t ngx_http_scgi_commands[] = {
       NULL },
 
     { ngx_string("scgi_bind"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE12,
       ngx_http_upstream_bind_set_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_scgi_loc_conf_t, upstream.local),
@@ -269,6 +271,13 @@ static ngx_command_t ngx_http_scgi_commands[] = {
       offsetof(ngx_http_scgi_loc_conf_t, upstream.cache_min_uses),
       NULL },
 
+    { ngx_string("scgi_cache_max_range_offset"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_off_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_scgi_loc_conf_t, upstream.cache_max_range_offset),
+      NULL },
+
     { ngx_string("scgi_cache_use_stale"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
       ngx_conf_set_bitmask_slot,
@@ -309,6 +318,13 @@ static ngx_command_t ngx_http_scgi_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_scgi_loc_conf_t, upstream.cache_revalidate),
+      NULL },
+
+    { ngx_string("scgi_cache_background_update"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_scgi_loc_conf_t, upstream.cache_background_update),
       NULL },
 
 #endif
@@ -570,17 +586,16 @@ ngx_http_scgi_eval(ngx_http_request_t *r, ngx_http_scgi_loc_conf_t * scf)
         return NGX_ERROR;
     }
 
-    if (url.addrs && url.addrs[0].sockaddr) {
+    if (url.addrs) {
         u->resolved->sockaddr = url.addrs[0].sockaddr;
         u->resolved->socklen = url.addrs[0].socklen;
+        u->resolved->name = url.addrs[0].name;
         u->resolved->naddrs = 1;
-        u->resolved->host = url.addrs[0].name;
-
-    } else {
-        u->resolved->host = url.host;
-        u->resolved->port = url.port;
-        u->resolved->no_port = url.no_port;
     }
+
+    u->resolved->host = url.host;
+    u->resolved->port = url.port;
+    u->resolved->no_port = url.no_port;
 
     return NGX_OK;
 }
@@ -813,7 +828,7 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
             key = e.pos;
 #endif
             code = *(ngx_http_script_code_pt *) e.ip;
-            code((ngx_http_script_engine_t *) & e);
+            code((ngx_http_script_engine_t *) &e);
 
 #if (NGX_DEBUG)
             val = e.pos;
@@ -883,7 +898,7 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
         next:
 
             continue;
-         }
+        }
     }
 
     *b->last++ = (u_char) ',';
@@ -1034,6 +1049,7 @@ ngx_http_scgi_process_header(ngx_http_request_t *r)
                                       h->key.len + 1 + h->value.len + 1
                                       + h->key.len);
             if (h->key.data == NULL) {
+                h->hash = 0;
                 return NGX_ERROR;
             }
 
@@ -1217,6 +1233,7 @@ ngx_http_scgi_create_loc_conf(ngx_conf_t *cf)
 #if (NGX_HTTP_CACHE)
     conf->upstream.cache = NGX_CONF_UNSET;
     conf->upstream.cache_min_uses = NGX_CONF_UNSET_UINT;
+    conf->upstream.cache_max_range_offset = NGX_CONF_UNSET;
     conf->upstream.cache_bypass = NGX_CONF_UNSET_PTR;
     conf->upstream.no_cache = NGX_CONF_UNSET_PTR;
     conf->upstream.cache_valid = NGX_CONF_UNSET_PTR;
@@ -1224,6 +1241,7 @@ ngx_http_scgi_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.cache_lock_timeout = NGX_CONF_UNSET_MSEC;
     conf->upstream.cache_lock_age = NGX_CONF_UNSET_MSEC;
     conf->upstream.cache_revalidate = NGX_CONF_UNSET;
+    conf->upstream.cache_background_update = NGX_CONF_UNSET;
 #endif
 
     conf->upstream.hide_headers = NGX_CONF_UNSET_PTR;
@@ -1463,6 +1481,10 @@ ngx_http_scgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_uint_value(conf->upstream.cache_min_uses,
                               prev->upstream.cache_min_uses, 1);
 
+    ngx_conf_merge_off_value(conf->upstream.cache_max_range_offset,
+                              prev->upstream.cache_max_range_offset,
+                              NGX_MAX_OFF_T_VALUE);
+
     ngx_conf_merge_bitmask_value(conf->upstream.cache_use_stale,
                               prev->upstream.cache_use_stale,
                               (NGX_CONF_BITMASK_SET
@@ -1512,6 +1534,9 @@ ngx_http_scgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->upstream.cache_revalidate,
                               prev->upstream.cache_revalidate, 0);
+
+    ngx_conf_merge_value(conf->upstream.cache_background_update,
+                              prev->upstream.cache_background_update, 0);
 
 #endif
 
@@ -1574,6 +1599,20 @@ ngx_http_scgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
 #endif
+
+    /*
+     * special handling to preserve conf->params in the "http" section
+     * to inherit it to all servers
+     */
+
+    if (prev->params.hash.buckets == NULL
+        && conf->params_source == prev->params_source)
+    {
+        prev->params = conf->params;
+#if (NGX_HTTP_CACHE)
+        prev->params_cache = conf->params_cache;
+#endif
+    }
 
     return NGX_CONF_OK;
 }
@@ -1704,7 +1743,8 @@ ngx_http_scgi_init_params(ngx_conf_t *cf, ngx_http_scgi_loc_conf_t *conf,
             return NGX_ERROR;
         }
 
-        copy->code = (ngx_http_script_code_pt) ngx_http_script_copy_len_code;
+        copy->code = (ngx_http_script_code_pt) (void *)
+                                                 ngx_http_script_copy_len_code;
         copy->len = src[i].key.len + 1;
 
         copy = ngx_array_push_n(params->lengths,
@@ -1713,7 +1753,8 @@ ngx_http_scgi_init_params(ngx_conf_t *cf, ngx_http_scgi_loc_conf_t *conf,
             return NGX_ERROR;
         }
 
-        copy->code = (ngx_http_script_code_pt) ngx_http_script_copy_len_code;
+        copy->code = (ngx_http_script_code_pt) (void *)
+                                                 ngx_http_script_copy_len_code;
         copy->len = src[i].skip_empty;
 
 

--- a/src/http/modules/ngx_http_secure_link_module.c
+++ b/src/http/modules/ngx_http_secure_link_module.c
@@ -107,7 +107,7 @@ ngx_http_secure_link_variable(ngx_http_request_t *r,
     ngx_md5_t                     md5;
     ngx_http_secure_link_ctx_t   *ctx;
     ngx_http_secure_link_conf_t  *conf;
-    u_char                        hash_buf[16], md5_buf[16];
+    u_char                        hash_buf[18], md5_buf[16];
 
     conf = ngx_http_get_module_loc_conf(r, ngx_http_secure_link_module);
 
@@ -154,7 +154,6 @@ ngx_http_secure_link_variable(ngx_http_request_t *r,
         goto not_found;
     }
 
-    hash.len = 16;
     hash.data = hash_buf;
 
     if (ngx_decode_base64url(&hash, &val) != NGX_OK) {

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -81,6 +81,11 @@ static ngx_conf_enum_t  ngx_http_ssl_verify[] = {
 };
 
 
+static ngx_conf_deprecated_t  ngx_http_ssl_deprecated = {
+    ngx_conf_deprecated, "ssl", "listen ... ssl"
+};
+
+
 static ngx_command_t  ngx_http_ssl_commands[] = {
 
     { ngx_string("ssl"),
@@ -88,7 +93,7 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       ngx_http_ssl_enable,
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_ssl_srv_conf_t, enable),
-      NULL },
+      &ngx_http_ssl_deprecated },
 
 #if (NGX_HTTP_SSL && NGX_SSL_ASYNC)
     { ngx_string("ssl_async"),
@@ -340,6 +345,10 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
       (uintptr_t) ngx_ssl_get_raw_certificate,
       NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_client_escaped_cert"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_escaped_certificate,
+      NGX_HTTP_VAR_CHANGEABLE, 0 },
+
     { ngx_string("ssl_client_s_dn"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_subject_dn, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
@@ -375,7 +384,7 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
       (uintptr_t) ngx_ssl_get_handshake_time, NGX_HTTP_VAR_CHANGEABLE, 0 },
 #endif
 
-    { ngx_null_string, NULL, NULL, 0, 0, 0 }
+      ngx_http_null_variable
 };
 
 
@@ -1113,10 +1122,12 @@ invalid:
 static ngx_int_t
 ngx_http_ssl_init(ngx_conf_t *cf)
 {
-    ngx_uint_t                   s;
+    ngx_uint_t                   a, p, s;
+    ngx_http_conf_addr_t        *addr;
+    ngx_http_conf_port_t        *port;
     ngx_http_ssl_srv_conf_t     *sscf;
     ngx_http_core_loc_conf_t    *clcf;
-    ngx_http_core_srv_conf_t   **cscfp;
+    ngx_http_core_srv_conf_t   **cscfp, *cscf;
     ngx_http_core_main_conf_t   *cmcf;
 
     cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
@@ -1137,6 +1148,33 @@ ngx_http_ssl_init(ngx_conf_t *cf)
             != NGX_OK)
         {
             return NGX_ERROR;
+        }
+    }
+
+    if (cmcf->ports == NULL) {
+        return NGX_OK;
+    }
+
+    port = cmcf->ports->elts;
+    for (p = 0; p < cmcf->ports->nelts; p++) {
+
+        addr = port[p].addrs.elts;
+        for (a = 0; a < port[p].addrs.nelts; a++) {
+
+            if (!addr[a].opt.ssl) {
+                continue;
+            }
+
+            cscf = addr[a].default_server;
+            sscf = cscf->ctx->srv_conf[ngx_http_ssl_module.ctx_index];
+
+            if (sscf->certificates == NULL) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                              "no \"ssl_certificate\" is defined for "
+                              "the \"listen ... ssl\" directive in %s:%ui",
+                              cscf->file_name, cscf->line);
+                return NGX_ERROR;
+            }
         }
     }
 

--- a/src/http/modules/ngx_http_stub_status_module.c
+++ b/src/http/modules/ngx_http_stub_status_module.c
@@ -24,7 +24,7 @@ static ngx_int_t ngx_http_stub_status_init(ngx_conf_t *cf);
 static ngx_command_t  ngx_http_status_commands[] = {
 
     { ngx_string("stub_status"),
-      NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_NOARGS|NGX_CONF_TAKE1,
       ngx_http_set_stub_status,
       0,
       0,
@@ -32,7 +32,6 @@ static ngx_command_t  ngx_http_status_commands[] = {
 
       ngx_null_command
 };
-
 
 
 static ngx_http_module_t  ngx_http_stub_status_module_ctx = {
@@ -84,7 +83,7 @@ static ngx_http_variable_t  ngx_http_stub_status_vars[] = {
     { ngx_string("connections_waiting"), NULL, ngx_http_stub_status_variable,
       3, NGX_HTTP_VAR_NOCACHEABLE, 0 },
 
-    { ngx_null_string, NULL, NULL, 0, 0, 0 }
+      ngx_http_null_variable
 };
 
 
@@ -101,7 +100,7 @@ ngx_http_stub_status_handler(ngx_http_request_t *r)
     ngx_atomic_int_t   rt;
 #endif
 
-    if (r->method != NGX_HTTP_GET && r->method != NGX_HTTP_HEAD) {
+    if (!(r->method & (NGX_HTTP_GET|NGX_HTTP_HEAD))) {
         return NGX_HTTP_NOT_ALLOWED;
     }
 

--- a/src/http/modules/perl/Makefile.PL
+++ b/src/http/modules/perl/Makefile.PL
@@ -16,6 +16,8 @@ WriteMakefile(
     CCFLAGS           => "$ENV{NGX_PM_CFLAGS}",
     OPTIMIZE          => '-O',
 
+    LDDLFLAGS         => "$ENV{NGX_PM_LDFLAGS}",
+
     INC               => join(" ", map {
                              m#^/# ? "-I $_" : "-I ../../../../../$_"
                          } (split /\s+/, $ENV{NGX_INCS})),

--- a/src/http/modules/perl/nginx.pm
+++ b/src/http/modules/perl/nginx.pm
@@ -24,6 +24,7 @@ our @EXPORT = qw(
     HTTP_SEE_OTHER
     HTTP_NOT_MODIFIED
     HTTP_TEMPORARY_REDIRECT
+    HTTP_PERMANENT_REDIRECT
 
     HTTP_BAD_REQUEST
     HTTP_UNAUTHORIZED
@@ -72,6 +73,7 @@ use constant HTTP_REDIRECT                  => 302;
 use constant HTTP_SEE_OTHER                 => 303;
 use constant HTTP_NOT_MODIFIED              => 304;
 use constant HTTP_TEMPORARY_REDIRECT        => 307;
+use constant HTTP_PERMANENT_REDIRECT        => 308;
 
 use constant HTTP_BAD_REQUEST               => 400;
 use constant HTTP_UNAUTHORIZED              => 401;

--- a/src/http/modules/perl/nginx.xs
+++ b/src/http/modules/perl/nginx.xs
@@ -98,6 +98,9 @@ ngx_http_perl_output(ngx_http_request_t *r, ngx_buf_t *b)
 MODULE = nginx    PACKAGE = nginx
 
 
+PROTOTYPES: DISABLE
+
+
 void
 status(r, code)
     CODE:
@@ -268,18 +271,15 @@ header_in(r, key)
         }
 #endif
 
-        if (hh->offset) {
+        ph = (ngx_table_elt_t **) ((char *) &r->headers_in + hh->offset);
 
-            ph = (ngx_table_elt_t **) ((char *) &r->headers_in + hh->offset);
+        if (*ph) {
+            ngx_http_perl_set_targ((*ph)->value.data, (*ph)->value.len);
 
-            if (*ph) {
-                ngx_http_perl_set_targ((*ph)->value.data, (*ph)->value.len);
-
-                goto done;
-            }
-
-            XSRETURN_UNDEF;
+            goto done;
         }
+
+        XSRETURN_UNDEF;
 
     multi:
 
@@ -510,10 +510,12 @@ header_out(r, key, value)
     header->hash = 1;
 
     if (ngx_http_perl_sv2str(aTHX_ r, &header->key, key) != NGX_OK) {
+        header->hash = 0;
         XSRETURN_EMPTY;
     }
 
     if (ngx_http_perl_sv2str(aTHX_ r, &header->value, value) != NGX_OK) {
+        header->hash = 0;
         XSRETURN_EMPTY;
     }
 
@@ -1001,6 +1003,7 @@ sleep(r, sleep, next)
 
     ctx->next = SvRV(ST(2));
 
+    r->connection->write->delayed = 1;
     ngx_add_timer(r->connection->write, sleep);
 
     r->write_event_handler = ngx_http_perl_sleep_handler;

--- a/src/http/modules/perl/ngx_http_perl_module.c
+++ b/src/http/modules/perl/ngx_http_perl_module.c
@@ -207,6 +207,7 @@ ngx_http_perl_handle_request(ngx_http_request_t *r)
 
     dTHXa(pmcf->perl);
     PERL_SET_CONTEXT(pmcf->perl);
+    PERL_SET_INTERP(pmcf->perl);
 
     if (ctx->next == NULL) {
         plcf = ngx_http_get_module_loc_conf(r, ngx_http_perl_module);
@@ -277,15 +278,16 @@ ngx_http_perl_sleep_handler(ngx_http_request_t *r)
 
     wev = r->connection->write;
 
-    if (wev->timedout) {
-        wev->timedout = 0;
-        ngx_http_perl_handle_request(r);
+    if (wev->delayed) {
+
+        if (ngx_handle_write_event(wev, 0) != NGX_OK) {
+            ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        }
+
         return;
     }
 
-    if (ngx_handle_write_event(wev, 0) != NGX_OK) {
-        ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
-    }
+    ngx_http_perl_handle_request(r);
 }
 
 
@@ -322,6 +324,7 @@ ngx_http_perl_variable(ngx_http_request_t *r, ngx_http_variable_value_t *v,
 
     dTHXa(pmcf->perl);
     PERL_SET_CONTEXT(pmcf->perl);
+    PERL_SET_INTERP(pmcf->perl);
 
     rc = ngx_http_perl_call_handler(aTHX_ r, pmcf->nginx, pv->sub, NULL,
                                     &pv->handler, &value);
@@ -387,6 +390,7 @@ ngx_http_perl_ssi(ngx_http_request_t *r, ngx_http_ssi_ctx_t *ssi_ctx,
 
     dTHXa(pmcf->perl);
     PERL_SET_CONTEXT(pmcf->perl);
+    PERL_SET_INTERP(pmcf->perl);
 
 #if 0
 
@@ -410,7 +414,7 @@ ngx_http_perl_ssi(ngx_http_request_t *r, ngx_http_ssi_ctx_t *ssi_ctx,
 
     args = &params[NGX_HTTP_PERL_SSI_ARG];
 
-    if (args) {
+    if (args[0]) {
 
         for (i = 0; args[i]; i++) { /* void */ }
 
@@ -568,6 +572,7 @@ ngx_http_perl_create_interpreter(ngx_conf_t *cf,
 
     dTHXa(perl);
     PERL_SET_CONTEXT(perl);
+    PERL_SET_INTERP(perl);
 
     perl_construct(perl);
 
@@ -828,6 +833,7 @@ ngx_http_perl_cleanup_perl(void *data)
     PerlInterpreter  *perl = data;
 
     PERL_SET_CONTEXT(perl);
+    PERL_SET_INTERP(perl);
 
     (void) perl_destruct(perl);
 
@@ -936,6 +942,7 @@ ngx_http_perl(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     dTHXa(pmcf->perl);
     PERL_SET_CONTEXT(pmcf->perl);
+    PERL_SET_INTERP(pmcf->perl);
 
     ngx_http_perl_eval_anon_sub(aTHX_ &value[1], &plcf->sub);
 
@@ -1007,6 +1014,7 @@ ngx_http_perl_set(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     dTHXa(pmcf->perl);
     PERL_SET_CONTEXT(pmcf->perl);
+    PERL_SET_INTERP(pmcf->perl);
 
     ngx_http_perl_eval_anon_sub(aTHX_ &value[2], &pv->sub);
 
@@ -1039,6 +1047,7 @@ ngx_http_perl_init_worker(ngx_cycle_t *cycle)
     if (pmcf) {
         dTHXa(pmcf->perl);
         PERL_SET_CONTEXT(pmcf->perl);
+        PERL_SET_INTERP(pmcf->perl);
 
         /* set worker's $$ */
 

--- a/tests/nginx-tests/nginx-tests/addition_buffered.t
+++ b/tests/nginx-tests/nginx-tests/addition_buffered.t
@@ -1,0 +1,67 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for addition module with buffered data from other filters.
+
+# In particular, sub filter may have a partial match buffered.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy sub addition/)->plan(1);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / { }
+        location /proxy/ {
+            sub_filter foo bar;
+            add_after_body /after.html;
+            proxy_pass http://127.0.0.1:8080/;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('after.html', 'after');
+$t->write_file('body.html', 'XXXXX');
+
+$t->run();
+
+###############################################################################
+
+# if data is buffered, there should be no interleaved data in output
+
+like(http_get('/proxy/body.html'), qr/^XXXXXafter$/m, 'request');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/dav.t
+++ b/tests/nginx-tests/nginx-tests/dav.t
@@ -21,7 +21,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http dav/)->plan(15);
+my $t = Test::Nginx->new()->has(qw/http dav/)->plan(20);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -40,6 +40,11 @@ http {
         server_name  localhost;
 
         location / {
+            dav_methods PUT DELETE MKCOL COPY MOVE;
+        }
+
+        location /i/ {
+            alias %%TESTDIR%%/;
             dav_methods PUT DELETE MKCOL COPY MOVE;
         }
     }
@@ -143,5 +148,36 @@ EOF
 like($r, qr/204 No Content/, 'copy file escaped');
 
 is(-s $t->testdir() . '/file-moved escape', 10, 'file copied unescaped');
+
+$t->write_file('file.exist', join '', (1 .. 42));
+
+$r = http(<<EOF);
+COPY /file HTTP/1.1
+Host: localhost
+Destination: /file.exist
+Connection: close
+
+EOF
+
+like($r, qr/204 No Content/, 'copy file overwrite');
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.15.3');
+
+is(-s $t->testdir() . '/file.exist', 10, 'target file truncated');
+
+}
+
+$r = http(<<EOF . '0123456789');
+PUT /i/alias HTTP/1.1
+Host: localhost
+Connection: close
+Content-Length: 10
+
+EOF
+
+like($r, qr/201 Created.*(Content-Length|\x0d\0a0\x0d\x0a)/ms, 'put alias');
+like($r, qr!Location: http://localhost:\d+/i/alias\x0d?$!ms, 'location alias');
+is(-s $t->testdir() . '/alias', 10, 'put alias size');
 
 ###############################################################################

--- a/tests/nginx-tests/nginx-tests/debug_connection_syslog.t
+++ b/tests/nginx-tests/nginx-tests/debug_connection_syslog.t
@@ -11,6 +11,8 @@ use strict;
 
 use Test::More;
 
+use IO::Select;
+
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
@@ -21,7 +23,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http --with-debug ipv6 proxy/);
+my $t = Test::Nginx->new()->has(qw/http --with-debug proxy/);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -36,37 +38,38 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    error_log syslog:server=127.0.0.1:8080 alert;
-    error_log syslog:server=127.0.0.1:8081 alert;
+    error_log syslog:server=127.0.0.1:%%PORT_8981_UDP%% alert;
+    error_log syslog:server=127.0.0.1:%%PORT_8982_UDP%% alert;
 
     server {
         listen       127.0.0.1:8080;
-        listen       [::1]:8080;
+        listen       [::1]:%%PORT_8080%%;
         server_name  localhost;
 
         location /debug {
-            proxy_pass http://[::1]:8080/;
+            proxy_pass http://[::1]:%%PORT_8080%%/;
         }
     }
 }
 
 EOF
 
-eval {
-	open OLDERR, ">&", \*STDERR; close STDERR;
-	$t->run();
-	open STDERR, ">&", \*OLDERR;
-};
-plan(skip_all => 'no inet6 support') if $@;
-
-$t->plan(5);
+$t->try_run('no inet6 support')->plan(5);
 
 ###############################################################################
 
-is(get_syslog('/', 8080), '', 'no debug_connection syslog 1');
-is(get_syslog('/', 8081), '', 'no debug_connection syslog 2');
+my ($s1, $s2) = map {
+	IO::Socket::INET->new(
+		Proto => 'udp',
+		LocalAddr => "127.0.0.1:$_"
+	)
+		or die "Can't open syslog socket $_: $!";
+} port(8981), port(8982);
 
-my @msgs = get_syslog('/debug', 8080, 8081);
+is(get_syslog('/', $s1), '', 'no debug_connection syslog 1');
+is(get_syslog('/', $s2), '', 'no debug_connection syslog 2');
+
+my @msgs = get_syslog('/debug', $s1, $s2);
 like($msgs[0], qr/\[debug\]/, 'debug_connection syslog 1');
 like($msgs[1], qr/\[debug\]/, 'debug_connection syslog 2');
 is($msgs[0], $msgs[1], 'debug_connection syslog1 syslog2 match');
@@ -74,44 +77,20 @@ is($msgs[0], $msgs[1], 'debug_connection syslog1 syslog2 match');
 ###############################################################################
 
 sub get_syslog {
-	my ($uri, @port) = @_;
-	my (@s);
-	my $rfd = '';
+	my ($uri, @s) = @_;
 	my @data;
-
-	eval {
-		local $SIG{ALRM} = sub { die "timeout\n" };
-		local $SIG{PIPE} = sub { die "sigpipe\n" };
-		alarm(1);
-		map {
-			push @s, IO::Socket::INET->new(
-				Proto => 'udp',
-				LocalAddr => "127.0.0.1:$_"
-			);
-		} (@port);
-		alarm(0);
-	};
-	alarm(0);
-	if ($@) {
-		log_in("died: $@");
-		return undef;
-	}
 
 	http_get($uri);
 
 	map {
 		my $data = '';
-		vec($rfd, fileno($_), 1) = 1;
-		select $rfd, undef, undef, 1;
-		while (select($rfd, undef, undef, 0.1) > 0
-			&& vec($rfd, fileno($_), 1))
-		{
+		IO::Select->new($_)->can_read(1);
+		while (IO::Select->new($_)->can_read(0.1)) {
 			my ($buffer);
 			sysread($_, $buffer, 4096);
 			$data .= $buffer;
 		}
 		push @data, $data;
-		$_->close();
 	} (@s);
 
 	return $data[0] if scalar @data == 1;

--- a/tests/nginx-tests/nginx-tests/fastcgi.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi.t
@@ -61,7 +61,7 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -73,13 +73,14 @@ unlike(http_head('/'), qr/SEE-THIS/, 'no data in HEAD');
 
 like(http_get('/stderr'), qr/SEE-THIS/, 'large stderr handled');
 
-like(http_get('/var?b=127.0.0.1:8081'), qr/SEE-THIS/, 'fastcgi with variables');
+like(http_get('/var?b=127.0.0.1:' . port(8081)), qr/SEE-THIS/,
+	'fastcgi with variables');
 like(http_get('/var?b=u'), qr/SEE-THIS/, 'fastcgi with variables to upstream');
 
 ###############################################################################
 
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
 	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
 		$socket);
 
@@ -92,7 +93,7 @@ sub fastcgi_daemon {
 		}
 
 		print <<EOF;
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 SEE-THIS

--- a/tests/nginx-tests/nginx-tests/fastcgi_body.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_body.t
@@ -21,10 +21,6 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-eval { require FCGI; };
-plan(skip_all => 'FCGI not installed') if $@;
-plan(skip_all => 'win32') if $^O eq 'MSWin32';
-
 my $t = Test::Nginx->new()->has(qw/http fastcgi/)->plan(5)
 	->write_file_expand('nginx.conf', <<'EOF');
 
@@ -53,16 +49,17 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
-like(http_get('/'), qr/X-Body: /, 'fastcgi no body');
+like(http_get('/'), qr/X-Body: _eos\x0d?$/ms, 'fastcgi no body');
 
-like(http_get_length('/', ''), qr/X-Body: /, 'fastcgi empty body');
-like(http_get_length('/', 'foobar'), qr/X-Body: foobar/, 'fastcgi body');
+like(http_get_length('/', ''), qr/X-Body: _eos\x0d?$/ms, 'fastcgi empty body');
+like(http_get_length('/', 'foobar'), qr/X-Body: foobar_eos\x0d?$/ms,
+	'fastcgi body');
 
-like(http(<<EOF), qr/X-Body: foobar/, 'fastcgi chunked');
+like(http(<<EOF), qr/X-Body: foobar_eos\x0d?$/ms, 'fastcgi chunked');
 GET / HTTP/1.1
 Host: localhost
 Connection: close
@@ -74,7 +71,7 @@ foobar
 
 EOF
 
-like(http(<<EOF), qr/X-Body: /, 'fastcgi empty chunked');
+like(http(<<EOF), qr/X-Body: _eos\x0d?$/ms, 'fastcgi empty chunked');
 GET / HTTP/1.1
 Host: localhost
 Connection: close
@@ -101,29 +98,86 @@ EOF
 
 ###############################################################################
 
+# Simple FastCGI responder implementation.
+
+# http://www.fastcgi.com/devkit/doc/fcgi-spec.html
+
+sub fastcgi_read_record($) {
+	my ($buf) = @_;
+	my $h;
+
+	return undef unless length $$buf;
+
+	@{$h}{qw/ version type id clen plen /} = unpack("CCnnC", $$buf);
+
+	$h->{content} = substr $$buf, 8, $h->{clen};
+	$h->{padding} = substr $$buf, 8 + $h->{clen}, $h->{plen};
+
+	$$buf = substr $$buf, 8 + $h->{clen} + $h->{plen};
+
+	return $h;
+}
+
+sub fastcgi_respond($$$$) {
+	my ($socket, $version, $id, $body) = @_;
+
+	# stdout
+	$socket->write(pack("CCnnCx", $version, 6, $id, length($body), 0));
+	$socket->write($body);
+
+	# close stdout
+	$socket->write(pack("CCnnCx", $version, 6, $id, 0, 0));
+
+	# end request
+	$socket->write(pack("CCnnCx", $version, 3, $id, 8, 0));
+	$socket->write(pack("NCxxx", 0, 0));
+}
+
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
-	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
-		$socket);
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalAddr => '127.0.0.1:' . port(8081),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
 
-	my $count;
-	my $body;
+	local $SIG{PIPE} = 'IGNORE';
 
-	while( $request->Accept() >= 0 ) {
-		$count++;
-		read(STDIN, $body, $ENV{'CONTENT_LENGTH'});
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+		Test::Nginx::log_core('||', "fastcgi connection");
 
-		print <<EOF;
-Location: http://127.0.0.1:8080/redirect
+		$client->sysread(my $buf, 1024) or next;
+
+		my ($version, $id);
+		my $body = '';
+
+		while (my $h = fastcgi_read_record(\$buf)) {
+			$version = $h->{version};
+			$id = $h->{id};
+
+			Test::Nginx::log_core('||', "fastcgi record: "
+				. " $h->{version}, $h->{type}, $h->{id}, "
+				. "'$h->{content}'");
+
+			if ($h->{type} == 5) {
+				$body .= $h->{content} if $h->{clen} > 0;
+
+				# count stdin end-of-stream
+				$body .= '_eos' if $h->{clen} == 0;
+			}
+		}
+
+		# respond
+		fastcgi_respond($client, $version, $id, <<EOF);
+Location: http://localhost/redirect
 Content-Type: text/html
 X-Body: $body
 
 SEE-THIS
-$count
 EOF
 	}
-
-	FCGI::CloseSocket($socket);
 }
 
 ###############################################################################

--- a/tests/nginx-tests/nginx-tests/fastcgi_buffering.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_buffering.t
@@ -64,7 +64,7 @@ $t->write_file('inmemory.html',
 
 $t->run()->plan(2);
 
-$t->run_daemon(\&fastcgi_daemon)->waitforsocket('127.0.0.1:8081');
+$t->run_daemon(\&fastcgi_daemon)->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -74,7 +74,7 @@ like(http_get('/inmemory.html'), qr/set: SEE-THIS/, 'fastcgi inmemory');
 ###############################################################################
 
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
 	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
 		$socket);
 

--- a/tests/nginx-tests/nginx-tests/fastcgi_cache.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_cache.t
@@ -25,7 +25,7 @@ eval { require FCGI; };
 plan(skip_all => 'FCGI not installed') if $@;
 plan(skip_all => 'win32') if $^O eq 'MSWin32';
 
-my $t = Test::Nginx->new()->has(qw/http fastcgi cache shmem/)->plan(5)
+my $t = Test::Nginx->new()->has(qw/http fastcgi cache/)->plan(5)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -58,7 +58,7 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -79,7 +79,7 @@ like(http_get('/stderr'), qr/SEE-THIS.*^2$/ms, 'large stderr cached');
 ###############################################################################
 
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
 	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
 		$socket);
 
@@ -92,7 +92,7 @@ sub fastcgi_daemon {
 		}
 
 		print <<EOF;
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 SEE-THIS

--- a/tests/nginx-tests/nginx-tests/fastcgi_header_params.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_header_params.t
@@ -52,7 +52,7 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -92,7 +92,7 @@ EOF
 ###############################################################################
 
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
 	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
 		$socket);
 
@@ -101,7 +101,7 @@ sub fastcgi_daemon {
 		$count++;
 
 		print <<EOF;
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 SEE-THIS

--- a/tests/nginx-tests/nginx-tests/fastcgi_keepalive.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_keepalive.t
@@ -27,7 +27,7 @@ my $t = Test::Nginx->new()->has(qw/http fastcgi upstream_keepalive/)->plan(6)
 %%TEST_GLOBALS%%
 
 daemon off;
-worker_processes 1;
+worker_processes 1; # fixed for tengine
 
 events {
 }
@@ -54,7 +54,7 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_test_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -139,7 +139,7 @@ sub fastcgi_respond($$) {
 sub fastcgi_test_daemon {
 	my $server = IO::Socket::INET->new(
 		Proto => 'tcp',
-		LocalAddr => '127.0.0.1:8081',
+		LocalAddr => '127.0.0.1:' . port(8081),
 		Listen => 5,
 		Reuse => 1
 	)
@@ -168,7 +168,7 @@ sub fastcgi_test_daemon {
 
 			# respond
 			fastcgi_respond($h, <<EOF);
-Location: http://localhost:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 SEE-THIS

--- a/tests/nginx-tests/nginx-tests/fastcgi_merge_params.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_merge_params.t
@@ -25,7 +25,7 @@ eval { require FCGI; };
 plan(skip_all => 'FCGI not installed') if $@;
 plan(skip_all => 'win32') if $^O eq 'MSWin32';
 
-my $t = Test::Nginx->new()->has(qw/http fastcgi cache shmem/)->plan(9)
+my $t = Test::Nginx->new()->has(qw/http fastcgi cache/)->plan(9)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -70,7 +70,7 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -112,7 +112,7 @@ EOF
 ###############################################################################
 
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
 	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
 		$socket);
 
@@ -125,7 +125,7 @@ sub fastcgi_daemon {
 		my $blah = $ENV{HTTP_X_BLAH};
 
 		print <<EOF;
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 ims=$ims;iums=$iums;blah=$blah;

--- a/tests/nginx-tests/nginx-tests/fastcgi_merge_params2.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_merge_params2.t
@@ -25,7 +25,7 @@ eval { require FCGI; };
 plan(skip_all => 'FCGI not installed') if $@;
 plan(skip_all => 'win32') if $^O eq 'MSWin32';
 
-my $t = Test::Nginx->new()->has(qw/http fastcgi cache shmem/)->plan(4)
+my $t = Test::Nginx->new()->has(qw/http fastcgi cache/)->plan(4)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -65,7 +65,7 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -96,7 +96,7 @@ EOF
 ###############################################################################
 
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
 	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
 		$socket);
 
@@ -109,7 +109,7 @@ sub fastcgi_daemon {
 		my $blah = $ENV{HTTP_X_BLAH};
 
 		print <<EOF;
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 ims=$ims;iums=$iums;blah=$blah;

--- a/tests/nginx-tests/nginx-tests/fastcgi_split.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_split.t
@@ -60,13 +60,13 @@ http {
 
 EOF
 
-$t->run_daemon(\&fastcgi_daemon, 8081);
-$t->run_daemon(\&fastcgi_daemon, 8082);
+$t->run_daemon(\&fastcgi_daemon, port(8081));
+$t->run_daemon(\&fastcgi_daemon, port(8082));
 
 $t->run();
 
-$t->waitforsocket('127.0.0.1:8081');
-$t->waitforsocket('127.0.0.1:8082');
+$t->waitforsocket('127.0.0.1:' . port(8081));
+$t->waitforsocket('127.0.0.1:' . port(8082));
 
 ###############################################################################
 
@@ -84,10 +84,10 @@ sub fastcgi_daemon {
 	while( $request->Accept() >= 0 ) {
 		$count++;
 
-		if ($port == 8081) {
+		if ($port == port(8081)) {
 			print 'BAD';
 		}
-		if ($port == 8082) {
+		if ($port == port(8082)) {
 			print 'Good: header' . CRLF . CRLF;
 		}
 	}

--- a/tests/nginx-tests/nginx-tests/fastcgi_unix.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_unix.t
@@ -105,7 +105,7 @@ sub fastcgi_daemon {
 		}
 
 		print <<EOF;
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 SEE-THIS

--- a/tests/nginx-tests/nginx-tests/fastcgi_variables.t
+++ b/tests/nginx-tests/nginx-tests/fastcgi_variables.t
@@ -63,7 +63,7 @@ http {
 EOF
 
 $t->run_daemon(\&fastcgi_daemon);
-$t->run()->waitforsocket('127.0.0.1:8081');
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -76,7 +76,7 @@ like(http_get('/info.php/path/info'), qr/X-Path-Info: \/path\/info/ms,
 ###############################################################################
 
 sub fastcgi_daemon {
-	my $socket = FCGI::OpenSocket('127.0.0.1:8081', 5);
+	my $socket = FCGI::OpenSocket('127.0.0.1:' . port(8081), 5);
 	my $request = FCGI::Request(\*STDIN, \*STDOUT, \*STDERR, \%ENV,
 		$socket);
 

--- a/tests/nginx-tests/nginx-tests/geo_ipv6.t
+++ b/tests/nginx-tests/nginx-tests/geo_ipv6.t
@@ -22,7 +22,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http geo/)
+my $t = Test::Nginx->new()->has(qw/http geo proxy/)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%

--- a/tests/nginx-tests/nginx-tests/geo_unix.t
+++ b/tests/nginx-tests/nginx-tests/geo_unix.t
@@ -1,0 +1,110 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for http geo module with unix socket.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http geo proxy unix/)->plan(5);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    geo $geo {
+        default                  default;
+        255.255.255.255          none;
+    }
+
+    geo $remote_addr $geora {
+        default                  default;
+        255.255.255.255          none;
+    }
+
+    geo $geor {
+        ranges;
+        0.0.0.0-255.255.255.254  test;
+        default                  none;
+    }
+
+    geo $remote_addr $georra {
+        ranges;
+        0.0.0.0-255.255.255.254  test;
+        default                  none;
+    }
+
+    geo $arg_ip $geo_arg {
+        default                  default;
+        192.0.2.0/24             test;
+    }
+
+    server {
+        listen       unix:%%TESTDIR%%/unix.sock;
+        server_name  localhost;
+
+        location / {
+            add_header X-Geo          $geo;
+            add_header X-Addr         $geora;
+            add_header X-Ranges       $geor;
+            add_header X-Ranges-Addr  $georra;
+            add_header X-Arg          $geo_arg;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8080;
+
+        location / {
+            proxy_pass http://unix:%%TESTDIR%%/unix.sock;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('index.html', '');
+$t->run();
+
+###############################################################################
+
+my $r = http_get('/');
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.15.8');
+
+like($r, qr/^X-Geo: none/m, 'geo unix');
+like($r, qr/^X-Ranges: none/m, 'geo unix ranges');
+
+}
+
+like($r, qr/^X-Addr: none/m, 'geo unix remote addr');
+like($r, qr/^X-Ranges-Addr: none/m, 'geo unix ranges remote addr');
+
+like(http_get('/?ip=192.0.2.1'), qr/^X-Arg: test/m, 'geo unix variable');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/memcached.t
+++ b/tests/nginx-tests/nginx-tests/memcached.t
@@ -62,22 +62,22 @@ my @memopts = ();
 
 if ($memhelp =~ /repcached/) {
 	# repcached patch adds additional listen socket
-	push @memopts, '-X', '8082';
+	push @memopts, '-X', port(8082);
 }
 if ($memhelp =~ /-U/) {
 	# UDP port is on by default in memcached 1.2.7+
 	push @memopts, '-U', '0';
 }
 
-$t->run_daemon('memcached', '-l', '127.0.0.1', '-p', '8081', @memopts);
+$t->run_daemon('memcached', '-l', '127.0.0.1', '-p', port(8081), @memopts);
 $t->run();
 
-$t->waitforsocket('127.0.0.1:8081')
+$t->waitforsocket('127.0.0.1:' . port(8081))
 	or die "Can't start memcached";
 
 ###############################################################################
 
-my $memd = Cache::Memcached->new(servers => [ '127.0.0.1:8081' ],
+my $memd = Cache::Memcached->new(servers => [ '127.0.0.1:' . port(8081) ],
 	connect_timeout => 1.0);
 $memd->set('/', 'SEE-THIS')
 	or die "can't put value into memcached: $!";

--- a/tests/nginx-tests/nginx-tests/memcached_fake.t
+++ b/tests/nginx-tests/nginx-tests/memcached_fake.t
@@ -53,11 +53,14 @@ http {
 
 EOF
 
-$t->write_file('ssi.html', '<!--#include virtual="/" set="blah" -->blah: <!--#echo var="blah" -->');
+$t->write_file('ssi.html',
+	'<!--#include virtual="/" set="blah" -->' .
+	'blah: <!--#echo var="blah" -->');
+
 $t->run_daemon(\&memcached_fake_daemon);
 $t->run();
 
-$t->waitforsocket('127.0.0.1:8081')
+$t->waitforsocket('127.0.0.1:' . port(8081))
 	or die "Can't start fake memcached";
 
 ###############################################################################
@@ -66,14 +69,14 @@ like(http_get('/'), qr/SEE-THIS/, 'memcached split trailer');
 
 like(http_get('/ssi.html'), qr/SEE-THIS/, 'memcached ssi var');
 
-like(`grep -F '[error]' ${\($t->testdir())}/error.log`, qr/^$/s, 'no error');
+like(`grep -F '[error]' ${\($t->testdir())}/error.log`, qr/^$/s, 'no errors');
 
 ###############################################################################
 
 sub memcached_fake_daemon {
 	my $server = IO::Socket::INET->new(
 		Proto => 'tcp',
-		LocalAddr => '127.0.0.1:8081',
+		LocalAddr => '127.0.0.1:' . port(8081),
 		Listen => 5,
 		Reuse => 1
 	)

--- a/tests/nginx-tests/nginx-tests/memcached_keepalive_stale.t
+++ b/tests/nginx-tests/nginx-tests/memcached_keepalive_stale.t
@@ -65,7 +65,7 @@ if ($memhelp =~ /repcached/) {
 	# repcached patches adds additional listen socket memcached
 	# that should be different too
 
-	push @memopts1, '-X', '8091';
+	push @memopts1, '-X', port(8082);
 }
 if ($memhelp =~ /-U/) {
 	# UDP ports no longer off by default in memcached 1.2.7+
@@ -78,16 +78,16 @@ if ($memhelp =~ /-t/) {
 	push @memopts1, '-t', '1';
 }
 
-$t->run_daemon('memcached', '-l', '127.0.0.1', '-p', '8081', @memopts1);
+$t->run_daemon('memcached', '-l', '127.0.0.1', '-p', port(8081), @memopts1);
 
 $t->run();
 
-$t->waitforsocket('127.0.0.1:8081')
+$t->waitforsocket('127.0.0.1:' . port(8081))
 	or die "Unable to start memcached";
 
 ###############################################################################
 
-my $memd1 = Cache::Memcached->new(servers => [ '127.0.0.1:8081' ],
+my $memd1 = Cache::Memcached->new(servers => [ '127.0.0.1:' . port(8081) ],
 	connect_timeout => 1.0);
 
 # It's possible that stale events occur, i.e. read event handler called

--- a/tests/nginx-tests/nginx-tests/perl.t
+++ b/tests/nginx-tests/nginx-tests/perl.t
@@ -23,7 +23,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http perl rewrite/)->plan(13)
+my $t = Test::Nginx->new()->has(qw/http perl rewrite/)->plan(17)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -60,6 +60,25 @@ http {
                 $r->print("xfoo: ", $r->header_in("X-Foo"), "\n");
                 $r->print("cookie: ", $r->header_in("Cookie"), "\n");
                 $r->print("xff: ", $r->header_in("X-Forwarded-For"), "\n");
+
+                return OK;
+            }';
+        }
+
+        location /range {
+            perl 'sub {
+                use warnings;
+                use strict;
+
+                my $r = shift;
+
+                $r->header_out("Content-Length", "42");
+                $r->allow_ranges();
+                $r->send_http_header("text/plain");
+
+                return OK if $r->header_only;
+
+                $r->print("x" x 42);
 
                 return OK;
             }';
@@ -135,6 +154,35 @@ like(http(
 	. 'X-Forwarded-For: foo2' . CRLF
 	. 'Host: localhost' . CRLF . CRLF
 ), qr/xff: foo1, foo2/, 'perl header_in xff2');
+
+# headers_out content-length tests with range filter
+
+like(http_get('/range'), qr/Content-Length: 42.*^x{42}$/ms,
+	'perl header_out content-length');
+
+like(http(
+	'GET /range HTTP/1.0' . CRLF
+	. 'Host: localhost' . CRLF
+	. 'Range: bytes=0-1' . CRLF . CRLF
+), qr/Content-Length: 2.*^xx$/ms, 'perl header_out content-length range');
+
+like(http(
+	'GET /range HTTP/1.0' . CRLF
+	. 'Host: localhost' . CRLF
+	. 'Range: bytes=0-1,3-5' . CRLF . CRLF
+), qr/Content-Length: (?!42).*^xx\x0d.*^xxx\x0d/ms,
+	'perl header_out content-length multipart');
+
+TODO: {
+local $TODO = 'not yet';
+
+like(http(
+	'GET /range HTTP/1.0' . CRLF
+	. 'Host: localhost' . CRLF
+	. 'Range: bytes=100000-' . CRLF . CRLF
+), qr|^\QHTTP/1.1 416\E.*(?!xxx)|ms, 'perl range not satisfiable');
+
+}
 
 # various request body tests
 

--- a/tests/nginx-tests/nginx-tests/perl_sleep.t
+++ b/tests/nginx-tests/nginx-tests/perl_sleep.t
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+
+# (C) Maxim Dounin
+
+# Tests for embedded perl module, $r->sleep().
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http perl ssi/)->plan(2)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            ssi on;
+            sendfile_max_chunk 100;
+            postpone_output 0;
+        }
+
+        location /sleep {
+            perl 'sub {
+                my $r = shift;
+
+                $r->sleep(100, sub {
+                    my $r = shift;
+                    $r->send_http_header;
+                    $r->print("it works");
+                    return OK;
+                });
+
+                return OK;
+            }';
+        }
+    }
+}
+
+EOF
+
+$t->write_file('subrequest.html', ('x' x 200) .
+	'X<!--#include virtual="/sleep" -->X');
+
+$t->run();
+
+###############################################################################
+
+like(http_get('/sleep'), qr/works/, 'perl sleep');
+like(http_get('/subrequest.html'), qr/works/, 'perl sleep in subrequest');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/perl_ssi.t
+++ b/tests/nginx-tests/nginx-tests/perl_ssi.t
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+
+# (C) Maxim Dounin
+
+# Tests for embedded perl module.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http perl ssi/)->plan(3)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            ssi on;
+        }
+
+        location /dummy {
+            perl 'sub foo { my $r = shift; $r->print(join ",", @_); }';
+        }
+    }
+}
+
+EOF
+
+$t->write_file('t1.html', 'X<!--#perl sub="foo" arg="arg1" -->X');
+$t->write_file('t2.html', 'X<!--#perl sub="foo" arg="arg1" arg="arg2" -->X');
+$t->write_file('noargs.html', 'X<!--#perl sub="foo" -->X');
+
+$t->run();
+
+###############################################################################
+
+like(http_get('/t1.html'), qr/Xarg1X/, 'perl ssi response');
+like(http_get('/t2.html'), qr/Xarg1,arg2X/, 'perl ssi two args');
+like(http_get('/noargs.html'), qr/XX/, 'perl ssi noargs');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/realip_hostname.t
+++ b/tests/nginx-tests/nginx-tests/realip_hostname.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for nginx realip module, 'unix:' and hostname in set_real_ip_from.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http realip proxy unix/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        listen       unix:%%TESTDIR%%/unix.sock;
+        server_name  localhost;
+
+        location /1 {
+            set_real_ip_from  localhost;
+            add_header X-IP $remote_addr;
+        }
+
+        location /2 {
+            set_real_ip_from  unix:;
+            add_header X-IP $remote_addr;
+        }
+
+        location /unix {
+            proxy_pass http://unix:%%TESTDIR%%/unix.sock:/;
+            proxy_set_header X-Real-IP 192.0.2.1;
+        }
+
+        location /ip {
+            proxy_pass http://127.0.0.1:8080/;
+            proxy_set_header X-Real-IP 192.0.2.1;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('1', '');
+$t->write_file('2', '');
+$t->run();
+
+plan(skip_all => 'no 127.0.0.1 on host')
+	if http_get('/1') !~ /X-IP: 127.0.0.1/m;
+
+$t->plan(4);
+
+###############################################################################
+
+like(http_get('/unix/2'), qr/X-IP: 192.0.2.1/, 'realip unix');
+unlike(http_get('/unix/1'), qr/X-IP: 192.0.2.1/, 'realip unix - no match');
+
+like(http_get('/ip/1'), qr/X-IP: 192.0.2.1/, 'realip hostname');
+unlike(http_get('/ip/2'), qr/X-IP: 192.0.2.1/, 'realip hostname - no match');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/rewrite.t
+++ b/tests/nginx-tests/nginx-tests/rewrite.t
@@ -158,7 +158,15 @@ like(http_get('/return200'), qr!200 OK!, 'return 200');
 like(http_get('/return306'), qr!HTTP/1.1 306 !, 'return 306');
 like(http_get('/return405'), qr!HTTP/1.1 405.*body!ms, 'return 405');
 
-like(http_get('/error404return405'), qr!HTTP/1.1 404!, 'error 404 return 405');
+# this used to result in 404, but was changed in 1.15.4
+# to respond with 405 instead, much like a real error would do
+
+TODO: {
+local $TODO = 'not yet' unless $t->has_version('1.15.4');
+
+like(http_get('/error404return405'), qr!HTTP/1.1 405!, 'error 404 return 405');
+
+}
 
 # status code should be 405, and entity body is expected (vs. normal 204
 # replies which doesn't expect to have body); use HTTP/1.1 for test

--- a/tests/nginx-tests/nginx-tests/rewrite_if.t
+++ b/tests/nginx-tests/nginx-tests/rewrite_if.t
@@ -1,0 +1,195 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for rewrite "if" condition.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http rewrite/)->plan(33)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            if ($arg_c) {
+                return 204;
+            }
+        }
+
+        location /sp {
+            if ( $arg_c ) {
+                return 204;
+            }
+        }
+
+        location /eq {
+            if ($arg_c = 1) {
+                return 204;
+            }
+        }
+
+        location /not {
+            if ($arg_c != 2) {
+                return 204;
+            }
+        }
+
+        location /pos {
+            if ($arg_c ~ foo) {
+                return 204;
+            }
+        }
+
+        location /cpos {
+            if ($arg_c ~* foo) {
+                return 204;
+            }
+        }
+
+        location /neg {
+            if ($arg_c !~ foo) {
+                return 204;
+            }
+        }
+
+        location /cneg {
+            if ($arg_c !~* foo) {
+                return 204;
+            }
+        }
+
+        location /plain {
+            if (-f %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+
+        location /dir {
+            if (-d %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+
+        location /exist {
+            if (-e %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+
+        location /exec {
+            if (-x %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+
+        location /not_plain {
+            if (!-f %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+
+        location /not_dir {
+            if (!-d %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+
+        location /not_exist {
+            if (!-e %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+
+        location /not_exec {
+            if (!-x %%TESTDIR%%/$arg_c) {
+                return 204;
+            }
+        }
+    }
+}
+
+EOF
+
+$t->write_file('file', '');
+mkdir($t->testdir() . '/dir');
+
+$t->run();
+
+###############################################################################
+
+like(http_get('/?c=1'), qr/ 204 /, 'var');
+unlike(http_get('/?c=0'), qr/ 204 /, 'false');
+like(http_get('/sp?c=1'), qr/ 204 /, 'spaces');
+
+like(http_get('/eq?c=1'), qr/ 204 /, 'equal');
+unlike(http_get('/eq?c=2'), qr/ 204 /, 'equal false');
+like(http_get('/not?c=1'), qr/ 204 /, 'not equal');
+unlike(http_get('/not?c=2'), qr/ 204 /, 'not equal false');
+
+like(http_get('/pos?c=food'), qr/ 204 /, 'match');
+like(http_get('/cpos?c=FooD'), qr/ 204 /, 'match case');
+like(http_get('/neg?c=FooD'), qr/ 204 /, 'match negative');
+like(http_get('/cneg?c=bar'), qr/ 204 /, 'match negative case');
+
+unlike(http_get('/pos?c=FooD'), qr/ 204 /, 'mismatch');
+unlike(http_get('/cpos?c=bar'), qr/ 204 /, 'mismatch case');
+unlike(http_get('/neg?c=food'), qr/ 204 /, 'mismatch negative');
+unlike(http_get('/cneg?c=FooD'), qr/ 204 /, 'mismatch negative case');
+
+like(http_get('/plain?c=file'), qr/ 204 /, 'plain file');
+unlike(http_get('/plain?c=dir'), qr/ 204 /, 'plain dir');
+unlike(http_get('/not_plain?c=file'), qr/ 204 /, 'not plain file');
+like(http_get('/not_plain?c=dir'), qr/ 204 /, 'not plain dir');
+
+unlike(http_get('/dir/?c=file'), qr/ 204 /, 'directory file');
+like(http_get('/dir?c=dir'), qr/ 204 /, 'directory dir');
+like(http_get('/not_dir?c=file'), qr/ 204 /, 'not directory file');
+unlike(http_get('/not_dir?c=dir'), qr/ 204 /, 'not directory dir');
+
+like(http_get('/exist?c=file'), qr/ 204 /, 'exist file');
+like(http_get('/exist?c=dir'), qr/ 204 /, 'exist dir');
+unlike(http_get('/exist?c=nx'), qr/ 204 /, 'exist non-existent');
+unlike(http_get('/not_exist?c=file'), qr/ 204 /, 'not exist file');
+unlike(http_get('/not_exist?c=dir'), qr/ 204 /, 'not exist dir');
+like(http_get('/not_exist?c=nx'), qr/ 204 /, 'not exist non-existent');
+
+SKIP: {
+skip 'no exec on win32', 4 if $^O eq 'MSWin32';
+
+unlike(http_get('/exec?c=file'), qr/ 204 /, 'executable file');
+like(http_get('/exec?c=dir'), qr/ 204 /, 'executable dir');
+like(http_get('/not_exec?c=file'), qr/ 204 /, 'not executable file');
+unlike(http_get('/not_exec?c=dir'), qr/ 204 /, 'not executable dir');
+
+}
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/scgi_body.t
+++ b/tests/nginx-tests/nginx-tests/scgi_body.t
@@ -52,7 +52,7 @@ http {
 EOF
 
 $t->run_daemon(\&scgi_daemon);
-$t->run();
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -104,7 +104,7 @@ EOF
 sub scgi_daemon {
 	my $server = IO::Socket::INET->new(
 		Proto => 'tcp',
-		LocalHost => '127.0.0.1:8081',
+		LocalHost => '127.0.0.1:' . port(8081),
 		Listen => 5,
 		Reuse => 1
 	)
@@ -114,12 +114,14 @@ sub scgi_daemon {
 	my $body;
 
 	while (my $request = $scgi->accept()) {
-		$request->read_env();
+		eval { $request->read_env(); };
+		next if $@;
+
 		read($request->connection, $body,
 			$request->env->{CONTENT_LENGTH});
 
 		$request->connection()->print(<<EOF);
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 X-Body: $body
 

--- a/tests/nginx-tests/nginx-tests/scgi_merge_params.t
+++ b/tests/nginx-tests/nginx-tests/scgi_merge_params.t
@@ -24,7 +24,7 @@ select STDOUT; $| = 1;
 eval { require SCGI; };
 plan(skip_all => 'SCGI not installed') if $@;
 
-my $t = Test::Nginx->new()->has(qw/http scgi cache shmem/)->plan(9)
+my $t = Test::Nginx->new()->has(qw/http scgi cache/)->plan(9)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -71,7 +71,7 @@ http {
 EOF
 
 $t->run_daemon(\&scgi_daemon);
-$t->run();
+$t->run()->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -115,25 +115,24 @@ EOF
 sub scgi_daemon {
 	my $server = IO::Socket::INET->new(
 		Proto => 'tcp',
-		LocalHost => '127.0.0.1:8081',
+		LocalHost => '127.0.0.1:' . port(8081),
 		Listen => 5,
 		Reuse => 1
 	)
 		or die "Can't create listening socket: $!\n";
 
 	my $scgi = SCGI->new($server, blocking => 1);
-	my $count = 0;
 
 	while (my $request = $scgi->accept()) {
-		$count++;
-		$request->read_env();
+		eval { $request->read_env(); };
+		next if $@;
 
 		my $ims = $request->env->{HTTP_IF_MODIFIED_SINCE} || '';
 		my $iums = $request->env->{HTTP_IF_UNMODIFIED_SINCE} || '';
 		my $blah = $request->env->{HTTP_X_BLAH} || '';
 
 		$request->connection()->print(<<EOF);
-Location: http://127.0.0.1:8080/redirect
+Location: http://localhost/redirect
 Content-Type: text/html
 
 ims=$ims;iums=$iums;blah=$blah;

--- a/tests/nginx-tests/nginx-tests/ssl_certificates.t
+++ b/tests/nginx-tests/nginx-tests/ssl_certificates.t
@@ -1,0 +1,155 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for http ssl module with multiple certificates.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval {
+	require Net::SSLeay;
+	Net::SSLeay::load_error_strings();
+	Net::SSLeay::SSLeay_add_ssl_algorithms();
+	Net::SSLeay::randomize();
+	Net::SSLeay::SSLeay();
+};
+plan(skip_all => 'Net::SSLeay not installed or too old') if $@;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl/)->has_daemon('openssl');
+
+plan(skip_all => 'no multiple certificates') if $t->has_module('BoringSSL');
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    ssl_certificate_key rsa.key;
+    ssl_certificate rsa.crt;
+    ssl_ciphers DEFAULT:ECCdraft;
+
+    server {
+        listen       127.0.0.1:8080 ssl;
+        server_name  localhost;
+
+        ssl_certificate_key ec.key;
+        ssl_certificate ec.crt;
+
+        ssl_certificate_key rsa.key;
+        ssl_certificate rsa.crt;
+
+        ssl_certificate_key rsa.key;
+        ssl_certificate rsa.crt;
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 1024
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+system("openssl ecparam -genkey -out $d/ec.key -name prime256v1 "
+	. ">>$d/openssl.out 2>&1") == 0 or die "Can't create EC pem: $!\n";
+system("openssl genrsa -out $d/rsa.key 1024 >>$d/openssl.out 2>&1") == 0
+        or die "Can't create RSA pem: $!\n";
+
+foreach my $name ('ec', 'rsa') {
+	system("openssl req -x509 -new -key $d/$name.key "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+$t->run()->plan(2);
+
+###############################################################################
+
+like(get_cert('RSA'), qr/CN=rsa/, 'ssl cert RSA');
+like(get_cert('ECDSA'), qr/CN=ec/, 'ssl cert ECDSA');
+
+###############################################################################
+
+sub get_version {
+	my ($s, $ssl) = get_ssl_socket();
+	return Net::SSLeay::version($ssl);
+}
+
+sub get_cert {
+	my ($type) = @_;
+	$type = 'PSS' if $type eq 'RSA' && get_version() > 0x0303;
+	my ($s, $ssl) = get_ssl_socket($type);
+	my $cipher = Net::SSLeay::get_cipher($ssl);
+	Test::Nginx::log_core('||', "cipher: $cipher");
+	return Net::SSLeay::dump_peer_certificate($ssl);
+}
+
+sub get_ssl_socket {
+	my ($type) = @_;
+	my $s;
+
+	eval {
+		local $SIG{ALRM} = sub { die "timeout\n" };
+		local $SIG{PIPE} = sub { die "sigpipe\n" };
+		alarm(8);
+		$s = IO::Socket::INET->new('127.0.0.1:' . port(8080));
+		alarm(0);
+	};
+	alarm(0);
+
+	if ($@) {
+		log_in("died: $@");
+		return undef;
+	}
+
+	my $ctx = Net::SSLeay::CTX_new() or die("Failed to create SSL_CTX $!");
+
+	if (defined $type) {
+		my $ssleay = Net::SSLeay::SSLeay();
+		if ($ssleay < 0x1000200f || $ssleay == 0x20000000) {
+			Net::SSLeay::CTX_set_cipher_list($ctx, $type)
+				or die("Failed to set cipher list");
+		} else {
+			# SSL_CTRL_SET_SIGALGS_LIST
+			Net::SSLeay::CTX_ctrl($ctx, 98, 0, $type . '+SHA256')
+				or die("Failed to set sigalgs");
+		}
+	}
+
+	my $ssl = Net::SSLeay::new($ctx) or die("Failed to create SSL $!");
+	Net::SSLeay::set_fd($ssl, fileno($s));
+	Net::SSLeay::connect($ssl) or die("ssl connect");
+	return ($s, $ssl);
+}
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/ssl_client_escaped_cert.t
+++ b/tests/nginx-tests/nginx-tests/ssl_client_escaped_cert.t
@@ -1,0 +1,126 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for http ssl module, $ssl_client_escaped_cert variable.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval { require IO::Socket::SSL; };
+plan(skip_all => 'IO::Socket::SSL not installed') if $@;
+eval { IO::Socket::SSL::SSL_VERIFY_NONE(); };
+plan(skip_all => 'IO::Socket::SSL too old') if $@;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl rewrite/)
+	->has_daemon('openssl')->plan(3);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    ssl_certificate_key localhost.key;
+    ssl_certificate localhost.crt;
+    ssl_verify_client optional_no_ca;
+
+    server {
+        listen       127.0.0.1:8443 ssl;
+        server_name  localhost;
+
+        location /cert {
+            return 200 $ssl_client_raw_cert;
+        }
+        location /escaped {
+            return 200 $ssl_client_escaped_cert;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 1024
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('localhost') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+$t->run();
+
+###############################################################################
+
+my ($cert) = cert('/cert') =~ /\x0d\x0a?\x0d\x0a?(.*)/ms;
+my ($escaped) = cert('/escaped') =~ /\x0d\x0a?\x0d\x0a?(.*)/ms;
+
+ok($cert, 'ssl_client_raw_cert');
+ok($escaped, 'ssl_client_escaped_cert');
+
+$escaped =~ s/%([0-9A-Fa-f]{2})/chr(hex($1))/eg;
+is($escaped, $cert, 'ssl_client_escaped_cert unescape match');
+
+###############################################################################
+
+sub cert {
+	my ($uri) = @_;
+	my $s;
+
+	eval {
+		local $SIG{ALRM} = sub { die "timeout\n" };
+		local $SIG{PIPE} = sub { die "sigpipe\n" };
+		alarm(8);
+		$s = IO::Socket::SSL->new(
+			Proto => 'tcp',
+			PeerAddr => '127.0.0.1',
+			PeerPort => port(8443),
+			SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
+			SSL_cert_file => "$d/localhost.crt",
+			SSL_key_file => "$d/localhost.key",
+			SSL_error_trap => sub { die $_[1] },
+		);
+		alarm(0);
+	};
+	alarm(0);
+
+	if ($@) {
+		log_in("died: $@");
+		return undef;
+	}
+
+	http_get($uri, socket => $s);
+}
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/ssl_crl.t
+++ b/tests/nginx-tests/nginx-tests/ssl_crl.t
@@ -3,7 +3,7 @@
 # (C) Sergey Kandaurov
 # (C) Nginx, Inc.
 
-# Tests for http ssl module with certificate chain.
+# Tests for http ssl module, ssl_crl directive.
 
 ###############################################################################
 
@@ -42,28 +42,36 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
+    ssl_certificate_key  localhost.key;
+    ssl_certificate localhost.crt;
+
+    ssl_verify_client on;
+    ssl_client_certificate int-root.crt;
+
+    add_header X-Verify $ssl_client_verify always;
+
     server {
         listen       127.0.0.1:8080 ssl;
         server_name  localhost;
 
-        ssl_certificate_key end.key;
-        ssl_certificate end.crt;
+        ssl_client_certificate root.crt;
+        ssl_crl empty.crl;
     }
 
     server {
         listen       127.0.0.1:8081 ssl;
         server_name  localhost;
 
-        ssl_certificate_key int.key;
-        ssl_certificate int.crt;
+        ssl_client_certificate root.crt;
+        ssl_crl root.crl;
     }
 
     server {
         listen       127.0.0.1:8082 ssl;
         server_name  localhost;
 
-        ssl_certificate_key end.key;
-        ssl_certificate end-int.crt;
+        ssl_verify_depth 2;
+        ssl_crl root.crl;
     }
 }
 
@@ -90,16 +98,12 @@ default_md = sha1
 policy = myca_policy
 serial = $d/certserial
 default_days = 1
-x509_extensions = myca_extensions
 
 [ myca_policy ]
 commonName = supplied
-
-[ myca_extensions ]
-basicConstraints = critical,CA:TRUE
 EOF
 
-foreach my $name ('root') {
+foreach my $name ('root', 'localhost') {
 	system('openssl req -x509 -new '
 		. "-config $d/openssl.conf -subj /CN=$name/ "
 		. "-out $d/$name.crt -keyout $d/$name.key "
@@ -130,22 +134,46 @@ system("openssl ca -batch -config $d/ca.conf "
 	. ">>$d/openssl.out 2>&1") == 0
 	or die "Can't sign certificate for end: $!\n";
 
-$t->write_file('end-int.crt',
-	$t->read_file('end.crt') . $t->read_file('int.crt'));
+system("openssl ca -gencrl -config $d/ca.conf "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. "-out $d/empty.crl -crldays 1 "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create empty crl: $!\n";
 
+system("openssl ca -config $d/ca.conf -revoke $d/int.crt "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't revoke int.crt: $!\n";
+
+system("openssl ca -gencrl -config $d/ca.conf "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. "-out $d/root.crl -crldays 1 "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't update crl: $!\n";
+
+$t->write_file('int-root.crt',
+	$t->read_file('int.crt') . $t->read_file('root.crt'));
+
+$t->write_file('t', '');
 $t->run();
 
 ###############################################################################
 
-is(get_ssl_socket(port(8080)), undef, 'incomplete chain');
-ok(get_ssl_socket(port(8081)), 'intermediate');
-ok(get_ssl_socket(port(8082)), 'intermediate server');
+like(get(8080, 'int'), qr/SUCCESS/, 'crl - no revoked certs');
+like(get(8081, 'int'), qr/FAILED/, 'crl - client cert revoked');
+like(get(8082, 'end'), qr/FAILED/, 'crl - intermediate cert revoked');
 
 ###############################################################################
 
+sub get {
+	my ($port, $cert) = @_;
+	my $s = get_ssl_socket($port, $cert) or return;
+	http_get('/t', socket => $s);
+}
+
 sub get_ssl_socket {
-	my ($port) = @_;
-	my ($s, $verify);
+	my ($port, $cert) = @_;
+	my ($s);
 
 	eval {
 		local $SIG{ALRM} = sub { die "timeout\n" };
@@ -154,14 +182,10 @@ sub get_ssl_socket {
 		$s = IO::Socket::SSL->new(
 			Proto => 'tcp',
 			PeerAddr => '127.0.0.1',
-			PeerPort => $port,
-			SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_PEER(),
-			SSL_ca_file => "$d/root.crt",
-			SSL_verify_callback => sub {
-				my ($ok) = @_;
-				$verify = $ok;
-				return $ok;
-			},
+			PeerPort => port($port),
+			SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
+			SSL_cert_file => "$d/$cert.crt",
+			SSL_key_file => "$d/$cert.key",
 			SSL_error_trap => sub { die $_[1] }
 		);
 		alarm(0);
@@ -173,7 +197,7 @@ sub get_ssl_socket {
 		return undef;
 	}
 
-	return $verify;
+	return $s;
 }
 
 ###############################################################################

--- a/tests/nginx-tests/nginx-tests/ssl_engine_keys.t
+++ b/tests/nginx-tests/nginx-tests/ssl_engine_keys.t
@@ -27,7 +27,7 @@ plan(skip_all => 'win32') if $^O eq 'MSWin32';
 plan(skip_all => 'may not work, leaves coredump')
 	unless $ENV{TEST_NGINX_UNSAFE};
 
-my $t = Test::Nginx->new()->has(qw/http http_ssl/)->has_daemon('openssl')
+my $t = Test::Nginx->new()->has(qw/http proxy http_ssl/)->has_daemon('openssl')
 	->has_daemon('softhsm')->has_daemon('pkcs11-tool')->plan(1);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
@@ -43,18 +43,18 @@ http {
     %%TEST_GLOBALS_HTTP%%
 
     server {
-        listen       127.0.0.1:8443 ssl;
+        listen       127.0.0.1:8081 ssl;
         listen       127.0.0.1:8080;
         server_name  localhost;
 
-        ssl_certificate_key engine:pkcs11:slot_0-id_00;
         ssl_certificate localhost.crt;
+        ssl_certificate_key engine:pkcs11:slot_0-id_00;
 
         location / {
             # index index.html by default
         }
         location /proxy {
-            proxy_pass https://127.0.0.1:8443/;
+            proxy_pass https://127.0.0.1:8081/;
         }
     }
 }
@@ -81,13 +81,13 @@ pkcs11 = pkcs11_section
 
 [pkcs11_section]
 engine_id = pkcs11
-dynamic_path = /usr/local/lib/engines/engine_pkcs11.so
+dynamic_path = /usr/local/lib/engines/pkcs11.so
 MODULE_PATH = /usr/local/lib/softhsm/libsofthsm.so
-init = 0
+init = 1
 PIN = 1234
 
 [ req ]
-default_bits = 2048
+default_bits = 1024
 encrypt_key = no
 distinguished_name = req_distinguished_name
 [ req_distinguished_name ]
@@ -108,12 +108,12 @@ foreach my $name ('localhost') {
 		. ">>$d/openssl.out 2>&1");
 
 	system('pkcs11-tool --module=/usr/local/lib/softhsm/libsofthsm.so '
-		. '-p 1234 -l -k -d 0 -a nx_key_0 --key-type rsa:2048 '
+		. '-p 1234 -l -k -d 0 -a nx_key_0 --key-type rsa:1024 '
 		. ">>$d/openssl.out 2>&1");
 
 	system('openssl req -x509 -new -engine pkcs11 '
-		. "-config '$d/openssl.conf' -subj '/CN=$name/' "
-		. "-out '$d/$name.crt' -keyform engine -text -key id_00 "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyform engine -text -key id_00 "
 		. ">>$d/openssl.out 2>&1") == 0
 		or die "Can't create certificate for $name: $!\n";
 }

--- a/tests/nginx-tests/nginx-tests/ssl_proxy_protocol.t
+++ b/tests/nginx-tests/nginx-tests/ssl_proxy_protocol.t
@@ -29,7 +29,7 @@ plan(skip_all => 'IO::Socket::SSL not installed') if $@;
 eval { IO::Socket::SSL::SSL_VERIFY_NONE(); };
 plan(skip_all => 'IO::Socket::SSL too old') if $@;
 
-my $t = Test::Nginx->new()->has(qw/http http_ssl access ipv6 realip/)
+my $t = Test::Nginx->new()->has(qw/http http_ssl access realip/)
 	->has_daemon('openssl');
 
 $t->write_file_expand('nginx.conf', <<'EOF')->plan(18);
@@ -76,7 +76,7 @@ EOF
 
 $t->write_file('openssl.conf', <<EOF);
 [ req ]
-default_bits = 2048
+default_bits = 1024
 encrypt_key = no
 distinguished_name = req_distinguished_name
 [ req_distinguished_name ]
@@ -86,8 +86,8 @@ my $d = $t->testdir();
 
 foreach my $name ('localhost') {
 	system('openssl req -x509 -new '
-		. "-config '$d/openssl.conf' -subj '/CN=$name/' "
-		. "-out '$d/$name.crt' -keyout '$d/$name.key' "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
 		. ">>$d/openssl.out 2>&1") == 0
 	or die "Can't create certificate for $name: $!\n";
 }
@@ -142,16 +142,7 @@ like($r, qr/403 Forbidden/, 'tcp6 access');
 
 $t->stop();
 
-my $log;
-
-{
-	open LOG, $t->testdir() . '/pp.log'
-		or die("Can't open nginx access log file.\n");
-	local $/;
-	$log = <LOG>;
-	close LOG;
-}
-
+my $log = $t->read_file('pp.log');
 like($log, qr!^192\.0\.2\.1 GET /pp_4!m, 'tcp4 access log');
 like($log, qr!^2001:DB8::1 GET /pp_6!mi, 'tcp6 access log');
 
@@ -162,10 +153,22 @@ sub pp_get {
 
 	my $s = http($proxy, start => 1);
 
-	IO::Socket::SSL->start_SSL($s,
-		SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
-		SSL_error_trap => sub { die $_[1] }
-	);
+	eval {
+		local $SIG{ALRM} = sub { die "timeout\n" };
+		local $SIG{PIPE} = sub { die "sigpipe\n" };
+		alarm(8);
+		IO::Socket::SSL->start_SSL($s,
+			SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
+			SSL_error_trap => sub { die $_[1] }
+		);
+		alarm(0);
+	};
+	alarm(0);
+
+	if ($@) {
+		log_in("died: $@");
+		return undef;
+	}
 
 	return http(<<EOF, socket => $s);
 GET $url HTTP/1.0

--- a/tests/nginx-tests/nginx-tests/ssl_sni.t
+++ b/tests/nginx-tests/nginx-tests/ssl_sni.t
@@ -37,7 +37,7 @@ http {
     %%TEST_GLOBALS_HTTP%%
 
     server {
-        listen       127.0.0.1:8443 ssl;
+        listen       127.0.0.1:8080 ssl;
         server_name  localhost;
 
         ssl_certificate_key localhost.key;
@@ -49,7 +49,7 @@ http {
     }
 
     server {
-        listen       127.0.0.1:8443;
+        listen       127.0.0.1:8080;
         server_name  example.com;
 
         ssl_certificate_key example.com.key;
@@ -84,7 +84,7 @@ $t->plan(6);
 
 $t->write_file('openssl.conf', <<EOF);
 [ req ]
-default_bits = 2048
+default_bits = 1024
 encrypt_key = no
 distinguished_name = req_distinguished_name
 [ req_distinguished_name ]
@@ -94,8 +94,8 @@ my $d = $t->testdir();
 
 foreach my $name ('localhost', 'example.com') {
 	system('openssl req -x509 -new '
-		. "-config '$d/openssl.conf' -subj '/CN=$name/' "
-		. "-out '$d/$name.crt' -keyout '$d/$name.key' "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
 		. ">>$d/openssl.out 2>&1") == 0
 		or die "Can't create certificate for $name: $!\n";
 }
@@ -133,10 +133,10 @@ sub get_ssl_socket {
 	eval {
 		local $SIG{ALRM} = sub { die "timeout\n" };
 		local $SIG{PIPE} = sub { die "sigpipe\n" };
-		alarm(2);
+		alarm(8);
 		$s = IO::Socket::SSL->new(
 			Proto => 'tcp',
-			PeerAddr => '127.0.0.1:8443',
+			PeerAddr => '127.0.0.1:' . port(8080),
 			SSL_hostname => $host,
 			SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
 			SSL_error_trap => sub { die $_[1] }

--- a/tests/nginx-tests/nginx-tests/ssl_sni_reneg.t
+++ b/tests/nginx-tests/nginx-tests/ssl_sni_reneg.t
@@ -39,8 +39,7 @@ eval {
 };
 plan(skip_all => 'Net::SSLeay with OpenSSL SNI support required') if $@;
 
-my $t = Test::Nginx->new()->has(qw/http http_ssl/)->has_daemon('openssl')
-	->plan(4);
+my $t = Test::Nginx->new()->has(qw/http http_ssl/)->has_daemon('openssl');
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -58,8 +57,16 @@ http {
     ssl_certificate localhost.crt;
 
     server {
-        listen       127.0.0.1:8443 ssl;
+        listen       127.0.0.1:8080 ssl;
+        listen       127.0.0.1:8081 ssl;
         server_name  localhost;
+
+        location / { }
+    }
+
+    server {
+        listen       127.0.0.1:8081 ssl;
+        server_name  localhost2;
 
         location / { }
     }
@@ -69,7 +76,7 @@ EOF
 
 $t->write_file('openssl.conf', <<EOF);
 [ req ]
-default_bits = 2048
+default_bits = 1024
 encrypt_key = no
 distinguished_name = req_distinguished_name
 [ req_distinguished_name ]
@@ -79,34 +86,74 @@ my $d = $t->testdir();
 
 foreach my $name ('localhost') {
 	system('openssl req -x509 -new '
-		. "-config '$d/openssl.conf' -subj '/CN=$name/' "
-		. "-out '$d/$name.crt' -keyout '$d/$name.key' "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
 		. ">>$d/openssl.out 2>&1") == 0
 		or die "Can't create certificate for $name: $!\n";
 }
 
 $t->run();
 
+{
+	my (undef, $ssl) = get_ssl_socket(8080);
+	plan(skip_all => "TLS 1.3 forbids renegotiation")
+		if Net::SSLeay::version($ssl) > 0x0303;
+}
+
+$t->plan(8);
+
 ###############################################################################
 
-my ($s, $ssl) = get_ssl_socket();
+my ($ossl) = $t->{_configure_args} =~ /OpenSSL ([\d\.]+)/;
+
+my ($s, $ssl) = get_ssl_socket(8080);
 ok($s, 'connection');
 
 SKIP: {
 skip 'connection failed', 3 unless $s;
+
+local $SIG{PIPE} = 'IGNORE';
 
 Net::SSLeay::write($ssl, 'GET / HTTP/1.0' . CRLF);
 
 ok(Net::SSLeay::renegotiate($ssl), 'renegotiation');
 ok(Net::SSLeay::set_tlsext_host_name($ssl, 'localhost'), 'SNI');
 
+Net::SSLeay::write($ssl, 'Host: localhost' . CRLF . CRLF);
+
+TODO: {
+local $TODO = 'not yet' if $ossl ge '1.1.1' and $^O eq 'linux'
+	and !$t->has_version('1.15.2');
+
+ok(!Net::SSLeay::read($ssl), 'response');
+
+}
+
+}
+
+# virtual servers
+# in [1.15.4..1.15.5) SSL_OP_NO_RENEGOTIATION is cleared in servername callback
+
+($s, $ssl) = get_ssl_socket(8081);
+ok($s, 'connection 2');
+
 SKIP: {
-skip 'leaves coredump', 1 unless $t->has_version('1.9.8')
-	or $ENV{TEST_NGINX_UNSAFE};
+skip 'connection failed', 3 unless $s;
+
+local $SIG{PIPE} = 'IGNORE';
+
+Net::SSLeay::write($ssl, 'GET / HTTP/1.0' . CRLF);
+
+ok(Net::SSLeay::renegotiate($ssl), 'renegotiation');
+ok(Net::SSLeay::set_tlsext_host_name($ssl, 'localhost'), 'SNI');
 
 Net::SSLeay::write($ssl, 'Host: localhost' . CRLF . CRLF);
 
-is(Net::SSLeay::read($ssl), undef, 'response');
+TODO: {
+local $TODO = 'not yet' if $ossl ge '1.1.1' and $^O eq 'linux'
+	and !$t->has_version('1.15.2');
+
+ok(!Net::SSLeay::read($ssl), 'virtual servers');
 
 }
 
@@ -115,15 +162,16 @@ is(Net::SSLeay::read($ssl), undef, 'response');
 ###############################################################################
 
 sub get_ssl_socket {
+	my ($port) = @_;
 	my $s;
 
 	my $dest_ip = inet_aton('127.0.0.1');
-	my $dest_serv_params = sockaddr_in(8443, $dest_ip);
+	my $dest_serv_params = sockaddr_in(port($port), $dest_ip);
 
 	eval {
 		local $SIG{ALRM} = sub { die "timeout\n" };
 		local $SIG{PIPE} = sub { die "sigpipe\n" };
-		alarm(2);
+		alarm(8);
 		socket($s, &AF_INET, &SOCK_STREAM, 0) or die "socket: $!";
 		connect($s, $dest_serv_params) or die "connect: $!";
 		alarm(0);
@@ -137,7 +185,8 @@ sub get_ssl_socket {
 
 	my $ctx = Net::SSLeay::CTX_new() or die("Failed to create SSL_CTX $!");
 	my $ssl = Net::SSLeay::new($ctx) or die("Failed to create SSL $!");
-	Net::SSLeay::set_fd( $ssl, fileno($s));
+	Net::SSLeay::set_fd($ssl, fileno($s));
+	Net::SSLeay::set_tlsext_host_name($ssl, 'localhost');
 	Net::SSLeay::connect($ssl) or die("ssl connect");
 
 	return ($s, $ssl);

--- a/tests/nginx-tests/nginx-tests/ssl_stapling.t
+++ b/tests/nginx-tests/nginx-tests/ssl_stapling.t
@@ -1,0 +1,406 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for OCSP stapling.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+use MIME::Base64 qw/ decode_base64 /;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval {
+	require Net::SSLeay;
+	Net::SSLeay::load_error_strings();
+	Net::SSLeay::SSLeay_add_ssl_algorithms();
+	Net::SSLeay::randomize();
+	Net::SSLeay::SSLeay();
+	defined &Net::SSLeay::set_tlsext_status_type or die;
+};
+plan(skip_all => 'Net::SSLeay not installed or too old') if $@;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl/)->has_daemon('openssl');
+
+plan(skip_all => 'no OCSP stapling') if $t->has_module('BoringSSL');
+
+$t->plan(9)->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+worker_processes 1;  # NOTE: The default value of Tengine worker_processes directive is `worker_processes auto;`.
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    ssl_stapling on;
+    ssl_trusted_certificate trusted.crt;
+
+    ssl_certificate ec-end-int.crt;
+    ssl_certificate_key ec-end.key;
+
+    ssl_certificate end-int.crt;
+    ssl_certificate_key end.key;
+
+    server {
+        listen       127.0.0.1:8443 ssl;
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+    }
+
+    server {
+        listen       127.0.0.1:8444 ssl;
+        server_name  localhost;
+
+        ssl_stapling_responder http://127.0.0.1:8081/;
+    }
+
+    server {
+        listen       127.0.0.1:8445 ssl;
+        server_name  localhost;
+
+        ssl_stapling_verify on;
+    }
+
+    server {
+        listen       127.0.0.1:8446 ssl;
+        server_name  localhost;
+
+        ssl_certificate ec-end.crt;
+        ssl_certificate_key ec-end.key;
+    }
+
+    server {
+        listen       127.0.0.1:8447 ssl;
+        server_name  localhost;
+
+        ssl_certificate end-int.crt;
+        ssl_certificate_key end.key;
+
+        ssl_stapling_file %%TESTDIR%%/resp.der;
+    }
+
+    server {
+        listen       127.0.0.1:8448 ssl;
+        server_name  localhost;
+
+        ssl_certificate ec-end-int.crt;
+        ssl_certificate_key ec-end.key;
+
+        ssl_stapling_file %%TESTDIR%%/ec-resp.der;
+    }
+
+    server {
+        listen       127.0.0.1:8449 ssl;
+        server_name  localhost;
+
+        ssl_stapling_responder http://127.0.0.1:8080/;
+    }
+}
+
+EOF
+
+my $d = $t->testdir();
+my $p = port(8081);
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 1024
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+$t->write_file('ca.conf', <<EOF);
+[ ca ]
+default_ca = myca
+
+[ myca ]
+new_certs_dir = $d
+database = $d/certindex
+default_md = sha1
+policy = myca_policy
+serial = $d/certserial
+default_days = 1
+x509_extensions = myca_extensions
+
+[ myca_policy ]
+commonName = supplied
+
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE
+authorityInfoAccess = OCSP;URI:http://127.0.0.1:$p
+EOF
+
+foreach my $name ('root') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+foreach my $name ('int', 'end') {
+	system("openssl req -new "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.csr -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+foreach my $name ('ec-end') {
+	system("openssl ecparam -genkey -out $d/$name.key -name prime256v1 "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create EC param: $!\n";
+	system("openssl req -new -key $d/$name.key "
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.csr "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+$t->write_file('certserial', '1000');
+$t->write_file('certindex', '');
+
+system("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. "-subj /CN=int/ -in $d/int.csr -out $d/int.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't sign certificate for int: $!\n";
+
+system("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/int.key -cert $d/int.crt "
+	. "-subj /CN=ec-end/ -in $d/ec-end.csr -out $d/ec-end.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't sign certificate for ec-end: $!\n";
+
+system("openssl ca -batch -config $d/ca.conf "
+	. "-keyfile $d/int.key -cert $d/int.crt "
+	. "-subj /CN=end/ -in $d/end.csr -out $d/end.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't sign certificate for end: $!\n";
+
+# RFC 6960, serialNumber
+
+system("openssl x509 -in $d/end.crt -serial -noout "
+	. ">>$d/serial 2>>$d/openssl.out") == 0
+	or die "Can't obtain serial for end: $!\n";
+
+my $serial = pack("n2", 0x0202, hex $1) if $t->read_file('serial') =~ /(\d+)/;
+
+system("openssl ca -config $d/ca.conf -revoke $d/end.crt "
+	. "-keyfile $d/root.key -cert $d/root.crt "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't revoke end.crt: $!\n";
+
+system("openssl ocsp -issuer $d/int.crt -cert $d/end.crt "
+	. "-reqout $d/req.der >>$d/openssl.out 2>&1") == 0
+	or die "Can't create OCSP request: $!\n";
+
+system("openssl ocsp -index $d/certindex -CA $d/int.crt "
+	. "-rsigner $d/root.crt -rkey $d/root.key "
+	. "-reqin $d/req.der -respout $d/resp.der -ndays 1 "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create OCSP response: $!\n";
+
+system("openssl ocsp -issuer $d/int.crt -cert $d/ec-end.crt "
+	. "-reqout $d/ec-req.der >>$d/openssl.out 2>&1") == 0
+	or die "Can't create EC OCSP request: $!\n";
+
+system("openssl ocsp -index $d/certindex -CA $d/int.crt "
+	. "-rsigner $d/root.crt -rkey $d/root.key "
+	. "-reqin $d/ec-req.der -respout $d/ec-resp.der -ndays 1 "
+	. ">>$d/openssl.out 2>&1") == 0
+	or die "Can't create EC OCSP response: $!\n";
+
+$t->write_file('trusted.crt',
+	$t->read_file('int.crt') . $t->read_file('root.crt'));
+$t->write_file('end-int.crt',
+	$t->read_file('end.crt') . $t->read_file('int.crt'));
+$t->write_file('ec-end-int.crt',
+	$t->read_file('ec-end.crt') . $t->read_file('int.crt'));
+
+$t->run_daemon(\&http_daemon, $t);
+$t->run();
+
+$t->waitforsocket("127.0.0.1:" . port(8081));
+
+###############################################################################
+
+my $version = get_version();
+
+staple(8443, 'RSA');
+staple(8443, 'ECDSA');
+staple(8444, 'RSA');
+staple(8444, 'ECDSA');
+staple(8445, 'ECDSA');
+staple(8446, 'ECDSA');
+staple(8449, 'ECDSA');
+
+sleep 1;
+
+ok(!staple(8443, 'RSA'), 'staple revoked');
+ok(staple(8443, 'ECDSA'), 'staple success');
+
+ok(!staple(8444, 'RSA'), 'responder revoked');
+ok(staple(8444, 'ECDSA'), 'responder success');
+
+ok(!staple(8445, 'ECDSA'), 'verify - root not trusted');
+
+ok(staple(8446, 'ECDSA', "$d/int.crt"), 'cert store');
+
+is(staple(8447, 'RSA'), '1 1', 'file revoked');
+is(staple(8448, 'ECDSA'), '1 0', 'file success');
+
+ok(!staple(8449, 'ECDSA'), 'ocsp error');
+
+###############################################################################
+
+sub staple {
+	my ($port, $ciphers, $ca) = @_;
+	my (@resp);
+
+	my $staple_cb = sub {
+		my ($ssl, $resp) = @_;
+		push @resp, !!$resp;
+		return 1 unless $resp;
+		my $cert = Net::SSLeay::get_peer_certificate($ssl);
+		my $certid = eval { Net::SSLeay::OCSP_cert2ids($ssl, $cert) }
+			or do { die "no OCSP_CERTID for certificate: $@"; };
+
+		my @res = Net::SSLeay::OCSP_response_results($resp, $certid);
+		push @resp, $res[0][2]->{'statusType'};
+	};
+
+	my $s;
+
+	eval {
+		local $SIG{ALRM} = sub { die "timeout\n" };
+		local $SIG{PIPE} = sub { die "sigpipe\n" };
+		alarm(8);
+		$s = IO::Socket::INET->new('127.0.0.1:' . port($port));
+		alarm(0);
+	};
+	alarm(0);
+
+	if ($@) {
+		log_in("died: $@");
+		return undef;
+	}
+
+	my $ctx = Net::SSLeay::CTX_new() or die("Failed to create SSL_CTX $!");
+
+	my $ssleay = Net::SSLeay::SSLeay();
+	if ($ssleay < 0x1000200f || $ssleay == 0x20000000) {
+		Net::SSLeay::CTX_set_cipher_list($ctx, $ciphers)
+			or die("Failed to set cipher list");
+	} else {
+		# SSL_CTRL_SET_SIGALGS_LIST
+		$ciphers = 'PSS' if $ciphers eq 'RSA' && $version > 0x0303;
+		Net::SSLeay::CTX_ctrl($ctx, 98, 0, $ciphers . '+SHA256')
+			or die("Failed to set sigalgs");
+	}
+
+	Net::SSLeay::CTX_load_verify_locations($ctx, $ca || '', '');
+	Net::SSLeay::CTX_set_tlsext_status_cb($ctx, $staple_cb);
+	my $ssl = Net::SSLeay::new($ctx) or die("Failed to create SSL $!");
+	Net::SSLeay::set_tlsext_status_type($ssl,
+		Net::SSLeay::TLSEXT_STATUSTYPE_ocsp());
+	Net::SSLeay::set_fd($ssl, fileno($s));
+	Net::SSLeay::connect($ssl) or die("ssl connect");
+
+	return join ' ', @resp;
+}
+
+sub get_version {
+	my $s;
+
+	eval {
+		local $SIG{ALRM} = sub { die "timeout\n" };
+		local $SIG{PIPE} = sub { die "sigpipe\n" };
+		alarm(8);
+		$s = IO::Socket::INET->new('127.0.0.1:' . port(8443));
+		alarm(0);
+	};
+	alarm(0);
+
+	if ($@) {
+		log_in("died: $@");
+		return undef;
+	}
+
+	my $ctx = Net::SSLeay::CTX_new() or die("Failed to create SSL_CTX $!");
+	my $ssl = Net::SSLeay::new($ctx) or die("Failed to create SSL $!");
+	Net::SSLeay::set_fd($ssl, fileno($s));
+	Net::SSLeay::connect($ssl) or die("ssl connect");
+
+	Net::SSLeay::version($ssl);
+}
+
+###############################################################################
+
+sub http_daemon {
+	my ($t) = shift;
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => "127.0.0.1:" . port(8081),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		my $headers = '';
+		my $uri = '';
+
+		while (<$client>) {
+			$headers .= $_;
+			last if (/^\x0d?\x0a?$/);
+		}
+
+		$uri = $1 if $headers =~ /^\S+\s+\/([^ ]+)\s+HTTP/i;
+		next unless $uri;
+
+		$uri =~ s/%([0-9A-Fa-f]{2})/chr(hex($1))/eg;
+		my $req = decode_base64($uri);
+		my $resp = index($req, $serial) > 0 ? 'resp' : 'ec-resp';
+
+		# ocsp dummy handler
+
+		select undef, undef, undef, 0.02;
+
+		$headers = <<"EOF";
+HTTP/1.1 200 OK
+Connection: close
+Content-Type: application/ocsp-response
+
+EOF
+
+		print $client $headers . $t->read_file("$resp.der");
+	}
+}
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/ssl_verify_client.t
+++ b/tests/nginx-tests/nginx-tests/ssl_verify_client.t
@@ -1,0 +1,204 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for http ssl module, ssl_verify_client.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+use Socket qw/ :DEFAULT CRLF /;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval {
+	require Net::SSLeay;
+	Net::SSLeay::load_error_strings();
+	Net::SSLeay::SSLeay_add_ssl_algorithms();
+	Net::SSLeay::randomize();
+};
+plan(skip_all => 'Net::SSLeay not installed') if $@;
+
+eval {
+	my $ctx = Net::SSLeay::CTX_new() or die;
+	my $ssl = Net::SSLeay::new($ctx) or die;
+	Net::SSLeay::set_tlsext_host_name($ssl, 'example.org') == 1 or die;
+};
+plan(skip_all => 'Net::SSLeay with OpenSSL SNI support required') if $@;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl sni/)
+	->has_daemon('openssl')->plan(11);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    add_header X-Verify x$ssl_client_verify:${ssl_client_cert}x;
+
+    ssl_session_cache shared:SSL:1m;
+    ssl_session_tickets off;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        ssl_certificate_key 1.example.com.key;
+        ssl_certificate 1.example.com.crt;
+
+        ssl_verify_client on;
+        ssl_client_certificate 2.example.com.crt;
+    }
+
+    server {
+        listen       127.0.0.1:8081 ssl;
+        server_name  on;
+
+        ssl_certificate_key 1.example.com.key;
+        ssl_certificate 1.example.com.crt;
+
+        ssl_verify_client on;
+        ssl_client_certificate 2.example.com.crt;
+    }
+
+    server {
+        listen       127.0.0.1:8081 ssl;
+        server_name  optional;
+
+        ssl_certificate_key 1.example.com.key;
+        ssl_certificate 1.example.com.crt;
+
+        ssl_verify_client optional;
+        ssl_client_certificate 2.example.com.crt;
+        ssl_trusted_certificate 3.example.com.crt;
+    }
+
+    server {
+        listen       127.0.0.1:8081 ssl;
+        server_name  optional_no_ca;
+
+        ssl_certificate_key 1.example.com.key;
+        ssl_certificate 1.example.com.crt;
+
+        ssl_verify_client optional_no_ca;
+        ssl_client_certificate 2.example.com.crt;
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  no_context;
+
+        ssl_verify_client on;
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 1024
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('1.example.com', '2.example.com', '3.example.com') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+sleep 1 if $^O eq 'MSWin32';
+
+$t->write_file('t', 'SEE-THIS');
+
+$t->run();
+
+###############################################################################
+
+
+like(http_get('/t'), qr/x:x/, 'plain connection');
+like(get('on'), qr/400 Bad Request/, 'no cert');
+like(get('no_context'), qr/400 Bad Request/, 'no server cert');
+like(get('optional'), qr/NONE:x/, 'no optional cert');
+like(get('optional', '1.example.com'), qr/400 Bad/, 'bad optional cert');
+like(get('optional_no_ca', '1.example.com'), qr/FAILED.*BEGIN/,
+	'bad optional_no_ca cert');
+
+like(get('localhost', '2.example.com'), qr/SUCCESS.*BEGIN/, 'good cert');
+like(get('optional', '2.example.com'), qr/SUCCESS.*BEGI/, 'good cert optional');
+like(get('optional', '3.example.com'), qr/SUCCESS.*BEGIN/, 'good cert trusted');
+
+SKIP: {
+skip 'Net::SSLeay version >= 1.36 required', 1 if $Net::SSLeay::VERSION < 1.36;
+
+my $ca = join ' ', get('optional', '3.example.com');
+is($ca, '/CN=2.example.com', 'no trusted sent');
+
+}
+
+like(get('optional', undef, 'localhost'), qr/421 Misdirected/, 'misdirected');
+
+###############################################################################
+
+sub get {
+	my ($sni, $cert, $host) = @_;
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	$host = $sni if !defined $host;
+
+	my $dest_ip = inet_aton('127.0.0.1');
+	my $dest_serv_params = sockaddr_in(port(8081), $dest_ip);
+
+	socket(my $s, &AF_INET, &SOCK_STREAM, 0) or die "socket: $!";
+	connect($s, $dest_serv_params) or die "connect: $!";
+
+	my $ctx = Net::SSLeay::CTX_new() or die("Failed to create SSL_CTX $!");
+	Net::SSLeay::set_cert_and_key($ctx, "$d/$cert.crt", "$d/$cert.key")
+		or die if $cert;
+	my $ssl = Net::SSLeay::new($ctx) or die("Failed to create SSL $!");
+	Net::SSLeay::set_tlsext_host_name($ssl, $sni) == 1 or die;
+	Net::SSLeay::set_fd($ssl, fileno($s));
+	Net::SSLeay::connect($ssl) or die("ssl connect");
+
+	Net::SSLeay::write($ssl, 'GET /t HTTP/1.0' . CRLF);
+	Net::SSLeay::write($ssl, "Host: $host" . CRLF . CRLF);
+	my $buf = Net::SSLeay::read($ssl);
+	log_in($buf);
+	return $buf unless wantarray();
+
+	my $list = Net::SSLeay::get_client_CA_list($ssl);
+	my @names;
+	for my $i (0 .. Net::SSLeay::sk_X509_NAME_num($list) - 1) {
+		my $name = Net::SSLeay::sk_X509_NAME_value($list, $i);
+		push @names, Net::SSLeay::X509_NAME_oneline($name);
+	}
+	return @names;
+}
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/stream_access_log.t
+++ b/tests/nginx-tests/nginx-tests/stream_access_log.t
@@ -1,0 +1,206 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for stream access_log module and variables.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_map gzip/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    log_format  test  $server_addr;
+    log_format  vars  $connection:$nginx_version:$hostname:$pid;
+    log_format  addr  $binary_remote_addr:$remote_addr:$remote_port:
+                      $server_addr:$server_port:$upstream_addr;
+    log_format  date  $msec!$time_local!$time_iso8601;
+    log_format  byte  $bytes_received:$bytes_sent:
+                      $upstream_bytes_sent:$upstream_bytes_received;
+    log_format  time  $upstream_connect_time:$upstream_first_byte_time:
+                      $upstream_session_time;
+
+    access_log  %%TESTDIR%%/off.log test;
+
+    map $server_port $logme {
+        %%PORT_8083%%  1;
+        default        0;
+    }
+
+    server {
+        listen      127.0.0.1:8081;
+        proxy_pass  127.0.0.1:8080;
+        access_log  off;
+    }
+
+    server {
+        listen      127.0.0.1:8082;
+        proxy_pass  127.0.0.1:8080;
+        access_log  %%TESTDIR%%/time.log time;
+    }
+
+    server {
+        listen      127.0.0.1:8083;
+        listen      127.0.0.1:8084;
+        proxy_pass  127.0.0.1:8080;
+        access_log  %%TESTDIR%%/filtered.log test if=$logme;
+    }
+
+    server {
+        listen      127.0.0.1:8085;
+        proxy_pass  127.0.0.1:8080;
+        access_log  %%TESTDIR%%/complex.log test if=$logme$logme;
+    }
+
+    server {
+        listen      127.0.0.1:8086;
+        proxy_pass  127.0.0.1:8080;
+        access_log  %%TESTDIR%%/compressed.log test
+                    gzip buffer=1m flush=100ms;
+    }
+
+    server {
+        listen      127.0.0.1:8087;
+        proxy_pass  127.0.0.1:8080;
+        access_log  %%TESTDIR%%/varlog_$bytes_sent.log test;
+    }
+
+    server {
+        listen      127.0.0.1:8088;
+        proxy_pass  127.0.0.1:8080;
+        access_log  %%TESTDIR%%/vars.log vars;
+        access_log  %%TESTDIR%%/addr.log addr;
+        access_log  %%TESTDIR%%/date.log date;
+        access_log  %%TESTDIR%%/byte.log byte;
+    }
+}
+
+EOF
+
+$t->run_daemon(\&stream_daemon);
+$t->run()->plan(10);
+
+$t->waitforsocket('127.0.0.1:' . port(8080));
+
+###############################################################################
+
+my $str = 'SEE-THIS';
+
+stream('127.0.0.1:' . port(8081))->io($str);
+stream('127.0.0.1:' . port(8082))->io($str);
+stream('127.0.0.1:' . port(8083))->io($str);
+stream('127.0.0.1:' . port(8084))->io($str);
+stream('127.0.0.1:' . port(8085))->io($str);
+stream('127.0.0.1:' . port(8086))->io($str);
+stream('127.0.0.1:' . port(8087))->io($str);
+
+my $dport = port(8088);
+my $s = stream("127.0.0.1:$dport");
+my $lhost = $s->sockhost();
+my $escaped = $s->sockaddr();
+$escaped =~ s/([^\x20-\x7e])/sprintf('\\x%02X', ord($1))/gmxe;
+my $lport = $s->sockport();
+my $uport = port(8080);
+
+$s->io($str);
+
+# wait for file to appear with nonzero size thanks to the flush parameter
+
+for (1 .. 10) {
+	last if -s $t->testdir() . '/compressed.log';
+	select undef, undef, undef, 0.1;
+}
+
+# verify that "gzip" parameter turns on compression
+
+SKIP: {
+	eval { require IO::Uncompress::Gunzip; };
+	skip("IO::Uncompress::Gunzip not installed", 1) if $@;
+
+	my $gzipped = $t->read_file('compressed.log');
+	my $log;
+	IO::Uncompress::Gunzip::gunzip(\$gzipped => \$log);
+	like($log, qr/^127.0.0.1/, 'compressed log - flush time');
+}
+
+# now verify all other logs
+
+$t->stop();
+
+is($t->read_file('off.log'), '', 'log off');
+is($t->read_file('filtered.log'), "127.0.0.1\n", 'log filtering');
+ok($t->read_file('complex.log'), 'if with complex value');
+ok($t->read_file('varlog_3.log'), 'variable in file');
+
+chomp(my $hostname = lc `hostname`);
+like($t->read_file('vars.log'), qr/^\d+:[\d.]+:$hostname:\d+$/, 'log vars');
+is($t->read_file('addr.log'),
+	"$escaped:$lhost:$lport:127.0.0.1:$dport:127.0.0.1:$uport\n",
+	'log addr');
+like($t->read_file('date.log'), qr#^\d+.\d+![-+\w/: ]+![-+\dT:]+$#, 'log date');
+is($t->read_file('byte.log'), "8:3:8:3\n", 'log bytes');
+like($t->read_file('time.log'), qr/0\.\d{3}:0\.\d{3}:0\.\d{3}/, 'log time');
+
+###############################################################################
+
+sub stream_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalAddr => '127.0.0.1',
+		LocalPort => port(8080),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		log2c("(new connection $client)");
+
+		$client->sysread(my $buffer, 65536) or next;
+
+		log2i("$client $buffer");
+
+		$buffer = "ack";
+
+		log2o("$client $buffer");
+
+		$client->syswrite($buffer);
+
+		close $client;
+	}
+}
+
+sub log2i { Test::Nginx::log_core('|| <<', @_); }
+sub log2o { Test::Nginx::log_core('|| >>', @_); }
+sub log2c { Test::Nginx::log_core('||', @_); }
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/stream_access_log_escape.t
+++ b/tests/nginx-tests/nginx-tests/stream_access_log_escape.t
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Stream tests for access_log with escape parameter.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_map stream_return/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    map $pid $a {
+        default '" \ "';
+    }
+    map $pid $b {
+        default "foo";
+    }
+
+    log_format json     escape=json     $a$b$upstream_addr;
+    log_format default  escape=default  $a$b$upstream_addr;
+
+    server {
+        listen       127.0.0.1:8080;
+        return       ok;
+
+        access_log %%TESTDIR%%/json.log json;
+        access_log %%TESTDIR%%/test.log default;
+    }
+}
+
+EOF
+
+$t->run()->plan(2);
+
+###############################################################################
+
+http_get('/');
+
+$t->stop();
+
+is($t->read_file('json.log'), '\" \\\\ \"foo' . "\n", 'json');
+is($t->read_file('test.log'), '\x22 \x5C \x22foo-' . "\n", 'default');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/stream_access_log_none.t
+++ b/tests/nginx-tests/nginx-tests/stream_access_log_none.t
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Stream tests for access_log with escape parameter.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_map stream_return/)->plan(1)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    map $pid $a {
+        default '" \ "';
+    }
+    map $pid $b {
+        default "foo";
+    }
+
+    log_format none     escape=none     $a$b$upstream_addr;
+
+    server {
+        listen       127.0.0.1:8080;
+        return       ok;
+
+        access_log %%TESTDIR%%/none.log none;
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+http_get('/');
+
+$t->stop();
+
+is($t->read_file('none.log'), '" \\ "foo' . "\n", 'none');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/sub_filter_buffering.t
+++ b/tests/nginx-tests/nginx-tests/sub_filter_buffering.t
@@ -24,7 +24,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http sub/)->plan(2)
+my $t = Test::Nginx->new()->has(qw/http sub proxy/)->plan(2)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%

--- a/tests/nginx-tests/nginx-tests/subrequest_output_buffer_size.t
+++ b/tests/nginx-tests/nginx-tests/subrequest_output_buffer_size.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for subrequest_output_buffer_size directive.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy ssi/)->plan(4)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            proxy_pass http://127.0.0.1:8081;
+            subrequest_output_buffer_size 42;
+        }
+
+        location /longok {
+            proxy_pass http://127.0.0.1:8081/long;
+        }
+
+        location /ssi {
+            ssi on;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  localhost;
+
+        location / { }
+    }
+}
+
+EOF
+
+$t->write_file('ssi.html',
+	'<!--#include virtual="/$arg_c" set="x" -->' .
+	'set: <!--#echo var="x" -->');
+
+$t->write_file('length', 'TEST-OK-IF-YOU-SEE-THIS');
+$t->write_file('long', 'x' x 400);
+$t->write_file('empty', '');
+
+$t->run();
+
+###############################################################################
+
+my ($r, $n);
+
+like(http_get('/ssi.html?c=length'), qr/SEE-THIS/, 'request');
+like(http_get('/ssi.html?c=empty'), qr/set: $/, 'empty');
+unlike(http_get('/ssi.html?c=long'), qr/200 OK/, 'long');
+like(http_get('/ssi.html?c=longok'), qr/x{400}/, 'long ok');
+
+###############################################################################


### PR DESCRIPTION
# updated module from nginx-1.15.1

* addtion filter module
* dav module
* browser module
* fastcgi module
* geo module
* scgi module
* headers filter module
* realip module
* memcached module

# updated module from nginx-1.15.2

Some test cases need nginx-1.15.2.

* ssl module (from nginx-1.15.2)
* perl module (from nginx-1.15.2)
* log module (from nginx-1.15.2)
* rewrite module

# updated test cases 

cases from latest nginx-tests hg repo

* sub_filter*.t
* addtion*.t
* dav*.t
* fastcgi*.t
* geo*.t
* headers.t
* scgi*.t
* realip*.t
* memcached*.t
* ssl*.t
* perl*.t
* \*log*.t
* rewrite*.t

# not updated module, for next pull request

* limit_req: tengine has its own function
* image filter: tengine has its own function