### PR TITLE
fix 'make modules' for compiling dynamic modules

### DIFF
--- a/auto/install
+++ b/auto/install
@@ -204,6 +204,7 @@ build:
 install:
 	\$(MAKE) -f $NGX_MAKEFILE install
 
+.PHONE: modules
 modules:
 	\$(MAKE) -f $NGX_MAKEFILE modules
 


### PR DESCRIPTION
since there exists a directory called modules, the 'modules' target
of the top-level Makefile should have an associtated phony target. otherwise
'make modules' will do nothing expect complaining the target 'is up to date'