### PR TITLE
bugfix: http2 directive should not work on h2c

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -221,10 +221,6 @@ ngx_http_init_connection(ngx_connection_t *c)
     struct sockaddr_in6    *sin6;
     ngx_http_in6_addr_t    *addr6;
 #endif
-#if (NGX_HTTP_V2 && T_NGX_HTTP2_SRV_ENABLE)
-    ngx_http_v2_srv_conf_t *h2scf;
-#endif
-
 
     hc = ngx_pcalloc(c->pool, sizeof(ngx_http_connection_t));
     if (hc == NULL) {
@@ -332,21 +328,8 @@ ngx_http_init_connection(ngx_connection_t *c)
     rev->handler = ngx_http_wait_request_handler;
     c->write->handler = ngx_http_empty_handler;
 
-#if (NGX_HTTP_V2 && T_NGX_HTTP2_SRV_ENABLE)
-    h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
-#endif
-
 #if (NGX_HTTP_V2)
-    if (
-#if (T_NGX_HTTP2_SRV_ENABLE)
-        (
-#endif
-         hc->addr_conf->http2
-#if (T_NGX_HTTP2_SRV_ENABLE)
-         && h2scf->enable != 0) || h2scf->enable == 1
-#endif
-       )
-    {
+    if (hc->addr_conf->http2) {
         rev->handler = ngx_http_v2_init;
     }
 #endif


### PR DESCRIPTION
The http2 directive works on HTTP2 over TLS not on HTTP2 cleartext.

For HTTP2 cleartext, the default server still controls using http2
or not. the "http2 off;" line in other servers is not going to work
as expected.

So, we should just make http2 directive only affects HTTP2 over TLS.