### PR TITLE
Bugfix: avoid limit_req_zone directive in multiple variables problems.

### DIFF
--- a/src/http/modules/ngx_http_limit_req_module.c
+++ b/src/http/modules/ngx_http_limit_req_module.c
@@ -967,8 +967,10 @@ ngx_http_limit_req_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     for (i = 1; i < cf->args->nelts; i++) {
         if (i == 1 || value[i].data[0] == '$') {
             len += value[i].len;
-        }
-        break;
+
+        } else {
+            break;
+	}
     }
 
     p = ngx_palloc(cf->pool, len);
@@ -982,8 +984,10 @@ ngx_http_limit_req_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     for (i = 1; i < cf->args->nelts; i++) {
         if (i == 1 || value[i].data[0] == '$') {
             p = ngx_cpymem(p, value[i].data, value[i].len);
-        }
-        break;
+
+        } else {
+            break;
+	}
 
     }
 


### PR DESCRIPTION

* Test Result

``` 
$ TEST_NGINX_BINARY=/home/fakang.wfk/work/github/tengine/objs/nginx  prove -v -I ./tests/nginx-tests/nginx-tests/lib/  ./tests/nginx-tests/tengine-tests/limit_req_enhance.t
./tests/nginx-tests/tengine-tests/limit_req_enhance.t .. 
1..29
ok 1 - request accept
ok 2 - request accept
ok 3 - request accept
ok 4 - request accept
ok 5 - request accept
ok 6 - request rejected
ok 7 - request accept
ok 8 - request accept
ok 9 - request rejected
ok 10 - request rejected
ok 11 - delayed big request not truncated
ok 12 - negative excess
ok 13 - request accept
ok 14 - request accept
ok 15 - request accept
ok 16 - request accept
ok 17 - request accept
ok 18 - request accept
ok 19 - request accept
ok 20 - request accept
ok 21 - request accept
ok 22 - request accept
ok 23 - request accept
ok 24 - request accept
ok 25 - request accept
ok 26 - request accept
ok 27 - request rejected
ok 28 - no alerts
ok 29 - no sanitizer errors
ok
All tests successful.
Files=1, Tests=29,  2 wallclock secs ( 0.02 usr  0.01 sys +  0.09 cusr  0.03 csys =  0.15 CPU)
Result: PASS
```