### PR TITLE
bugfix: reqstat record keys may duplicate if concurrency level is high

### DIFF
--- a/modules/ngx_http_reqstat_module/ngx_http_reqstat_module.c
+++ b/modules/ngx_http_reqstat_module/ngx_http_reqstat_module.c
@@ -1268,13 +1268,13 @@ ngx_http_reqstat_rbtree_lookup(ngx_shm_zone_t *shm_zone, ngx_str_t *val)
 
     hash = ngx_murmur_hash2(val->data, val->len);
 
-    node = ctx->sh->rbtree.root;
-    sentinel = ctx->sh->rbtree.sentinel;
-
     tp = ngx_timeofday();
     now = (ngx_msec_t) (tp->sec * 1000 + tp->msec);
 
     ngx_shmtx_lock(&ctx->shpool->mutex);
+
+    node = ctx->sh->rbtree.root;
+    sentinel = ctx->sh->rbtree.sentinel;
 
     while (node != sentinel) {
 


### PR DESCRIPTION
In ngx_http_reqstat_module:

* Root of the red-black tree may change when inserting a new record if rotation occurs. `ctx->sh->rbtree.root` is NOT read-only.
* The process of retrieving the tree root is not protected by mutex lock, which may introduce race condition.

In some rare cases, when the concurrency level is high enough, 
`ngx_http_reqstat_rbtree_lookup()` may fail to find an existing node and allocate a new one. This will cause repeated keys in the reqstat output.