### PR TITLE
support websocket check of upstream check module

### DIFF
--- a/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
+++ b/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
@@ -176,10 +176,12 @@ typedef struct {
 #define NGX_HTTP_CHECK_MYSQL                 0x0008
 #define NGX_HTTP_CHECK_AJP                   0x0010
 
-#define NGX_CHECK_HTTP_2XX                   0x0002
-#define NGX_CHECK_HTTP_3XX                   0x0004
-#define NGX_CHECK_HTTP_4XX                   0x0008
-#define NGX_CHECK_HTTP_5XX                   0x0010
+#define NGX_CHECK_HTTP_1XX                   0x0002
+#define NGX_CHECK_HTTP_2XX                   0x0004
+#define NGX_CHECK_HTTP_3XX                   0x0008
+#define NGX_CHECK_HTTP_4XX                   0x0010
+#define NGX_CHECK_HTTP_5XX                   0x0020
+
 #define NGX_CHECK_HTTP_ERR                   0x8000
 
 typedef struct {
@@ -530,6 +532,7 @@ static ngx_int_t ngx_http_upstream_check_init_process(ngx_cycle_t *cycle);
 
 
 static ngx_conf_bitmask_t  ngx_check_http_expect_alive_masks[] = {
+    { ngx_string("http_1xx"), NGX_CHECK_HTTP_1XX },
     { ngx_string("http_2xx"), NGX_CHECK_HTTP_2XX },
     { ngx_string("http_3xx"), NGX_CHECK_HTTP_3XX },
     { ngx_string("http_4xx"), NGX_CHECK_HTTP_4XX },
@@ -1996,7 +1999,9 @@ ngx_http_upstream_check_http_parse(ngx_http_upstream_check_peer_t *peer)
 
         code = ctx->status.code;
 
-        if (code >= 200 && code < 300) {
+        if (code > 0 && code < 200) {
+            code_n = NGX_CHECK_HTTP_1XX;
+        } else if (code >= 200 && code < 300) {
             code_n = NGX_CHECK_HTTP_2XX;
         } else if (code >= 300 && code < 400) {
             code_n = NGX_CHECK_HTTP_3XX;
@@ -2264,7 +2269,9 @@ ngx_http_upstream_check_fastcgi_parse(ngx_http_upstream_check_peer_t *peer)
 
         code = ctx->status.code;
 
-        if (code >= 200 && code < 300) {
+        if (code > 0 && code < 200) {
+            code_n = NGX_CHECK_HTTP_1XX;
+        } else if (code >= 200 && code < 300) {
             code_n = NGX_CHECK_HTTP_2XX;
         } else if (code >= 300 && code < 400) {
             code_n = NGX_CHECK_HTTP_3XX;

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/websocket.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/websocket.t
@@ -1,0 +1,94 @@
+# vi:filetype=perl
+# Copyright (C) 2019 Alibaba Group Holding Limited.
+#
+use lib 'lib';
+use Test::Nginx::LWP;
+use Test::Nginx::Socket;
+
+plan tests => repeat_each(1) * 2 * blocks();
+
+no_root_location();
+
+run_tests();
+
+__DATA__
+
+
+
+=== TEST 1: the websocket check
+--- http_config
+    upstream testwebsocket{
+        server 127.0.0.1:1970;
+        server 127.0.0.1:1971;
+
+        check interval=3000 rise=1 fall=1 timeout=1000 type=http;
+        #It's a standard websocket request.
+        check_http_send "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n\r\n";
+        check_http_expect_alive http_1xx;
+    }
+
+    server {
+        listen 1971;
+
+        location / {
+            #For health checker's response.
+            if ($http_upgrade = "websocket") {
+                return 101;
+            }
+            return 200 "websocket service";
+        }
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            return 200 "http service";
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://testwebsocket;
+    }
+
+--- request
+GET /
+--- response_body_like: ^.*websocket.*$
+
+
+=== TEST 2: the http check
+--- http_config
+    upstream testhttp{
+        server 127.0.0.1:1970;
+        server 127.0.0.1:1971;
+
+        check interval=3000 rise=1 fall=1 timeout=1000 type=http;
+        check_http_send "GET /hc HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        check_http_expect_alive http_2xx;
+    }
+
+    server {
+        listen 1971;
+
+        location / {
+            return 101;
+        }
+    }
+
+    server {
+        listen 1970;
+
+        location / {
+            return 200 "http service";
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://testhttp;
+    }
+
+--- request
+GET /http
+--- response_body_like: ^.*http.*$


### PR DESCRIPTION
Supporting status code 101 is enough.
```
$TEST_NGINX_SLEEP=3  TEST_NGINX_LEAVE=1 TEST_NGINX_BINARY=/home/shangxu.cjy/code/tmp/tengine/objs/nginx prove -v -I  ./test-nginx/lib/ tests/test-nginx/cases/ngx_http_upstream_check_module/websocket.t 
tests/test-nginx/cases/ngx_http_upstream_check_module/websocket.t .. 
1..4
ok 1 - TEST 1: the websocket check - status code ok
ok 2 - TEST 1: the websocket check - response_body_like - response is expected (websocket service)
ok 3 - TEST 2: the http check - status code ok
ok 4 - TEST 2: the http check - response_body_like - response is expected (http service)
ok
All tests successful.
Files=1, Tests=4, 26 wallclock secs ( 0.03 usr  0.01 sys +  0.27 cusr  0.05 csys =  0.36 CPU)
Result: PASS
``` 
support https://github.com/alibaba/tengine/issues/1239