### PR TITLE
Fix(ngx_http_upstream_dyups_module): If a domain name contains multip…

### DIFF
--- a/modules/ngx_http_upstream_dyups_module/ngx_http_dyups_module.c
+++ b/modules/ngx_http_upstream_dyups_module/ngx_http_dyups_module.c
@@ -1699,7 +1699,7 @@ ngx_dyups_init_upstream(ngx_http_dyups_srv_conf_t *duscf, ngx_str_t *name,
 static void
 ngx_dyups_mark_upstream_delete(ngx_http_dyups_srv_conf_t *duscf)
 {
-    ngx_uint_t                      i;
+    ngx_uint_t                      i, j;
     ngx_http_upstream_server_t     *us;
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
@@ -1719,9 +1719,9 @@ ngx_dyups_mark_upstream_delete(ngx_http_dyups_srv_conf_t *duscf)
         us[i].down = 1;
 
 #if (NGX_HTTP_UPSTREAM_CHECK)
-        if (us[i].addrs) {
+        for (j = 0; j < us[i].naddrs; j++) {
             ngx_http_upstream_check_delete_dynamic_peer(&uscf->host,
-                                                        us[i].addrs);
+                                                        &us[i].addrs[j]);
         }
 #endif
     }


### PR DESCRIPTION
…le IP addresses, call them

如果upstrem下的server是域名的情况下，并且这个域名解析出来对应的多个ip地址，这里需要分别调用多次
因为添加的时候对多个ip分别进行了添加，启动定时器去做健康检查功能，所以删除的时候也需要同步删除。不然会存在定时器泄露，而定时器里面访问相关变量时会奔溃
