### PR TITLE
fix ngx_http_upstream_check_module.c:3471:55: error: variable 'last' …

### DIFF
--- a/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
+++ b/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
@@ -3468,13 +3468,12 @@ static void
 ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
     ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag)
 {
-    ngx_uint_t                       count, final, i, last;
+    ngx_uint_t                       count, i, last;
     ngx_http_upstream_check_peer_t  *peer;
 
     peer = peers->peers.elts;
 
     count = 0;
-    final = 0;
 
     for (i = 0; i < peers->peers.nelts; i++) {
 
@@ -3506,7 +3505,7 @@ ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
             count,
             ngx_http_upstream_check_shm_generation);
 
-    last = peers->peers.nelts - 1;
+    last = 0;
     for (i = 0; i < peers->peers.nelts; i++) {
 
         if (peer[i].delete) {
@@ -3525,8 +3524,8 @@ ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
                 continue;
             }
         }
-        
-        final++;
+
+        last++;
 
         b->last = ngx_snprintf(b->last, b->end - b->last,
                 "    {\"index\": %ui, "
@@ -3546,7 +3545,7 @@ ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
                 peer[i].shm->fall_count,
                 &peer[i].conf->check_type_conf->name,
                 peer[i].conf->port,
-                (final == count) ? "" : ",");
+                (last == count) ? "" : ",");
     }
 
     b->last = ngx_snprintf(b->last, b->end - b->last,


### PR DESCRIPTION
https://github.com/alibaba/tengine/commit/29cbde5641567b2b02253483a309faadf6e3185a#diff-74ba9ba29563a12b6a79e679a89dcf50

…set but not used [-Werror=unused-but-set-variable]

ngx_uint_t count, final, i, last;
^~~~
cc1: all warnings being treated as errors