### PR TITLE
stream sni: fixed segfault that addr_conf->default_server is NULL

### DIFF
--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -872,6 +872,8 @@ ngx_stream_add_addrs6(ngx_conf_t *cf, ngx_stream_port_t *stport,
         addrs6[i].conf.addr_text = addr[i].opt.addr_text;
 
 #if (NGX_STREAM_SNI)
+        addrs6[i].conf.default_server = addr[i].default_server;
+
         if (addr[i].hash.buckets == NULL
             && (addr[i].wc_head == NULL
                 || addr[i].wc_head->hash.buckets == NULL)


### PR DESCRIPTION
If INET6 is enabled, ngx_stream_add_addrs6 is runned instead of ngx_stream_add_addrs. The stream sni logic forgot to initialize addr_conf->default_server in ngx_stream_add_addrs6().