### PR TITLE
Bugfix: ensured 'init_worker_by_lua*' does not mutate another NGINX module's main_conf.

### DIFF
--- a/modules/ngx_http_lua_module/t/162-fake-merge.t
+++ b/modules/ngx_http_lua_module/t/162-fake-merge.t
@@ -1,0 +1,36 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+master_on();
+#workers(2);
+#log_level('warn');
+
+repeat_each(1);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+#no_diff();
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: get fake_var 
+--- http_config
+    init_worker_by_lua '
+        local a = 1
+    ';
+--- config
+    location /t {
+        content_by_lua '
+            ngx.say("fake_var = ", ngx.var.fake_var)
+        ';
+    }
+--- request
+    GET /t
+--- response_body
+fake_var = 1
+--- no_error_log
+[error]

--- a/modules/ngx_http_lua_module/t/data/fake-merge-module/config
+++ b/modules/ngx_http_lua_module/t/data/fake-merge-module/config
@@ -1,0 +1,3 @@
+ngx_addon_name=ngx_http_fake_merge_module
+HTTP_MODULES="$HTTP_MODULES ngx_http_fake_merge_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_fake_merge_module.c"

--- a/modules/ngx_http_lua_module/t/data/fake-merge-module/ngx_http_fake_merge_module.c
+++ b/modules/ngx_http_lua_module/t/data/fake-merge-module/ngx_http_fake_merge_module.c
@@ -1,0 +1,203 @@
+/*
+ * This fake module was used to reproduce a bug in ngx_lua's
+ * init_worker_by_lua implementation.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <nginx.h>
+
+
+typedef struct {
+    ngx_flag_t a;
+} ngx_http_fake_merge_main_conf_t;
+
+
+typedef struct {
+    ngx_flag_t a;
+} ngx_http_fake_merge_srv_conf_t;
+
+
+typedef struct {
+    ngx_flag_t a;
+} ngx_http_fake_merge_loc_conf_t;
+
+
+static ngx_int_t ngx_http_fake_merge_add_variable(ngx_conf_t *cf);
+static ngx_int_t ngx_http_fake_merge_var(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_fake_merge_init(ngx_conf_t *cf);
+static void *ngx_http_fake_merge_create_main_conf(ngx_conf_t *cf);
+static void *ngx_http_fake_merge_create_loc_conf(ngx_conf_t *cf);
+static char *ngx_http_fake_merge_merge_loc_conf(ngx_conf_t *cf, void *prev,
+    void *conf);
+
+
+/* flow identify module configure struct */
+static ngx_http_module_t  ngx_http_fake_merge_module_ctx = {
+    ngx_http_fake_merge_init,             /* preconfiguration */
+    NULL,                                 /* postconfiguration */
+
+    ngx_http_fake_merge_create_main_conf, /* create main configuration */
+    NULL,                                 /* init main configuration */
+
+    NULL,                                 /* create server configuration */
+    NULL,                                 /* merge server configuration */
+
+    ngx_http_fake_merge_create_loc_conf,  /* create location configuration */
+    ngx_http_fake_merge_merge_loc_conf    /* merge location configuration */
+};
+
+
+/* flow identify module struct */
+ngx_module_t  ngx_http_fake_merge_module = {
+    NGX_MODULE_V1,
+    &ngx_http_fake_merge_module_ctx,      /* module context */
+    NULL,                                 /* module directives */
+    NGX_HTTP_MODULE,                      /* module type */
+    NULL,                                 /* init master */
+    NULL,                                 /* init module */
+    NULL,                                 /* init process */
+    NULL,                                 /* init thread */
+    NULL,                                 /* exit thread */
+    NULL,                                 /* exit process */
+    NULL,                                 /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_http_variable_t  ngx_http_fake_merge_variables[] = {
+
+    { ngx_string("fake_var"), NULL,
+      ngx_http_fake_merge_var, 0,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_null_string, NULL, NULL, 0, 0, 0 }
+};
+
+
+static ngx_int_t
+ngx_http_fake_merge_var(ngx_http_request_t *r, ngx_http_variable_value_t *v,
+    uintptr_t data)
+{
+    ngx_http_fake_merge_main_conf_t * fmcf;
+    static char *str[] = {"0", "1"};
+
+    fmcf = ngx_http_get_module_main_conf(r, ngx_http_fake_merge_module);
+    if (fmcf == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "get module main conf failed if fake_var");
+        return NGX_ERROR;
+    }
+
+    v->len = 1;
+    v->data = (u_char *) str[fmcf->a];
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t 
+ngx_http_fake_merge_add_variable(ngx_conf_t *cf)
+{
+    ngx_http_variable_t  *var, *v;
+
+    for (v = ngx_http_fake_merge_variables; v->name.len; v++) {
+        var = ngx_http_add_variable(cf, &v->name, v->flags);
+        if (var == NULL) {
+            return NGX_ERROR;
+        }
+        
+        var->get_handler = v->get_handler;
+        var->data = v->data;
+        v->index = ngx_http_get_variable_index(cf, &v->name);
+        if (v->index == (ngx_uint_t) NGX_ERROR) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+
+}
+
+
+/* postconfiguration init */
+static ngx_int_t ngx_http_fake_merge_init(ngx_conf_t *cf)
+{
+    ngx_http_fake_merge_loc_conf_t   *flcf;
+
+    flcf = ngx_http_conf_get_module_loc_conf(cf,
+                                              ngx_http_fake_merge_module);
+    if (flcf == NULL) {
+        return NGX_ERROR;
+    }
+
+    flcf->a = 1;
+ 
+    if (ngx_http_fake_merge_add_variable(cf) != NGX_OK) {
+        return NGX_ERROR;
+    }
+    
+    return NGX_OK;
+}
+
+
+/* create main configure */
+static void *ngx_http_fake_merge_create_main_conf(ngx_conf_t *cf)
+{
+    ngx_http_fake_merge_main_conf_t   *fmcf;
+
+    fmcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_fake_merge_main_conf_t));
+    if (fmcf == NULL) {
+        ngx_conf_log_error(NGX_LOG_ALERT, cf, 0, "create module main conf");
+        return NULL;
+    }
+
+    return fmcf;
+}
+
+
+/* create location configure */
+static void *ngx_http_fake_merge_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_http_fake_merge_loc_conf_t   *flcf;
+
+    flcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_fake_merge_loc_conf_t));
+    if (flcf == NULL) {
+        return NULL;
+    }
+
+    flcf->a = NGX_CONF_UNSET;
+
+    return flcf;
+}
+
+
+/* merge location configure */
+static char *
+ngx_http_fake_merge_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_http_fake_merge_loc_conf_t    *conf = child;
+    ngx_http_fake_merge_loc_conf_t    *prev = parent;
+    ngx_http_fake_merge_main_conf_t   *fmcf;
+
+    ngx_conf_merge_value(conf->a, prev->a, 0);
+
+    fmcf = ngx_http_conf_get_module_main_conf(cf,
+                                              ngx_http_fake_merge_module);
+    if (fmcf == NULL) {
+        ngx_conf_log_error(NGX_LOG_ALERT, cf, 0,
+                           "get module main conf failed in merge loc conf");
+        return NGX_CONF_ERROR;
+    }
+   
+
+    fmcf->a = conf->a;
+
+    return NGX_CONF_OK;
+}

--- a/modules/ngx_http_lua_module/util/build.sh
+++ b/modules/ngx_http_lua_module/util/build.sh
@@ -23,6 +23,7 @@ force=$2
             #--with-http_spdy_module \
 
 add_fake_shm_module="--add-module=$root/t/data/fake-shm-module"
+add_fake_merge_module="--add-module=$root/t/data/fake-merge-module"
 
 time ngx-build $force $version \
             --with-pcre-jit \
@@ -58,6 +59,7 @@ time ngx-build $force $version \
                 --add-module=$root/../stream-lua-nginx-module \
                 --add-module=$root/t/data/fake-module \
                 $add_fake_shm_module \
+                $add_fake_merge_module \
                 --add-module=$root/t/data/fake-delayed-load-module \
                 --with-http_gunzip_module \
                 --with-http_dav_module \


### PR DESCRIPTION
OpenResty official has been merged the [PR](https://github.com/openresty/lua-nginx-module/pull/1555), please see [Issue](https://github.com/openresty/lua-nginx-module/issues/1553) for details.

In the `ngx_http_lua_init_worker` function,  use the [`http_ctx.main_conf = cycle->conf_ctx->main_conf`](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_initworkerby.c#L89)  to initialize. However, the value of `main_conf` may be modified in the later by [`merge_srv_conf`](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_initworkerby.c#L227) or [`merge_loc_conf`](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_initworkerby.c#L256) functions, which may cause some unexpected problems.

Forexample `ngx_http_charset_merge_loc_conf` function will be modify the value of [ `mcf->recodes`](https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_charset_filter_module.c#L1595
).


```
static char *
ngx_http_charset_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
{
    ngx_http_charset_loc_conf_t *prev = parent;
    ngx_http_charset_loc_conf_t *conf = child;

    ngx_uint_t                     i;
    ngx_http_charset_recode_t     *recode;
    ngx_http_charset_main_conf_t  *mcf;

    if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                             &prev->types_keys, &prev->types,
                             ngx_http_charset_default_types)
        != NGX_OK)
    {
        return NGX_CONF_ERROR;
    }

    ngx_conf_merge_value(conf->override_charset, prev->override_charset, 0);
    ngx_conf_merge_value(conf->charset, prev->charset, NGX_HTTP_CHARSET_OFF);
    ngx_conf_merge_value(conf->source_charset, prev->source_charset,
                         NGX_HTTP_CHARSET_OFF);

    if (conf->charset == NGX_HTTP_CHARSET_OFF
        || conf->source_charset == NGX_HTTP_CHARSET_OFF
        || conf->charset == conf->source_charset)
    {
        return NGX_CONF_OK;
    }

    if (conf->source_charset >= NGX_HTTP_CHARSET_VAR
        || conf->charset >= NGX_HTTP_CHARSET_VAR)
    {
        return NGX_CONF_OK;
    }

    mcf = ngx_http_conf_get_module_main_conf(cf,
                                             ngx_http_charset_filter_module);
    recode = mcf->recodes.elts;
    for (i = 0; i < mcf->recodes.nelts; i++) {
        if (conf->source_charset == recode[i].src
            && conf->charset == recode[i].dst)
        {
            return NGX_CONF_OK;
        }
    }

    recode = ngx_array_push(&mcf->recodes);
    if (recode == NULL) {
        return NGX_CONF_ERROR;
    }

    recode->src = conf->source_charset;
    recode->dst = conf->charset;

    return NGX_CONF_OK;
}


```

Test Result

![image](https://user-images.githubusercontent.com/8215757/61871257-f3703500-af12-11e9-92dc-a123892e27d0.png)
