### PR TITLE
ssl_verify_client_exception: fixed segfault of referring null pointer

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1056,7 +1056,7 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
                               "client SSL certificate verify error: (%l:%s)",
                               rc, X509_verify_cert_error_string(rc));
 
-                ngx_ssl_remove_cached_session(sscf->ssl.ctx,
+                ngx_ssl_remove_cached_session(c->ssl->session_ctx,
                                        (SSL_get0_session(c->ssl->connection)));
 
                 ngx_http_finalize_request(r, NGX_HTTPS_CERT_ERROR);
@@ -1070,7 +1070,7 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
                     ngx_log_error(NGX_LOG_INFO, c->log, 0,
                                   "client sent no required SSL certificate");
 
-                    ngx_ssl_remove_cached_session(sscf->ssl.ctx,
+                    ngx_ssl_remove_cached_session(c->ssl->session_ctx,
                                        (SSL_get0_session(c->ssl->connection)));
 
                     ngx_http_finalize_request(r, NGX_HTTPS_NO_CERT);


### PR DESCRIPTION
    import bugfix of nginx core phase from this nginx commit:

    ```
    commit 57dde2ab37708423d97333be19830437732b3f4f
    Author: Sergey Kandaurov <pluknet@nginx.com>
    Date:   Tue Jan 30 17:46:31 2018 +0300

        SSL: using default server context in session remove (closes #1464).

        This fixes segfault in configurations with multiple virtual servers sharing
        the same port, where a non-default virtual server block misses certificate.
    ```