### PR TITLE
Add NGX_SSL_ASYNC macro for ssl_async and repair some fix.

### DIFF
--- a/src/core/ngx_conf_file.h
+++ b/src/core/ngx_conf_file.h
@@ -129,6 +129,9 @@ struct ngx_conf_s {
 
     ngx_conf_handler_pt   handler;
     void                 *handler_conf;
+#if (NGX_SSL && NGX_SSL_ASYNC)
+    ngx_flag_t            no_ssl_init;
+#endif
 };
 
 

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5530,6 +5530,12 @@ ngx_openssl_engine(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return "is duplicate";
     }
 
+#if (NGX_SSL && NGX_SSL_ASYNC)
+    if (cf->no_ssl_init) {
+        return NGX_CONF_OK;
+    }
+#endif
+
     oscf->engine = 1;
 
     value = cf->args->elts;

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -2982,13 +2982,6 @@ ngx_ssl_free_buffer(ngx_connection_t *c)
             c->ssl->buf->start = NULL;
         }
     }
-#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER >= 0x10101000L)
-    if (c->ssl->early_buf && c->ssl->early_buf->start) {
-        if (ngx_pfree(c->pool, c->ssl->early_buf->start) == NGX_OK) {
-            c->ssl->early_buf->start = NULL;
-        }
-    }
-#endif
 }
 
 


### PR DESCRIPTION
## Test environment

```
Tengine version: Tengine/2.2.0 (nginx/1.15.9)
built by gcc 4.8.5 20150623 (Red Hat 4.8.5-28) (GCC) 
built with OpenSSL 1.1.0f  25 May 2017
TLS SNI support enabled
configure arguments: --with-debug --with-http_ssl_module --with-openssl-async --with-cc-opt='-DNGX_SECURE_MEM -I /home/fakang.wfk/work/github/openssl/.openssl/include -Wno-error=deprecated-declarations' --with-ld-opt='-Wl,-rpath=/home/fakang.wfk/work/github/openssl/.openssl/lib -L/home/fakang.wfk/work/github/openssl/.openssl/lib'
```

## Test results

```
TEST_NGINX_BINARY=/home/fakang.wfk/work/github/tengine/objs/nginx  prove -v -I tests/nginx-tests/nginx-tests/lib/  ./tests/nginx-tests/nginx-tests/http_ssl_asynchronous_mode.t 
./tests/nginx-tests/nginx-tests/http_ssl_asynchronous_mode.t .. 
1..4
depth=0 CN = localhost
verify error:num=18:self signed certificate
verify return:1
depth=0 CN = localhost
verify return:1
CONNECTED(00000003)
---
Certificate chain
 0 s:/CN=localhost
   i:/CN=localhost
---
Server certificate
-----BEGIN CERTIFICATE-----
MIICpDCCAYwCCQDEm6P+1If8wTANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
b2NhbGhvc3QwHhcNMTkwMzA2MTgxNTQ3WhcNMTkwNDA1MTgxNTQ3WjAUMRIwEAYD
VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDD
ZxSUMhe7uGTB6Htfq1/GObc/fKCltrOGHNB9QArl0+970jHLKAbt+ARHhNQow4Kb
oCsUi9Ef1A8rWXyqkP8wdEGlirvpihKaFkQDmbu2drhdHlfp72HzORRyqVrDMDWF
6oe2nnlWTZMEC1fRbUdvR/klw4Kr3HVmkNbfsQQqPWYEny8rksfEhvYICbvpZQMZ
4aKADpk+s7P+nRFbvcOuoaVaO5hsNHcO/ruBM/lE8xKakBXuuVUJmWSQJQyGIMzP
TU7WD31CdFKLXXqurev2L0CK8yX5NzwJXud/NgpbzhabW4PuGufpw7ZwbEgblzOv
Ixy/NEABmRRxxPTfojSjAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJBQBkszIMdt
9gI1FrmtyEzBp84hjtmNCy9EKD6/iwDlr2WXph87Ec6bD478qvy5jaEcA6KhN/Lv
y2whmH5riMiY126L/NUMneKiztAfYlGcqMeJJW4tEPbz1OdX0yfchETM7DBk+LCT
97oHy6ixL6eJDlA9sKdcEs668RNg9CBefE9T9lttEI1Fh5909DknATCNhmm2YlD0
PHQ9qp1L+lsiijer3X1PFTLbOYOSGsLf66TLuem7jcrSt9sxj7TEgzEkENkOjTkb
+gMFdls5IKlYIYnmDCxBBnBj9ft7SLSp50du50mxukLQfBku2TpZYfH/RgQaewBN
DZJ5eWwqWKU=
-----END CERTIFICATE-----
subject=/CN=localhost
issuer=/CN=localhost
---
No client certificate CA names sent
---
SSL handshake has read 1040 bytes and written 448 bytes
Verification error: self signed certificate
---
New, SSLv3, Cipher is AES128-SHA
Server public key is 2048 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : AES128-SHA
    Session-ID: 86FC2DCECA44500FDCABE8517E5E48093A92A3F6DEBDAC5CE2BF7542D36ACB68
    Session-ID-ctx: 
    Master-Key: F45CF82682F141010DA2080691A267D98F9692B63327D635818ACFD84538B1EAF3046FE7D1D11063308C25AF21562692
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 300 (seconds)
    TLS session ticket:
    0000 - a4 c3 4e 99 9d a9 92 a8-b7 5e 17 ab 58 b3 e5 6f   ..N......^..X..o
    0010 - 6c 4a 27 12 6a 2a e4 67-19 8d 60 fb 66 21 6d 50   lJ'.j*.g..`.f!mP
    0020 - 5f 54 6a 74 99 3e 76 ef-51 62 7a 45 29 b8 d6 e3   _Tjt.>v.QbzE)...
    0030 - 05 8b 96 10 36 4f 21 ed-8a f7 01 22 6e ce 37 11   ....6O!...."n.7.
    0040 - 38 3a 16 e2 94 39 ab 37-51 6f 81 a1 9d 6a 39 bb   8:...9.7Qo...j9.
    0050 - 7e 6e 00 d3 4e 3c 5a 9c-f3 2c c0 b0 a1 bf 4f 87   ~n..N<Z..,....O.
    0060 - 04 40 f9 25 37 40 2b 57-19 d5 58 b9 a5 11 a8 9f   .@.%7@+W..X.....
    0070 - 57 0c 1d 44 24 f2 b0 c6-00 08 1a 1d 10 07 ca d3   W..D$...........
    0080 - 96 21 a3 d0 0e 59 03 7f-f3 cf b3 57 1d 81 bd 4b   .!...Y.....W...K
    0090 - f8 f7 36 5e 7d 9e e2 40-3f ac 6e 1b 60 e3 2e 6c   ..6^}..@?.n.`..l
    00a0 - 7e 1e c6 c2 f9 23 5f 7a-7d 55 33 fa 98 51 ac 59   ~....#_z}U3..Q.Y

    Start Time: 1551896157
    Timeout   : 7200 (sec)
    Verify return code: 18 (self signed certificate)
    Extended master secret: yes
---
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
closed
ok 1 - Test AES128-SHA!
#     **Note**: Please make sure build Nginx using "--with-debug --with-openssl-async" and set COUNT_RSA 2 if you want see the result of async mode
depth=0 CN = localhost
verify error:num=18:self signed certificate
verify return:1
depth=0 CN = localhost
verify return:1
CONNECTED(00000003)
---
Certificate chain
 0 s:/CN=localhost
   i:/CN=localhost
---
Server certificate
-----BEGIN CERTIFICATE-----
MIICpDCCAYwCCQDEm6P+1If8wTANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
b2NhbGhvc3QwHhcNMTkwMzA2MTgxNTQ3WhcNMTkwNDA1MTgxNTQ3WjAUMRIwEAYD
VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDD
ZxSUMhe7uGTB6Htfq1/GObc/fKCltrOGHNB9QArl0+970jHLKAbt+ARHhNQow4Kb
oCsUi9Ef1A8rWXyqkP8wdEGlirvpihKaFkQDmbu2drhdHlfp72HzORRyqVrDMDWF
6oe2nnlWTZMEC1fRbUdvR/klw4Kr3HVmkNbfsQQqPWYEny8rksfEhvYICbvpZQMZ
4aKADpk+s7P+nRFbvcOuoaVaO5hsNHcO/ruBM/lE8xKakBXuuVUJmWSQJQyGIMzP
TU7WD31CdFKLXXqurev2L0CK8yX5NzwJXud/NgpbzhabW4PuGufpw7ZwbEgblzOv
Ixy/NEABmRRxxPTfojSjAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJBQBkszIMdt
9gI1FrmtyEzBp84hjtmNCy9EKD6/iwDlr2WXph87Ec6bD478qvy5jaEcA6KhN/Lv
y2whmH5riMiY126L/NUMneKiztAfYlGcqMeJJW4tEPbz1OdX0yfchETM7DBk+LCT
97oHy6ixL6eJDlA9sKdcEs668RNg9CBefE9T9lttEI1Fh5909DknATCNhmm2YlD0
PHQ9qp1L+lsiijer3X1PFTLbOYOSGsLf66TLuem7jcrSt9sxj7TEgzEkENkOjTkb
+gMFdls5IKlYIYnmDCxBBnBj9ft7SLSp50du50mxukLQfBku2TpZYfH/RgQaewBN
DZJ5eWwqWKU=
-----END CERTIFICATE-----
subject=/CN=localhost
issuer=/CN=localhost
---
No client certificate CA names sent
Peer signing digest: SHA256
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 1353 bytes and written 245 bytes
Verification error: self signed certificate
---
New, TLSv1.0, Cipher is ECDHE-RSA-AES128-SHA
Server public key is 2048 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-AES128-SHA
    Session-ID: 2B1A14AB0E663DF3F2F0620449AC5FFDE2483B0E8FCC04E645EF84E70ED1E640
    Session-ID-ctx: 
    Master-Key: A530750EC75B3CF00ED70F8382BA444EF5868F14C49E43CCFB0CC4CA28066F3B7FC02EAA3F5D9A271AB0339B41E6F570
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 300 (seconds)
    TLS session ticket:
    0000 - a4 c3 4e 99 9d a9 92 a8-b7 5e 17 ab 58 b3 e5 6f   ..N......^..X..o
    0010 - 61 3f e9 d3 fa 6b ec 2c-10 b6 f7 35 53 13 60 e7   a?...k.,...5S.`.
    0020 - 2e a7 f1 27 5b dc 59 64-91 49 31 89 cc 8f a9 ea   ...'[.Yd.I1.....
    0030 - c7 64 52 5a a8 40 33 2c-30 85 54 26 5e d1 eb e1   .dRZ.@3,0.T&^...
    0040 - 65 e7 97 d2 c5 fa ad 11-0d ed c8 a6 e2 13 a6 48   e..............H
    0050 - 65 c8 cd 16 ef 44 7b 54-39 98 6a 2c 5d e0 7e 08   e....D{T9.j,].~.
    0060 - 9e 17 c0 ca 30 1a 85 f4-29 16 1a 80 44 7f 3d 2d   ....0...)...D.=-
    0070 - 85 f2 f1 3a 3c b7 ae de-d9 b2 a1 b4 50 7b f8 57   ...:<.......P{.W
    0080 - 94 ca 82 01 27 73 3b c1-2b 8f dd 9e 67 64 e3 08   ....'s;.+...gd..
    0090 - 7e 63 a6 2d dd 9e 34 6a-6d 25 20 24 2d a4 71 41   ~c.-..4jm% $-.qA
    00a0 - 8a cd 9b b1 c9 9c c2 92-c1 ba d6 c5 7c aa 81 02   ............|...

    Start Time: 1551896162
    Timeout   : 7200 (sec)
    Verify return code: 18 (self signed certificate)
    Extended master secret: yes
---
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
closed
ok 2 - Test ECDHE-RSA-AES128-SHA!
#     **Note**: Please make sure build Nginx using "--with-debug" and "--with-openssl-async" and set COUNT_ECDHE_RSA 2 if you want see the result of async mode
ok 3 - no alerts
ok 4 - no sanitizer errors
ok
All tests successful.
Files=1, Tests=4, 16 wallclock secs ( 0.05 usr  0.02 sys +  0.35 cusr  0.07 csys =  0.49 CPU)
Result: PASS
```