### PR TITLE
Fixes for resolv.conf detection and specification

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -1437,7 +1437,6 @@ have=T_NGX_MASTER_ENV . auto/have
 have=T_PIPES . auto/have
 have=T_NGX_INPUT_BODY_FILTER . auto/have
 have=T_NGX_GZIP_CLEAR_ETAG . auto/have
-have=T_NGX_RESOLVER_FILE . auto/have
 have=T_DEPRECATED . auto/have
 have=T_NGX_VARS . auto/have
 have=T_NGX_HTTP_STUB_STATUS . auto/have

--- a/auto/options
+++ b/auto/options
@@ -167,6 +167,8 @@ LUAJIT_LIB=$LUAJIT_LIB
 LUA_INC=$LUA_INC
 LUA_LIB=$LUA_LIB
 
+NGX_RESOLVER_FILE=
+
 USE_LIBXSLT=NO
 USE_LIBGD=NO
 USE_GEOIP=NO
@@ -308,6 +310,9 @@ $0: warning: the \"--with-ipv6\" option is deprecated"
         --with-luajit-lib=*)             LUAJIT_LIB="$value"        ;;
         --with-lua-inc=*)                LUA_INC="$value"           ;;
         --with-lua-lib=*)                LUA_LIB="$value"           ;;
+
+        # RESOLV
+        --with-resolve-file=*)           NGX_RESOLVER_FILE="$value" ;;
 
         # STUB
         --with-http_stub_status_module)  HTTP_STUB_STATUS=YES       ;;
@@ -545,6 +550,7 @@ cat << END
   --with-luajit-lib=PATH             set LuaJIT library path (where libluajit-5.1.{a,so} are located)
   --with-lua-inc=PATH                set Lua headers path (where lua.h/lauxlib.h/... are located)
   --with-lua-lib=PATH                set Lua library path (where liblua.{a,so} are located, only support Lua-5.1.x)
+  --with-resolve-file=PATH           unconditionally specify complete path to resolv.conf, e.g. /etc/resolv.conf
   --http-log-path=PATH               set http access log pathname
   --http-client-body-temp-path=PATH  set path to store
                                      http client request body temporary files
@@ -672,3 +678,4 @@ case ".$NGX_PERL_MODULES" in
         NGX_PERL_MODULES=$NGX_PREFIX/$NGX_PERL_MODULES
     ;;
 esac
+

--- a/auto/summary
+++ b/auto/summary
@@ -89,4 +89,10 @@ if [ $HTTP_SCGI = YES ]; then
     echo "  nginx http scgi temporary files: \"$NGX_HTTP_SCGI_TEMP_PATH\""
 fi
 
+if test -n "$NGX_RESOLVER_FILE"; then
+    echo "  resolv.conf file: \"$NGX_RESOLVER_FILE\""
+else
+    echo "  resolv.conf file: n/a"
+fi
+
 echo "$NGX_POST_CONF_MSG"

--- a/auto/unix
+++ b/auto/unix
@@ -1082,11 +1082,16 @@ ngx_feature_test='int fd;
                   if (open("/proc/stat", O_RDONLY) == -1) return 1;'
 . auto/feature
 
-
-# Auto read nameserver from /etc/resolv.conf.
- if [ -f "/etc/resolv.conf" ]; then
-    have=NGX_RESOLVER_FILE
-    value=\"/etc/resolv.conf\"
-    . auto/define
+if [ -z "$NGX_RESOLVER_FILE" ]; then
+   # Auto read nameserver from /etc/resolv.conf.
+   if [ -f "/etc/resolv.conf" ]; then
+     NGX_RESOLVER_FILE="/etc/resolv.conf"
+   fi
 fi
 
+if [ -n "$NGX_RESOLVER_FILE" ]; then
+    have=NGX_RESOLVER_FILE
+    value=\"$NGX_RESOLVER_FILE\"
+    . auto/define
+    have=T_NGX_RESOLVER_FILE . auto/have
+fi


### PR DESCRIPTION
This PR fixes #1546 and also allows to unconditionally specify location of `/etc/resolv.conf`, thus avoiding the file check for environments that might not *yet* have `/etc/resolv.conf` created; as well as allowing Tengine to have its own app-specific `resolv.conf` location customized.

E.g. 

    ./configure --with-resolve-file=/etc/resolv.conf

This disables file check during built and unconditionally uses the specified filename.

Summary example:

```
  ...
  nginx http fastcgi temporary files: "fastcgi_temp"
  nginx http uwsgi temporary files: "uwsgi_temp"
  nginx http scgi temporary files: "scgi_temp"
  resolv.conf file: "/etc/resolv.conf"
```