### PR TITLE
Support Stream module's server_name directive by using SNI extension o…

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -1204,6 +1204,14 @@ if [ $STREAM != NO ]; then
 
         . auto/module
     fi
+
+    if [ $STREAM_SNI = YES ]; then
+        if [ $STREAM_SSL != YES ]; then
+            echo "--with-stream_ssl_module is needed by --with-stream_sni"
+            exit 1;
+        fi
+        have=NGX_STREAM_SNI . auto/have
+    fi
 fi
 
 

--- a/auto/options
+++ b/auto/options
@@ -136,6 +136,7 @@ STREAM_UPSTREAM_LEAST_CONN=YES
 STREAM_UPSTREAM_RANDOM=YES
 STREAM_UPSTREAM_ZONE=YES
 STREAM_SSL_PREREAD=NO
+STREAM_SNI=NO
 
 DYNAMIC_MODULES=
 
@@ -341,6 +342,7 @@ use the \"--with-mail_ssl_module\" option instead"
                                          STREAM_GEOIP=DYNAMIC       ;;
         --with-stream_ssl_preread_module)
                                          STREAM_SSL_PREREAD=YES     ;;
+        --with-stream_sni)               STREAM_SNI=YES             ;;
         --without-stream_limit_conn_module)
                                          STREAM_LIMIT_CONN=NO       ;;
         --without-stream_access_module)  STREAM_ACCESS=NO           ;;
@@ -573,6 +575,7 @@ cat << END
   --with-stream_geoip_module         enable ngx_stream_geoip_module
   --with-stream_geoip_module=dynamic enable dynamic ngx_stream_geoip_module
   --with-stream_ssl_preread_module   enable ngx_stream_ssl_preread_module
+  --with-stream_sni                  enable dynamic server block
   --without-stream_limit_conn_module disable ngx_stream_limit_conn_module
   --without-stream_access_module     disable ngx_stream_access_module
   --without-stream_geo_module        disable ngx_stream_geo_module

--- a/docs/core.md
+++ b/docs/core.md
@@ -162,3 +162,33 @@ turn on support for SO_REUSEPORT socket option. This option is supported since L
 
 Note:
 Removed reuse_port directive after the Tengine-2.3.0 version and use the official reuseport of Nginx, detailed reference [document](https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1/).
+
+### server_name
+
+Syntax: **server_name** name;
+
+Default: —
+
+Context: server
+
+`server_name` used in Stream module makes Tengine have the ability to listen same ip:port in multiply server blocks and. The connection will be attached to a certain server block by SNI extension in TLS. That means `server_name` should be used with SSL offloading(using `ssl` after `listen`).
+The `server_name` support in Stream module is not enabled by default. You should compile it explicitly:
+
+```
+ ./configure --with-stream_sni
+```
+Note:
+This feature is experimental. We will deprecate this feature if there is any conflict with similar feature of nginx official.
+
+### ssl_sni_force
+
+Syntax: **ssl_sni_force** on | off
+
+Default: ssl_sni_force off
+
+Context: stream, server
+
+`ssl_sni_force` will determine whether the TLS handsheke is rejected or not if SNI is not matched with server name which we configure by `server_name` in Stream module.
+
+Note:
+Same note in `server_name` above.

--- a/docs/core_cn.md
+++ b/docs/core_cn.md
@@ -169,3 +169,33 @@ Context: events
 
 注意：Tengine-2.3.0 版本后废弃reuse_port指令，使用Nginx官方的reuseport。升级方法：将events配置块里面的reuse_port on|off 释掉，在对应的监听端口后面加reuseport参数、详细参考[文档](https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1/) 。
 
+### server_name
+
+Syntax: **server_name** name;
+
+Default: —
+
+Context: server
+
+在Stream模块中，`server_name` 可以用来允许多个server块监听同一个ip:port。Tengine会根据TLS的SNI来决定请求连接匹配到哪个server块。这意味着，Stream模块的`server_name`必须用在SSL卸载的情况下（即`listen`指令后面有`ssl`这个参数）。
+
+Stream模块中的`server_name` 默认是不开启的. 你需要这么显示的编译:
+
+```
+ ./configure --with-stream_sni
+```
+注意:
+这个特性是实验性的。如果Nginx官方有类似的功能和该功能有冲突，那么改功能将被废弃。
+
+### ssl_sni_force
+
+Syntax: **ssl_sni_force** on | off
+
+Default: ssl_sni_force off
+
+Context: stream, server
+
+在Stream模块中，`ssl_sni_force`决定了如果TLS的SNI和配置的`server_name`不匹配，TLS握手是否被拒绝。
+
+注意:
+详见`server_name`的注意点.

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -661,7 +661,9 @@ ngx_stream_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
     ngx_stream_conf_port_t      *port;
     ngx_stream_conf_addr_t      *addr;
     ngx_stream_core_srv_conf_t  *cscf;
-
+#if (NGX_STREAM_SNI)
+    ngx_stream_core_main_conf_t *cmcf;
+#endif
     port = ports->elts;
     for (p = 0; p < ports->nelts; p++) {
 
@@ -741,9 +743,10 @@ ngx_stream_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
             stport->naddrs = i + 1;
 
 #if (NGX_STREAM_SNI)
-            /*Because of ssl_sni_force we have to add hash key even one server*/
+            cmcf = addr->opt.ctx->main_conf[ngx_stream_core_module.ctx_index];
+            /*Because of ssl_sni_force we have to do this even one server*/
             if (addr[i].servers.nelts >= 1) {
-                if (ngx_stream_server_names(cf, addr->opt.ctx->main_conf[ngx_stream_core_module.ctx_index], &addr[i]) != NGX_OK) {
+                if (ngx_stream_server_names(cf, cmcf, &addr[i]) != NGX_OK) {
                     return NGX_CONF_ERROR;
                 }
             }

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -661,6 +661,7 @@ ngx_stream_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
     ngx_stream_conf_port_t      *port;
     ngx_stream_conf_addr_t      *addr;
     ngx_stream_core_srv_conf_t  *cscf;
+
 #if (NGX_STREAM_SNI)
     ngx_stream_core_main_conf_t *cmcf;
 #endif

--- a/src/stream/ngx_stream.h
+++ b/src/stream/ngx_stream.h
@@ -65,6 +65,9 @@ typedef struct {
     int                            rcvbuf;
     int                            sndbuf;
     int                            type;
+#if (NGX_STREAM_SNI)
+    unsigned                       default_server;
+#endif
 } ngx_stream_listen_t;
 
 
@@ -73,6 +76,10 @@ typedef struct {
     ngx_str_t                      addr_text;
     unsigned                       ssl:1;
     unsigned                       proxy_protocol:1;
+#if (NGX_STREAM_SNI)
+    void                          *default_server;
+    void                          *virtual_names;
+#endif
 } ngx_stream_addr_conf_t;
 
 typedef struct {
@@ -108,6 +115,13 @@ typedef struct {
 
 typedef struct {
     ngx_stream_listen_t            opt;
+#if (NGX_STREAM_SNI)
+    void                          *default_server;
+    ngx_array_t                    servers;  /* array of ngx_stream_core_srv_conf_t */
+    ngx_hash_t                     hash;
+    ngx_hash_wildcard_t           *wc_head;
+    ngx_hash_wildcard_t           *wc_tail;
+#endif
 } ngx_stream_conf_addr_t;
 
 
@@ -165,6 +179,11 @@ typedef struct {
     ngx_hash_keys_arrays_t        *variables_keys;
 
     ngx_stream_phase_t             phases[NGX_STREAM_LOG_PHASE + 1];
+
+#if (NGX_STREAM_SNI)
+    ngx_uint_t                     server_names_hash_max_size;
+    ngx_uint_t                     server_names_hash_bucket_size;
+#endif
 } ngx_stream_core_main_conf_t;
 
 
@@ -188,8 +207,25 @@ typedef struct {
     ngx_msec_t                     proxy_protocol_timeout;
 
     ngx_uint_t                     listen;  /* unsigned  listen:1; */
+
+#if (NGX_STREAM_SNI)
+    /* array of the ngx_stream_server_name_t, "server_name" directive */
+    ngx_array_t                    server_names;
+    ngx_str_t                      server_name;
+#endif
 } ngx_stream_core_srv_conf_t;
 
+#if (NGX_STREAM_SNI)
+/* list of structures to find core_srv_conf quickly at run time */
+typedef struct {
+    ngx_stream_core_srv_conf_t  *server;   /* virtual name server conf */
+    ngx_str_t                    name;
+} ngx_stream_server_name_t;
+
+typedef struct {
+    ngx_hash_combined_t        names;
+} ngx_stream_virtual_names_t;
+#endif
 
 struct ngx_stream_session_s {
     uint32_t                       signature;         /* "STRM" */
@@ -225,6 +261,9 @@ struct ngx_stream_session_s {
     unsigned                       stat_processing:1;
 
     unsigned                       health_check:1;
+#if (NGX_STREAM_SNI)
+    ngx_stream_addr_conf_t        *addr_conf;
+#endif
 };
 
 

--- a/src/stream/ngx_stream_handler.c
+++ b/src/stream/ngx_stream_handler.c
@@ -125,6 +125,12 @@ ngx_stream_init_connection(ngx_connection_t *c)
     s->main_conf = addr_conf->ctx->main_conf;
     s->srv_conf = addr_conf->ctx->srv_conf;
 
+#if (NGX_STREAM_SNI)
+    s->addr_conf = addr_conf;
+    s->main_conf = ((ngx_stream_core_srv_conf_t*)addr_conf->default_server)->ctx->main_conf;
+    s->srv_conf = ((ngx_stream_core_srv_conf_t*)addr_conf->default_server)->ctx->srv_conf;
+#endif
+
 #if (NGX_STREAM_SSL)
     s->ssl = addr_conf->ssl;
 #endif

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -45,8 +45,8 @@ static char *ngx_stream_ssl_session_cache(ngx_conf_t *cf, ngx_command_t *cmd,
 static ngx_int_t ngx_stream_ssl_init(ngx_conf_t *cf);
 
 #if (NGX_STREAM_SNI)
-int
-ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg);
+int ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad,
+    void *arg);
 #endif
 
 
@@ -655,6 +655,7 @@ ngx_stream_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
 #if (NGX_STREAM_SNI)
     ngx_conf_merge_value(conf->sni_force, prev->sni_force, 0);
+    if (!conf->listen)
 #endif
 
     conf->ssl.log = cf->log;
@@ -812,15 +813,19 @@ ngx_stream_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
 #if (NGX_STREAM_SNI)
+#if (SSL_CTRL_SET_TLSEXT_HOSTNAME)
     if (SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
                                                ngx_stream_ssl_servername)
         == 0)
     {
+#endif
         ngx_log_error(NGX_LOG_WARN, cf->log, 0,
             "nginx was built with SNI support, however, now it is linked "
             "dynamically to an OpenSSL library which has no tlsext support, "
             "therefore SNI is not available");
+#if (SSL_CTRL_SET_TLSEXT_HOSTNAME)
     }
+#endif
 #endif
 
     return NGX_CONF_OK;

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -44,6 +44,11 @@ static char *ngx_stream_ssl_session_cache(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static ngx_int_t ngx_stream_ssl_init(ngx_conf_t *cf);
 
+#if (NGX_STREAM_SNI)
+int
+ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg);
+#endif
+
 
 static ngx_conf_bitmask_t  ngx_stream_ssl_protocols[] = {
     { ngx_string("SSLv2"), NGX_SSL_SSLv2 },
@@ -192,6 +197,15 @@ static ngx_command_t  ngx_stream_ssl_commands[] = {
       NGX_STREAM_SRV_CONF_OFFSET,
       offsetof(ngx_stream_ssl_conf_t, crl),
       NULL },
+
+#if (NGX_STREAM_SNI)
+    { ngx_string("ssl_sni_force"),
+        NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+        ngx_conf_set_flag_slot,
+        NGX_STREAM_SRV_CONF_OFFSET,
+        offsetof(ngx_stream_ssl_conf_t, sni_force),
+        NULL },
+#endif
 
       ngx_null_command
 };
@@ -589,6 +603,9 @@ ngx_stream_ssl_create_conf(ngx_conf_t *cf)
     scf->session_tickets = NGX_CONF_UNSET;
     scf->session_ticket_keys = NGX_CONF_UNSET_PTR;
 
+#if (NGX_STREAM_SNI)
+    scf->sni_force = NGX_CONF_UNSET;
+#endif
     return scf;
 }
 
@@ -636,6 +653,9 @@ ngx_stream_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_str_value(conf->ciphers, prev->ciphers, NGX_DEFAULT_CIPHERS);
 
+#if (NGX_STREAM_SNI)
+    ngx_conf_merge_value(conf->sni_force, prev->sni_force, 0);
+#endif
 
     conf->ssl.log = cf->log;
 
@@ -790,6 +810,18 @@ ngx_stream_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     {
         return NGX_CONF_ERROR;
     }
+
+#if (NGX_STREAM_SNI)
+    if (SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
+                                               ngx_stream_ssl_servername)
+        == 0)
+    {
+        ngx_log_error(NGX_LOG_WARN, cf->log, 0,
+            "nginx was built with SNI support, however, now it is linked "
+            "dynamically to an OpenSSL library which has no tlsext support, "
+            "therefore SNI is not available");
+    }
+#endif
 
     return NGX_CONF_OK;
 }
@@ -1031,3 +1063,112 @@ ngx_stream_ssl_init(ngx_conf_t *cf)
 
     return NGX_OK;
 }
+
+#ifdef NGX_STREAM_SNI
+static ngx_int_t
+ngx_stream_find_virtual_server(ngx_connection_t *c,
+    ngx_stream_virtual_names_t *virtual_names, ngx_str_t *host,
+    ngx_stream_core_srv_conf_t **cscfp)
+{
+    ngx_stream_core_srv_conf_t  *cscf;
+
+    if (virtual_names == NULL) {
+        return NGX_DECLINED;
+    }
+
+    cscf = ngx_hash_find_combined(&virtual_names->names,
+                                  ngx_hash_key(host->data, host->len),
+                                  host->data, host->len);
+
+    if (cscf) {
+        *cscfp = cscf;
+        return NGX_OK;
+    }
+
+    return NGX_DECLINED;
+}
+
+int
+ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
+{
+    ngx_str_t                   host;
+    const char                 *servername;
+    ngx_connection_t           *c;
+    ngx_stream_session_t       *s;
+    ngx_stream_ssl_conf_t      *sscf;
+    ngx_stream_core_srv_conf_t *cscf;
+
+    c = ngx_ssl_get_connection(ssl_conn);
+    s = c->data;
+
+    servername = SSL_get_servername(ssl_conn, TLSEXT_NAMETYPE_host_name);
+
+    if (servername == NULL) {
+        goto not_match;
+    }
+
+    if (c->ssl->renegotiation) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    host.len = ngx_strlen(servername);
+    if (host.len == 0) {
+        goto not_match;
+    }
+
+    host.data = (u_char *) servername;
+
+
+    if (ngx_stream_find_virtual_server(c, s->addr_conf->virtual_names, &host,
+                                       &cscf)
+        != NGX_OK)
+    {
+        goto not_match;
+    }
+
+    ngx_set_connection_log(c, cscf->error_log);
+
+    s->main_conf = cscf->ctx->main_conf;
+    s->srv_conf  = cscf->ctx->srv_conf;
+
+    sscf = ngx_stream_get_module_srv_conf(cscf->ctx, ngx_stream_ssl_module);
+
+    if (sscf->ssl.ctx) {
+        SSL_set_SSL_CTX(ssl_conn, sscf->ssl.ctx);
+
+        /*
+         * SSL_set_SSL_CTX() only changes certs as of 1.0.0d
+         * adjust other things we care about
+         */
+
+        SSL_set_verify(ssl_conn, SSL_CTX_get_verify_mode(sscf->ssl.ctx),
+                       SSL_CTX_get_verify_callback(sscf->ssl.ctx));
+
+        SSL_set_verify_depth(ssl_conn, SSL_CTX_get_verify_depth(sscf->ssl.ctx));
+
+#ifdef SSL_CTRL_CLEAR_OPTIONS
+        /* only in 0.9.8m+ */
+        SSL_clear_options(ssl_conn, SSL_get_options(ssl_conn) &
+                                    ~SSL_CTX_get_options(sscf->ssl.ctx));
+#endif
+
+        SSL_set_options(ssl_conn, SSL_CTX_get_options(sscf->ssl.ctx));
+    }
+
+    return SSL_TLSEXT_ERR_OK;
+
+not_match:
+    sscf = ngx_stream_get_module_srv_conf(s, ngx_stream_ssl_module);
+
+    if (sscf->sni_force) {
+        ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                      "SSL sni not match, sni:%s, reject", servername?servername:"NULL");
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+
+    } else {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+}
+
+#endif
+

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -200,11 +200,11 @@ static ngx_command_t  ngx_stream_ssl_commands[] = {
 
 #if (NGX_STREAM_SNI)
     { ngx_string("ssl_sni_force"),
-        NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
-        ngx_conf_set_flag_slot,
-        NGX_STREAM_SRV_CONF_OFFSET,
-        offsetof(ngx_stream_ssl_conf_t, sni_force),
-        NULL },
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, sni_force),
+      NULL },
 #endif
 
       ngx_null_command

--- a/src/stream/ngx_stream_ssl_module.h
+++ b/src/stream/ngx_stream_ssl_module.h
@@ -54,6 +54,10 @@ typedef struct {
 
     u_char          *file;
     ngx_uint_t       line;
+
+#if (NGX_STREAM_SNI)
+    ngx_flag_t       sni_force;
+#endif
 } ngx_stream_ssl_conf_t;
 
 

--- a/tests/nginx-tests/nginx-tests/lib/Test/Nginx.pm
+++ b/tests/nginx-tests/nginx-tests/lib/Test/Nginx.pm
@@ -184,6 +184,8 @@ sub has_module($) {
 			=> '(?s)^(?!.*--without-stream_split_clients_module)',
 		stream_ssl
 			=> '--with-stream_ssl_module',
+		stream_sni
+			=> '--with-stream_sni',
 		stream_upstream_hash
 			=> '(?s)^(?!.*--without-stream_upstream_hash_module)',
 		stream_upstream_least_conn

--- a/tests/nginx-tests/nginx-tests/stream_sni.t
+++ b/tests/nginx-tests/nginx-tests/stream_sni.t
@@ -1,0 +1,112 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Stream tests for proxy to ssl backend.
+
+###############################################################################
+# "For using stream_sni.t, you should configure Tengine by using --with-stream_ssl_module --with-stream_sni";
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_ssl stream_return stream_sni/)->plan(5);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+worker_processes 1;  # NOTE: The default value of Tengine worker_processes directive is `worker_processes auto;`.
+
+stream {
+    proxy_ssl on;
+    proxy_ssl_session_reuse on;
+    proxy_connect_timeout 2s;
+
+    server {
+        listen      127.0.0.1:8081 ssl;
+        server_name www.test1.com;
+
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+        return "www.test1.com"; 
+    }
+
+    server {
+        listen      127.0.0.1:8081 ssl;
+        server_name www.test2.com;
+
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+        return "www.test2.com";
+    }
+
+    server {
+        listen      127.0.0.1:8081 ssl default;
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+        return "default";
+    }
+
+    server {
+        listen      127.0.0.1:8082 ssl;
+        server_name www.testsniforce.com;
+        ssl_sni_force on;
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+        return "www.testsniforce.com";
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 1024
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('localhost') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+
+$t->run();
+my $ret1 = `openssl s_client -connect localhost:8081 -quiet -servername "www.test1.com"| grep "test1"`;
+my $ret2 = `openssl s_client -connect localhost:8081 -quiet -servername "www.test2.com" | grep "test2"`;
+my $ret3 = `openssl s_client -connect localhost:8081 -quiet -servername "www.test3.com"| grep "default"`;
+my $ret4 = `openssl s_client -connect localhost:8082 -quiet -servername "www.testsniforce.com"| grep "force"`;
+my $ret5 = `openssl s_client -connect localhost:8082 -quiet -servername "www.testother.com"| grep "force"`;
+
+like($ret1, qr/www.test1.com/, 'Match www.test1.com success');
+like($ret2, qr/www.test2.com/, 'Match www.test2.com success');
+like($ret3, qr/default/, 'Match default success');
+like($ret4, qr/www.testsniforce.com/, 'sni force success');
+unlike($ret5, qr/www.testsniforce.com/, 'reject unknown domain success');
+$t->stop();

--- a/tests/nginx-tests/nginx-tests/stream_sni.t
+++ b/tests/nginx-tests/nginx-tests/stream_sni.t
@@ -1,9 +1,8 @@
 #!/usr/bin/perl
 
-# (C) Sergey Kandaurov
-# (C) Nginx, Inc.
+# Copyright (C) 2019 Alibaba Group Holding Limited
 
-# Stream tests for proxy to ssl backend.
+# Stream tests for SNI.
 
 ###############################################################################
 # "For using stream_sni.t, you should configure Tengine by using --with-stream_ssl_module --with-stream_sni";


### PR DESCRIPTION
# Primary Changes
* Support `Stream` module's `server_name` directive 
It's semantic equivalence between `HTTP` module and `Stream` module except that `Stream` module only uses SNI extension of TLS to locate server block.  
It gives Tengine an ability to distribute the `Stream` request by another dimension rather than using different port.  

* `server_name` only works under SSL offload which means  `server_name` only works with `listen ... ssl;`.  
*  Support `Stream` module's `ssl_sni_force` directive(Default is off) 
Reject the TLS handshake if SNI doesn't match the `server_name` we configured.   