### PR TITLE
Avoid multiple bind() for the same address during config test

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -104,7 +104,7 @@ ngx_clone_listening(ngx_cycle_t *cycle, ngx_listening_t *ls)
     ngx_core_conf_t  *ccf;
     ngx_listening_t   ols;
 
-    if (!ls->reuseport || ls->worker != 0) {
+    if (!ls->reuseport || ls->worker != 0 || ngx_test_config) {
         return NGX_OK;
     }
 


### PR DESCRIPTION
If reuseport is specified in the config, then during config test nginx makes multiple calls to the bind() function for the same address.
It causes a problem when large number of connections goes to the server and bind() with SO_REUSEPORT loads cpu  (inet_csk_bind_conflict()) multiple times.
After fixing, bind is called only 1 time per address while testing of the config.