### PR TITLE
Bugfix: a segmentation fault might occur in master process.

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -6958,6 +6958,10 @@ ngx_http_upstream_init_process(ngx_cycle_t *cycle)
     uscfp = umcf->upstreams.elts;
 
     for (i = 0; i < umcf->upstreams.nelts; i++) {
+	if (!(uscfp[i]->flags & T_NGX_HTTP_UPSTREAM_RANDOM_FLAG)) {
+	    continue;
+	}
+
         peers = uscfp[i]->peer.data;
 
         if (peers == NULL) {

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -133,6 +133,9 @@ typedef struct {
 #define NGX_HTTP_UPSTREAM_BACKUP        0x0020
 #define NGX_HTTP_UPSTREAM_MAX_CONNS     0x0100
 #define NGX_HTTP_UPSTREAM_ID            0x0040
+#if (T_NGX_HTTP_UPSTREAM_RANDOM)
+#define T_NGX_HTTP_UPSTREAM_RANDOM_FLAG 0x0200
+#endif
 
 
 struct ngx_http_upstream_srv_conf_s {

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -41,6 +41,9 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
     ngx_http_upstream_rr_peers_t  *peers, *backup;
 
     us->peer.init = ngx_http_upstream_init_round_robin_peer;
+#if (T_NGX_HTTP_UPSTREAM_RANDOM)
+    us->flags = T_NGX_HTTP_UPSTREAM_RANDOM_FLAG;
+#endif
 
     if (us->servers) {
         server = us->servers->elts;


### PR DESCRIPTION
* Test Result

```
$TEST_NGINX_BINARY=/home/fakang.wfk/work/github/tengine/objs/nginx  prove -v -I ./tests/nginx-tests/nginx-tests/lib/  ./tests/nginx-tests/nginx-tests/upstream_random.t  ./tests/nginx-tests/nginx-tests/upstream_ip_hash.t ./tests/nginx-tests/nginx-tests/upstream_least_conn.t ./tests/nginx-tests/nginx-tests/upstream.t  ./tests/nginx-tests/nginx-tests/upstream_hash.t ./tests/nginx-tests/nginx-tests/upstream_zone.t 
./tests/nginx-tests/nginx-tests/upstream_random.t ...... 
1..14
ok 1 - random
ok 2 - random two
ok 3 - random wait
ok 4 # skip long test
ok 5 # skip long test
ok 6 # skip long test
ok 7 - single one
ok 8 - single two
ok 9 - zone one
ok 10 - zone two
ok 11 - failures
ok 12 - failures two
ok 13 - no alerts
ok 14 - no sanitizer errors
ok
./tests/nginx-tests/nginx-tests/upstream_ip_hash.t ..... 
1..0 # SKIP no realip available
skipped: no realip available
./tests/nginx-tests/nginx-tests/upstream_least_conn.t .. 
1..4
ok 1 - balanced
ok 2 - least conn
ok 3 - no alerts
ok 4 - no sanitizer errors
ok
./tests/nginx-tests/nginx-tests/upstream.t ............. 
1..5
ok 1 - balanced
ok 2 - failures
ok 3 # skip long test
ok 4 - no alerts
ok 5 - no sanitizer errors
ok
./tests/nginx-tests/nginx-tests/upstream_hash.t ........ 
1..15
ok 1 - inconsistent
ok 2 - consistent
ok 3 - consistent weight
ok 4 - stable hash
ok 5 - stable hash - consistent
ok 6 - all hashed peers
ok 7 - no proxy_next_upstream
ok 8 - no proxy_next_upstream peers
ok 9 - proxy_next_upstream peers
ok 10 - all hashed peers - bad
ok 11 - all hashed peers - bad consistent
ok 12 - upstream name - busy
ok 13 - upstream name - busy consistent
ok 14 - no alerts
ok 15 - no sanitizer errors
ok
./tests/nginx-tests/nginx-tests/upstream_zone.t ........ 
1..4
ok 1 - upstream name
ok 2 - no live upstreams
ok 3 - no alerts
ok 4 - no sanitizer errors
ok
All tests successful.
Files=6, Tests=42,  4 wallclock secs ( 0.03 usr  0.02 sys +  0.56 cusr  0.27 csys =  0.88 CPU)
Result: PASS
```