### PR TITLE
fixed wrong resetting upstream flags in #T_NGX_HTTP_UPSTREAM_RANDOM

### DIFF
--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -42,7 +42,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
 
     us->peer.init = ngx_http_upstream_init_round_robin_peer;
 #if (T_NGX_HTTP_UPSTREAM_RANDOM)
-    us->flags = T_NGX_HTTP_UPSTREAM_RANDOM_FLAG;
+    us->flags |= T_NGX_HTTP_UPSTREAM_RANDOM_FLAG;
 #endif
 
     if (us->servers) {


### PR DESCRIPTION
* This bug was introduced by https://github.com/alibaba/tengine/pull/1379.
* Found by test case of dyups module:  the first test case of dyups.t failed.