### PR TITLE
Fix tests README.

### DIFF
--- a/tests/nginx-tests/README
+++ b/tests/nginx-tests/README
@@ -1,15 +1,5 @@
 Just test static modules:
 
-TEST_NGINX_BINARY=/path/to/nginx/sbin/nginx prove cases
+TEST_NGINX_BINARY=/path/to/nginx/sbin/nginx prove -I ./nginx-tests/lib/ tengine-tests
 TEST_NGINX_BINARY=/path/to/nginx/sbin/nginx prove nginx-tests
 
-Just test the dso modules:
-
-1. RUN the test command with TEST_NGINX_DSO=1
-TEST_NGINX_DSO=1 TEST_NGINX_BINARY=/path/to/nginx/sbin/nginx prove cases
-TEST_NGINX_DSO=1 TEST_NGINX_BINARY=/path/to/nginx/sbin/nginx prove dso-nginx-tests
-
-2. Add the dso module to the test script (The example module shared library should be under the modules directory):
-$t->set_dso("ngx_http_example_module", "ngx_http_example_module.so");
-...
-%%TEST_GLOBALS_DSO%%


### PR DESCRIPTION
* the directory was renamed by 27ffa0f.
* also the dso feature had deprecated by e4987ad.

Signed-off-by: u5surf <u5.horie@gmail.com>