### PR TITLE
Fix parse resolv.conf with IPv6%(interface)

### DIFF
--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -176,7 +176,7 @@ ngx_resolver_parse_resolv_address(ngx_conf_t *cf, ngx_file_t *file,
      line = p;
  
      for (/* void */; p < end; p++) {
-         if (*p == CR || *p == LF || p == (end - 1) || *(p + 1) == '#') {
+         if (*p == CR || *p == LF || p == (end - 1) || *(p + 1) == '#' || *(p + 1) == '%') {
  
              while (*line == ' ' || *line == '\t') {
                  line++;


### PR DESCRIPTION
Fix parse resolv.conf:

...
nameserver fe80::***%enp3s0
...