### PR TITLE
Fix(ngx_http_upstream_check_module): ngx_feature_libs need to be clea…

### DIFF
--- a/modules/ngx_http_upstream_check_module/config
+++ b/modules/ngx_http_upstream_check_module/config
@@ -2,6 +2,7 @@ ngx_feature="ngx_http_upstream_check_module"
 ngx_feature_name=
 ngx_feature_run=no
 ngx_feature_incs=
+ngx_feature_libs=
 ngx_feature_path="$ngx_addon_dir"
 ngx_feature_deps="$ngx_addon_dir/ngx_http_upstream_check_module.h"
 ngx_check_src="$ngx_addon_dir/ngx_http_upstream_check_module.c"


### PR DESCRIPTION
…red when compiled with some 3rdparty modules


When compiled with some 3rdparty modules, ngx_http_upstream_check_module may be affected by the dirty ngx_feature_libs and couldn't compiled successfully.

For example, https://github.com/openresty/stream-lua-nginx-module/blob/master/config
will try to make `ngx_feature_libs="-Wl,--require-defined=strerror"`, in some old ld, which has no "--require-defined" option, will failed to configured.  