### PR TITLE
fix stream_sni in Tengine 2.3.1

### DIFF
--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -601,8 +601,8 @@ found:
     addr = port->addrs.elts;
 
     for (i = 0; i < port->addrs.nelts; i++) {
-        if (ngx_cmp_sockaddr(&listen->sockaddr.sockaddr, listen->socklen,
-            &addr[i].opt.sockaddr.sockaddr,
+        if (ngx_cmp_sockaddr(listen->sockaddr, listen->socklen,
+            addr[i].opt.sockaddr,
             addr[i].opt.socklen, 0)
             != NGX_OK)
         {

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -944,9 +944,6 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             return "\"proxy_protocol\" parameter is incompatible with \"udp\"";
         }
     }
-#if (NGX_STREAM_SNI)
-    return NGX_CONF_OK;
-#endif
 
     als = cmcf->listen.elts;
 
@@ -957,6 +954,10 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         ls[n].socklen = u.addrs[n].socklen;
         ls[n].addr_text = u.addrs[n].name;
         ls[n].wildcard = ngx_inet_wildcard(ls[n].sockaddr);
+
+#if (NGX_STREAM_SNI)
+        continue;
+#endif
 
         for (i = 0; i < cmcf->listen.nelts - u.naddrs + n; i++) {
             if (ls[n].type != als[i].type) {


### PR DESCRIPTION
fix stream_sni in Tengine 2.3.1
```
$sudo TEST_NGINX_LEAVE=1 TEST_NGINX_BINARY=/home/shangxu.cjy/code/tengineopen/tengine/objs/nginx prove -v -I tests/nginx-tests/nginx-tests/lib/  ./tests/nginx-tests/nginx-tests/stream_sni.t
./tests/nginx-tests/nginx-tests/stream_sni.t .. 
1..7
depth=0 CN = localhost
verify error:num=18:self signed certificate
verify return:1
depth=0 CN = localhost
verify return:1
depth=0 CN = localhost
verify error:num=18:self signed certificate
verify return:1
depth=0 CN = localhost
verify return:1
depth=0 CN = localhost
verify error:num=18:self signed certificate
verify return:1
depth=0 CN = localhost
verify return:1
depth=0 CN = localhost
verify error:num=18:self signed certificate
verify return:1
depth=0 CN = localhost
verify return:1
140160056199056:error:14077458:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 unrecognized name:s23_clnt.c:769:
ok 1 - Match www.test1.com success
ok 2 - Match www.test2.com success
ok 3 - Match default success
ok 4 - sni force success
ok 5 - reject unknown domain success
ok 6 - no alerts
ok 7 - no sanitizer errors
ok
All tests successful.
Files=1, Tests=7,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.21 cusr  0.04 csys =  0.27 CPU)
Result: PASS

```