### PR TITLE
Add new variables: $ssl_handshake_time and $ssl_handshake_time_msec

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5448,7 +5448,7 @@ ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
     tp = ngx_timeofday();
 
     if (c->ssl->handshake_end_msec == 0) {
-        ms = tp->sec * 1000 + tp->sec - c->ssl->handshake_start_msec;
+        ms = tp->sec * 1000 + tp->msec - c->ssl->handshake_start_msec;
 
     } else {
         ms = c->ssl->handshake_end_msec - c->ssl->handshake_start_msec;
@@ -5484,7 +5484,7 @@ ngx_ssl_get_handshake_time_msec(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t
     tp = ngx_timeofday();
 
     if (c->ssl->handshake_end_msec == 0) {
-        ms = tp->sec * 1000 + tp->sec - c->ssl->handshake_start_msec;
+        ms = tp->sec * 1000 + tp->msec - c->ssl->handshake_start_msec;
 
     } else {
         ms = c->ssl->handshake_end_msec - c->ssl->handshake_start_msec;

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5461,6 +5461,42 @@ ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
         return NGX_ERROR;
     }
 
+    s->len = ngx_sprintf(p, "%T.%03M", (time_t) ms / 1000, ms % 1000) - p;
+    s->data = p;
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_ssl_get_handshake_time_msec(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{
+    ngx_msec_int_t   ms;
+    u_char          *p;
+    ngx_time_t      *tp;
+
+    if (c->ssl == NULL) {
+        ngx_str_null(s);
+
+        return NGX_OK;
+    }
+
+    tp = ngx_timeofday();
+
+    if (c->ssl->handshake_end_msec == 0) {
+        ms = tp->sec * 1000 + tp->sec - c->ssl->handshake_start_msec;
+
+    } else {
+        ms = c->ssl->handshake_end_msec - c->ssl->handshake_start_msec;
+    }
+
+    ms = ngx_max(ms, 0);
+
+    p = ngx_pnalloc(pool, NGX_TIME_T_LEN);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
     s->len = ngx_sprintf(p, "%i", ms) - p;
     s->data = p;
 

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -276,6 +276,8 @@ ngx_int_t ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool,
 #if (T_NGX_SSL_HANDSHAKE_TIME)
 ngx_int_t ngx_ssl_get_handshake_time(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_handshake_time_msec(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 #endif
 
 

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -385,8 +385,15 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
       (uintptr_t) ngx_ssl_get_client_v_remain, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
 #if (T_NGX_SSL_HANDSHAKE_TIME)
+    /* $ssl_shandshakd_time deprecated and will be removed in the next release */
     { ngx_string("ssl_handshakd_time"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_handshake_time, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_handshake_time"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_handshake_time, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_handshake_time_msec"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_handshake_time_msec, NGX_HTTP_VAR_CHANGEABLE, 0 },
 #endif
 
       ngx_http_null_variable

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -301,8 +301,15 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
       (uintptr_t) ngx_ssl_get_client_v_remain, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
 #if (T_NGX_SSL_HANDSHAKE_TIME)
+    /* $ssl_shandshakd_time deprecated and will be removed in the next release */
     { ngx_string("ssl_handshakd_time"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_handshake_time, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_handshake_time"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_handshake_time, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_handshake_time_msec"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_handshake_time_msec, NGX_STREAM_VAR_CHANGEABLE, 0 },
 #endif
 
       ngx_stream_null_variable

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -305,8 +305,8 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
     { ngx_string("ssl_handshakd_time"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_handshake_time, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
-    { ngx_string("ssl_handshake_time"), NULL, ngx_http_ssl_variable,
-      (uintptr_t) ngx_ssl_get_handshake_time, NGX_HTTP_VAR_CHANGEABLE, 0 },
+    { ngx_string("ssl_handshake_time"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_handshake_time, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
     { ngx_string("ssl_handshake_time_msec"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_handshake_time_msec, NGX_STREAM_VAR_CHANGEABLE, 0 },


### PR DESCRIPTION
1. Add new variables: $ssl_handshake_time and $ssl_handshake_time_msec
2. $ssl_shandshakd_time deprecated and will be removed in the next
release.