### PR TITLE
enable more test cases for ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
        run: |
          sudo apt update
          sudo apt remove nginx libgd3
-         sudo apt install -y libgd-dev libgeoip-dev libxslt1-dev libpcre++0v5 libpcre++-dev liblua5.1-0-dev lua5.1 libperl-dev cpanminus
+         sudo apt install -y libgd-dev libgeoip-dev libxslt1-dev libpcre++0v5 libpcre++-dev liblua5.1-0-dev lua5.1 libperl-dev cpanminus libssl-dev
      - name: 'checkout luajit2'
        uses: actions/checkout@v3
        with:
@@ -43,7 +43,40 @@ jobs:
          LUAJIT_LIB: /usr/local/lib
          LUAJIT_INC: /usr/local/include/luajit-2.1
        run: |
-         ./configure --with-ld-opt="-Wl,-rpath,/usr/local/lib" --with-ipv6 --with-http_v2_module --add-module=./modules/ngx_backtrace_module --add-module=./modules/ngx_debug_pool --add-module=./modules/ngx_debug_timer --add-module=./modules/ngx_http_concat_module --add-module=./modules/ngx_http_footer_filter_module --add-module=./modules/ngx_http_lua_module --add-module=./modules/ngx_http_proxy_connect_module --add-module=./modules/ngx_http_reqstat_module --add-module=./modules/ngx_http_slice_module --add-module=./modules/ngx_http_sysguard_module --add-module=./modules/ngx_http_trim_filter_module --add-module=./modules/ngx_http_upstream_check_module --add-module=./modules/ngx_http_upstream_consistent_hash_module --add-module=./modules/ngx_http_upstream_dynamic_module --add-module=./modules/ngx_http_upstream_dyups_module --add-module=./modules/ngx_http_upstream_keepalive_module --add-module=./modules/ngx_http_upstream_session_sticky_module --add-module=./modules/ngx_http_upstream_vnswrr_module --add-module=./modules/ngx_http_user_agent_module --add-module=./modules/ngx_multi_upstream_module --add-module=./modules/ngx_slab_stat --without-http_upstream_keepalive_module
+         ./configure \
+            --with-ld-opt="-Wl,-rpath,/usr/local/lib" \
+            --with-ipv6 \
+            --with-http_ssl_module \
+            --with-http_v2_module \
+            --with-http_addition_module \
+            --with-stream \
+            --with-stream_ssl_module \
+            --with-stream_realip_module \
+            --with-stream_geoip_module \
+            --with-stream_ssl_preread_module \
+            --with-stream_sni \
+            --add-module=./modules/ngx_backtrace_module \
+            --add-module=./modules/ngx_debug_pool \
+            --add-module=./modules/ngx_debug_timer \
+            --add-module=./modules/ngx_http_concat_module \
+            --add-module=./modules/ngx_http_footer_filter_module \
+            --add-module=./modules/ngx_http_lua_module \
+            --add-module=./modules/ngx_http_proxy_connect_module \
+            --add-module=./modules/ngx_http_reqstat_module \
+            --add-module=./modules/ngx_http_slice_module \
+            --add-module=./modules/ngx_http_sysguard_module \
+            --add-module=./modules/ngx_http_trim_filter_module \
+            --add-module=./modules/ngx_http_upstream_check_module \
+            --add-module=./modules/ngx_http_upstream_consistent_hash_module \
+            --add-module=./modules/ngx_http_upstream_dynamic_module \
+            --add-module=./modules/ngx_http_upstream_dyups_module \
+            --add-module=./modules/ngx_http_upstream_keepalive_module \
+            --add-module=./modules/ngx_http_upstream_session_sticky_module \
+            --add-module=./modules/ngx_http_upstream_vnswrr_module \
+            --add-module=./modules/ngx_http_user_agent_module \
+            --add-module=./modules/ngx_multi_upstream_module \
+            --add-module=./modules/ngx_slab_stat \
+            --without-http_upstream_keepalive_module
          make -j2
          sudo make install
      - name: test
@@ -52,5 +85,5 @@ jobs:
          TEST_NGINX_BINARY: /usr/local/nginx/sbin/nginx
        run: |
          sudo cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
-         ls tengine-tests | grep -v resolver_file | xargs -I {} prove -v -Inginx-tests/lib tengine-tests/{}
+         prove -v -Inginx-tests/lib $(ls -d tengine-tests/* | grep -v resolver_file)
          sudo TEST_NGINX_BINARY=/usr/local/nginx/sbin/nginx prove -v -Inginx-tests/lib tengine-tests/resolver_file.t

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -875,7 +875,6 @@ ngx_stream_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
 #if (NGX_STREAM_SNI)
     ngx_conf_merge_value(conf->sni_force, prev->sni_force, 0);
-    if (!conf->listen)
 #endif
 
     conf->ssl.log = cf->log;

--- a/tests/nginx-tests/tengine-tests/ngx_dtls.t
+++ b/tests/nginx-tests/tengine-tests/ngx_dtls.t
@@ -45,7 +45,7 @@ EOF
 
 $t->write_file('openssl.conf', <<EOF);
 [ req ]
-default_bits = 1024
+default_bits = 2048
 encrypt_key = no
 distinguished_name = req_distinguished_name
 [ req_distinguished_name ]
@@ -63,7 +63,8 @@ foreach my $name ('localhost') {
 
 
 $t->run();
-my $ret1 = `openssl s_client -connect 127.0.0.1:8980 -dtls1 | grep "ok"`;
+my $ret1 = `openssl s_client -connect 127.0.0.1:8980 -dtls1 | grep -i "ok"`;
 
-like($ret1, qr/ok/, 'https success');
+# check string "Verification: OK"
+like($ret1, qr/ok/i, 'https success');
 $t->stop();


### PR DESCRIPTION
1. enable ssl module for ngx_dtls.t (this case is skipped before)
2. enable addition module for http_raw_uri_variable.t
3. fixed ngx_dtls.t: 1. too small certificate key error 2. check verification string with case insensitivity
5. fixed segfault found by ngx_dtls.t, for details see here: https://github.com/alibaba/tengine/pull/1205#discussion_r1019963385

---

With this pr, all test cases in [tests/nginx-tests/tengine-tests](https://github.com/alibaba/tengine/tree/master/tests/nginx-tests/tengine-tests) will be checked.