### PR TITLE
bugfix: POST request with keepalive peer cause 400 response

### DIFF
--- a/modules/ngx_http_upstream_keepalive_module/ngx_http_upstream_keepalive_module.c
+++ b/modules/ngx_http_upstream_keepalive_module/ngx_http_upstream_keepalive_module.c
@@ -784,6 +784,10 @@ ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
         goto closed;
     }
 
+    if (!u->request_body_sent) {
+        goto closed;
+    }
+
     if (ngx_terminate || ngx_exiting) {
         goto closed;
     }


### PR DESCRIPTION
When the POST data sent is incomplete, the peer cannot be reused and should be discarded, otherwise the upstream server will discard some data from next request which use the same peer