### PR TITLE
Support dynamic build for upstream_dynamic module.

### DIFF
--- a/modules/ngx_http_upstream_dynamic_module/config
+++ b/modules/ngx_http_upstream_dynamic_module/config
@@ -1,4 +1,15 @@
-ddon_name=ngx_http_upstream_dynamic_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_upstream_dynamic_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upstream_dynamic_module.c"
+ngx_addon_name=ngx_http_upstream_dynamic_module
+HTTP_UPSTREAM_DYNAMIC_SRCS="$ngx_addon_dir/ngx_http_upstream_dynamic_module.c"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=$ngx_addon_name
+    ngx_module_srcs="$HTTP_UPSTREAM_DYNAMIC_SRCS"
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_http_upstream_dynamic_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $HTTP_UPSTREAM_DYNAMIC_SRCS"
+fi
+
 have=T_NGX_HTTP_DYNAMIC_RESOLVE  . auto/have

--- a/tests/nginx-tests/tengine-tests/dynamic_resolve.t
+++ b/tests/nginx-tests/tengine-tests/dynamic_resolve.t
@@ -28,7 +28,7 @@ my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(6);
 my @server_addrs = ("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4");
 my @domain_addrs = ("127.0.0.2");
 
-my $ipv6 = $t->has_module("ipv6") ? "ipv6=off" : "";
+my $ipv6 = $t->has_version('1.11.5') ? "ipv6=off" : "";
 
 my $nginx_conf = <<'EOF';
 


### PR DESCRIPTION
* build 

```
$./objs/nginx  -V
Tengine version: Tengine/2.3.0
nginx version: nginx/1.15.9
built by gcc 4.8.5 20150623 (Red Hat 4.8.5-28) (GCC) 
built with OpenSSL 1.0.2k-fips  26 Jan 2017
TLS SNI support enabled
configure arguments: --add-dynamic-module=modules/ngx_http_upstream_dynamic_module

$./objs/nginx  -c /home/fakang.wfk/work/github/tengine/conf/nginx.conf  -m 2>&1|grep dynamic
nginx:     ngx_http_upstream_dynamic_module (dynamic)
```

* test 

```

--- a/tests/nginx-tests/tengine-tests/dynamic_resolve.t
+++ b/tests/nginx-tests/tengine-tests/dynamic_resolve.t
@@ -37,6 +37,7 @@ my $nginx_conf = <<'EOF';
 daemon         off;
 worker_processes 1;
 
+load_module /home/fakang.wfk/work/github/tengine/objs/ngx_http_upstream_dynamic_module.so;
 events {
 }


$TEST_NGINX_LEAVE=1 TEST_NGINX_BINARY=/home/fakang.wfk/work/github/tengine/objs/nginx  prove -v -I tests/nginx-tests/nginx-tests/lib/  ./tests/nginx-tests/tengine-tests/dynamic_resolve.t 
./tests/nginx-tests/tengine-tests/dynamic_resolve.t .. 
1..8
ok 1 - static resolved should be taobao' IP addr
;; HEADER SECTION
;;	id = 47946
;;	qr = 0	aa = 0	tc = 0	rd = 1	opcode = QUERY
;;	ra = 0	z  = 0	ad = 0	cd = 0	rcode  = NOERROR
;;	qdcount = 1	ancount = 0	nscount = 0	arcount = 0
;;	do = 0

;; QUESTION SECTION (1 record)
;; www.taobao.com.	IN	A

;; ANSWER SECTION (0 records)

;; AUTHORITY SECTION (0 records)

;; ADDITIONAL SECTION (0 records)
ok 2 - http server should be 127.0.0.2
ok 3 - http server should be 127.0.0.2 for /proxy_pass_var
ok 4 - stale http server should be www.taobao.com:8081, using initial result
ok 5 - shutdown connection if dns query is failed
ok 6 - next upstream should be 127.0.0.4
ok 7 - no alerts
ok 8 - no sanitizer errors
ok
All tests successful.
Files=1, Tests=8, 14 wallclock secs ( 0.04 usr  0.00 sys +  0.19 cusr  0.06 csys =  0.29 CPU)
Result: PASS
```

