### PR TITLE
Bug fix: response with "NONE" if no shared memory segments used

### DIFF
--- a/modules/ngx_slab_stat/README.md
+++ b/modules/ngx_slab_stat/README.md
@@ -40,6 +40,8 @@ slot:        1024(Bytes) total:           0 used:           0 reqs:           0 
 slot:        2048(Bytes) total:           0 used:           0 reqs:           0 fails:           0
 ```
 
+If no shared memory segments used, then "NONE" will be returned.
+
 Get information of shared memory usage
 -----------------------------------
 


### PR DESCRIPTION
Hello,

We are using this module on production, and found that if no shared memory segments used, then this modules does not response well: i.e. returns "empty body error", and got error in the error log (see attachment).

This patch fixed this behavior.

Please let me know, if this patch should be modify.

Thanks!

<img width="1435" alt="Screen Shot 2021-03-15 at 5 13 35 PM" src="https://user-images.githubusercontent.com/1643154/111167066-c8d46380-85b1-11eb-9af4-47284902ced6.png">
 