### PR TITLE
Support dynamic build for ngx_http_upstream_session_sticky_module

### DIFF
--- a/modules/ngx_http_upstream_session_sticky_module/config
+++ b/modules/ngx_http_upstream_session_sticky_module/config
@@ -1,3 +1,21 @@
-ngx_ddon_name=ngx_http_upstream_session_sticky_module
-HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_upstream_session_sticky_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upstream_session_sticky_module.c"
+ngx_addon_name=ngx_http_upstream_session_sticky_module
+
+# Build for recent nginx versions
+if test -n "$ngx_module_link"; then
+
+    ngx_module_type=HTTP_AUX_FILTER
+    ngx_module_name=ngx_http_upstream_session_sticky_module
+    ngx_module_incs=
+    ngx_module_deps=
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_upstream_session_sticky_module.c"
+    ngx_module_libs=
+
+    . auto/module
+
+# Build for older nginx versions
+else
+
+    HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_upstream_session_sticky_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upstream_session_sticky_module.c"
+
+fi


### PR DESCRIPTION
Adapted from `modules/ngx_http_concat_module/config`.