### PR TITLE
Feature: Support DTLS offload

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -1477,4 +1477,4 @@ have=T_NGX_HTTP_UPSTREAM_ID . auto/have
 have=T_NGX_HTTP_IMPROVED_REWRITE . auto/have
 have=T_NGX_SHOW_INFO . auto/have
 have=T_NGX_HTTP_IMAGE_FILTER . auto/have
-
+have=T_NGX_HAVE_DTLS . auto/have

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -107,6 +107,17 @@ struct ngx_ssl_connection_s {
     unsigned                    in_early:1;
     unsigned                    early_preread:1;
     unsigned                    write_blocked:1;
+
+    
+
+#if (T_NGX_HAVE_DTLS)
+    unsigned                    bio_changed:1;
+    unsigned                    dtls_send:1;
+    unsigned                    client:1;
+    unsigned                    retrans_times;
+    ngx_event_t                *retrans;
+    u_char                      dtls_cookie_secret[32];
+#endif
 };
 
 
@@ -160,6 +171,10 @@ typedef struct {
 #define NGX_SSL_TLSv1_2  0x0020
 #define NGX_SSL_TLSv1_3  0x0040
 
+#if (T_NGX_HAVE_DTLS)
+#define NGX_SSL_DTLSv1   0x0080
+#define NGX_SSL_DTLSv1_2 0x0200
+#endif
 
 #define NGX_SSL_BUFFER   1
 #define NGX_SSL_CLIENT   2

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -931,9 +931,11 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 
 #if (NGX_STREAM_SSL)
+#if !(T_NGX_HAVE_DTLS)
         if (ls->ssl) {
             return "\"ssl\" parameter is incompatible with \"udp\"";
         }
+#endif
 #endif
 
         if (ls->so_keepalive) {

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -109,6 +109,11 @@ static ngx_conf_bitmask_t  ngx_stream_proxy_ssl_protocols[] = {
     { ngx_string("TLSv1.1"), NGX_SSL_TLSv1_1 },
     { ngx_string("TLSv1.2"), NGX_SSL_TLSv1_2 },
     { ngx_string("TLSv1.3"), NGX_SSL_TLSv1_3 },
+
+#if (T_NGX_HAVE_DTLS)
+    { ngx_string("DTLSv1"), NGX_SSL_DTLSv1 },
+    { ngx_string("DTLSv1.2"), NGX_SSL_DTLSv1_2 },
+#endif
     { ngx_null_string, 0 }
 };
 

--- a/tests/nginx-tests/tengine-tests/ngx_dtls.t
+++ b/tests/nginx-tests/tengine-tests/ngx_dtls.t
@@ -1,0 +1,69 @@
+#!/usr/bin/perl
+
+# Copyright (C) 2019 Alibaba Group Holding Limited
+
+# DTLS test.
+
+###############################################################################
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream_ssl/)->plan(1);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    server {
+        listen 127.0.0.1:%%PORT_8980_UDP%% reuseport ssl udp;
+        ssl_protocols dtlsv1;
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+        return "ok"; 
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 1024
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('localhost') {
+    system('openssl req -x509 -new '
+        . "-config $d/openssl.conf -subj /CN=$name/ "
+        . "-out $d/$name.crt -keyout $d/$name.key "
+        . ">>$d/openssl.out 2>&1") == 0
+        or die "Can't create certificate for $name: $!\n";
+}
+
+
+$t->run();
+my $ret1 = `openssl s_client -connect 127.0.0.1:8980 -dtls1 | grep "ok"`;
+
+like($ret1, qr/ok/, 'https success');
+$t->stop();


### PR DESCRIPTION
1. `reuseport` must be set for letting kernel delivering all udp packets of one session to same worker
2.`dtlsv1`and `dtlsv1.2` are supported.
3.  configure daemon
```
stream {
    server {
        listen 6443 ssl udp reuseport;
        ssl_protocols dtlsv1; #dtlsv1.2
        ssl_certificate      cert.pem;
        ssl_certificate_key  cert.key;
        return "xxx";
    }
}
```
4.test 
`openssl s_client -connect 127.0.0.1:6443 -dtls1`

5. Performance  

with same Linux server and same cipher:  
```
TLS qps: 7.2k
DTLS qps : 6.6k
```
