### PR TITLE
Fixed dyups module build error when compiled with a higher version of OpenSSL.

### DIFF
--- a/modules/ngx_http_upstream_dyups_module/ngx_http_dyups_module.c
+++ b/modules/ngx_http_upstream_dyups_module/ngx_http_dyups_module.c
@@ -2363,14 +2363,15 @@ ngx_http_dyups_set_peer_session(ngx_peer_connection_t *pc, void *data)
     ssl_session = ctx->ssl_session;
     rc = ngx_ssl_set_session(pc->connection, ssl_session);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "set session: %p", ssl_session);
+
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "set session: %p:%d", ssl_session,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-                   SSL_get_ref(ssl_session)
-#else
-                   ssl_session ? ssl_session->references : 0
+                   ssl_session ? ssl_session->references : 0);
 #endif
-                  );
 
     return rc;
 }
@@ -2389,28 +2390,30 @@ ngx_http_dyups_save_peer_session(ngx_peer_connection_t *pc, void *data)
         return;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "save session: %p", ssl_session);
+
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "save session: %p:%d", ssl_session,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-                   SSL_get_ref(ssl_session)
-#else
-                   ssl_session->references
+                   ssl_session->references);
 #endif
-                  );
 
     old_ssl_session = ctx->ssl_session;
     ctx->ssl_session = ssl_session;
 
     if (old_ssl_session) {
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                       "old session: %p:%d",
-                       old_ssl_session,
+
 #if OPENSSL_VERSION_NUMBER >= 0x10100003L
-                       SSL_get_ref(old_ssl_session)
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "old session: %p", old_ssl_session);
+
 #else
-                       old_ssl_session->references
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "old session: %p:%d", old_ssl_session,
+                       old_ssl_session->references);
 #endif
-                      );
 
         ngx_ssl_free_session(old_ssl_session);
     }


### PR DESCRIPTION
* case https://github.com/alibaba/tengine/issues/1320

* Test Result

```
$TEST_NGINX_BINARY=/home/fakang.wfk/work/github/tengine/objs/nginx  prove -v -I tests/nginx-tests/nginx-tests/lib/   ./tests/nginx-tests/tengine-tests/dyups.t 
./tests/nginx-tests/tengine-tests/dyups.t .. 
1..78
your test dir is /tmp/nginx-test-rBfHqZqNJp at ./tests/nginx-tests/tengine-tests/dyups.t line 85.
ok 1 - 2013-02-26 16:51:46
ok 2 - 2013-02-26 17:30:07
ok 3 - 2013-02-26 17:35:19
ok 4 - 2013-02-26 16:51:51
ok 5 - 2013-02-26 16:51:54
ok 6 - 2013-02-26 17:36:42
ok 7 - 2013-02-26 17:36:46
ok 8 - 2013-02-26 17:02:13
ok 9 - 2013-02-26 17:36:59
ok 10 - 2013-02-26 17:40:24
ok 11 - 2013-02-26 17:40:28
ok 12 - 2013-02-26 17:40:32
ok 13 - 2013-02-26 17:40:36
ok 14 - 2013-02-26 17:40:39
ok 15 - 2013-02-26 17:41:09
ok 16 - 2013-02-26 16:51:57
ok 17 - 2013-02-26 16:52:00
ok 18 - 2013-02-26 17:00:54
ok 19 - 2013-02-26 17:42:27
ok 20 - 2013-02-26 17:44:34
ok 21 - 2013-02-26 17:08:00
ok 22 - 2013-02-26 17:08:04
ok 23 - 2013-02-26 17:45:03
ok 24 - 2013-02-26 17:05:20
ok 25 - 2013-02-26 17:05:30
ok 26 - 2013-06-20 17:46:03
ok 27 - 2013-02-28 16:27:45
ok 28 - 2013-02-28 16:27:49
ok 29 - 2013-02-28 16:27:52
ok 30 - 2013-02-28 16:28:44
ok 31 - 2013-02-28 16:23:41
ok 32 - 2013-02-28 16:23:48
ok 33 - 2013-02-28 16:25:32
ok 34 - 2013-02-28 16:25:35
ok 35 - 2013-03-04 15:53:41
ok 36 - 2013-03-04 15:53:44
ok 37 - 2013-03-04 15:53:46
ok 38 - 2013-03-04 15:53:49
ok 39 - 2013-03-05 15:36:40
ok 40 - 2013-03-05 15:37:25
ok 41 - 2013-03-05 16:13:11
ok 42 - 2013-03-05 16:13:23
ok 43 - 2013-03-25 10:29:48
ok 44 - 2013-03-25 10:39:02
ok 45 - 2013-03-25 10:39:28
ok 46 - 2013-03-25 10:49:44
ok 47 - 2013-03-25 10:49:47
ok 48 - 2013-03-25 10:50:41
ok 49 - 2013-03-25 10:49:51
ok 50 - 2014-06-15 07:45:30
ok 51 - 2014-06-15 07:45:33
ok 52 - 2014-06-15 07:45:40
ok 53 - 2014-06-15 07:45:43
ok 54 - 2013-02-26 16:51:46
ok 55 - 2013-02-26 17:30:07
ok 56 - 2013-02-26 17:35:19
ok 57 - 2013-02-26 16:51:51
ok 58 - 2013-02-26 17:02:13
ok 59 - 2013-02-26 17:36:59
ok 60 - 2013-02-26 17:40:24
ok 61 - 2013-02-26 17:41:09
ok 62 - 2013-02-26 17:00:54
ok 63 - 2013-02-26 17:42:27
ok 64 - 2013-02-26 17:45:03
ok 65 - 2013-02-26 17:05:20
ok 66 - 2013-02-26 17:46:03
ok 67 - 2013-02-28 16:27:45
ok 68 - 2013-02-28 16:23:41
ok 69 - 2013-03-04 15:53:41
ok 70 - 2013-03-05 15:36:40
ok 71 - 2013-03-05 15:37:25
ok 72 - 2013-03-05 16:13:11
ok 73 - 5/ 5 11:04:49 2014
ok 74 - 5/ 5 11:04:42 2014
ok 75 - 5/ 5 11:08:08 2014
ok 76 - 5/ 5 11:08:16 2014
ok 77 - no alerts
ok 78 - no sanitizer errors
ok
All tests successful.
Files=1, Tests=78,  7 wallclock secs ( 0.03 usr  0.01 sys +  0.13 cusr  0.09 csys =  0.26 CPU)
Result: PASS
```