### PR TITLE
Fix outdated http_concat module installation documentation

### DIFF
--- a/docs/modules/ngx_http_concat_cn.md
+++ b/docs/modules/ngx_http_concat_cn.md
@@ -100,11 +100,11 @@
 
  1. 编译concat模块
          
-    configure  [--with-http_concat_module | --with-http_concat_module=shared]
+    configure  [--add-module=modules/ngx_http_concat_module | --add-dynamic-module=modules/ngx_http_concat_module]
 
-    --with-http_concat_module选项，concat模块将被静态编译到tengine中
+    --add-module=modules/ngx_http_concat_module选项，concat模块将被静态编译到tengine中
 
-    --with-http_concat_module=shared,concat模块将被编译成动态文件，采用动态模块的方式添加到tengine中
+    --add-dynamic-module=modules/ngx_http_concat_module,concat模块将被编译成动态文件，采用动态模块的方式添加到tengine中
 
  2. 编译,安装
 


### PR DESCRIPTION
The `--with-http_concat_module` configure option is no longer
available since Tengine 2.3.0.

Fixes #1558.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>