### PR TITLE
Bugfix: r->limit_rate does't work if limit_rate_set variable is not set

### DIFF
--- a/modules/ngx_http_tfs_module/ngx_http_tfs.c
+++ b/modules/ngx_http_tfs_module/ngx_http_tfs.c
@@ -1131,6 +1131,7 @@ ngx_http_tfs_send_response(ngx_http_request_t *r, ngx_http_tfs_t *t)
     r->write_event_handler = ngx_http_tfs_process_non_buffered_downstream;
 
     r->limit_rate = 0;
+    r->limit_rate_set = 1;
 
     if (clcf->tcp_nodelay && c->tcp_nodelay == NGX_TCP_NODELAY_UNSET) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "tcp_nodelay");

--- a/modules/ngx_multi_upstream_module/ngx_http_multi_upstream.c
+++ b/modules/ngx_multi_upstream_module/ngx_http_multi_upstream.c
@@ -62,6 +62,7 @@ ngx_http_multi_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t
                              ngx_http_upstream_process_non_buffered_downstream;
 
         r->limit_rate = 0;
+        r->limit_rate_set = 1;
 
         if (u->input_filter_init(u->input_filter_ctx) == NGX_ERROR) {
             ngx_http_upstream_finalize_request(r, u, NGX_ERROR);


### PR DESCRIPTION
tengine引入patch: https://github.com/alibaba/tengine/commit/c99b0416c349da9783e55c4b5f4df3ee743bbab3