### PR TITLE
Update Travis CI configuration to pass build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ addons:
 #       so we can run `make`, `make test`, `make install`.
 
 script:
-  - ./configure --enable-mods-static=all --with-ipv6 --with-http_v2_module
+  - ./configure --with-ipv6 --with-http_v2_module
   - make -j2
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - libgd2-xpm-dev
       - libgeoip-dev
       - libxslt1-dev
-      - libpcre++0
+      - libpcre++0v5
       - libpcre++-dev
       - liblua5.1-0-dev
       - libssl-dev


### PR DESCRIPTION
When building with Travis CI, I got some errors as bellow:

`E: Package 'libpcre++0' has no installation candidate`

and

`./configure: error: invalid option "--enable-mods-static=all"`

This pull request solved these problems by updating configuration file `.travis.yml`.

