### PR TITLE
SSL: disable T_NGX_HAVE_DTLS when build with boringssl

### DIFF
--- a/auto/lib/openssl/conf
+++ b/auto/lib/openssl/conf
@@ -177,3 +177,21 @@ END
     exit 1
 fi
 
+
+ngx_feature="OpenSSL DTLS support"
+ngx_feature_name=
+ngx_feature_run=no
+ngx_feature_incs="#include <openssl/ssl.h>"
+if [ $OPENSSL = NONE ]; then
+    ngx_feature_path=
+else
+    ngx_feature_path=$CORE_INCS
+fi
+ngx_feature_libs="-lssl -lcrypto"
+ngx_feature_test="SSL_CTX_set_cookie_generate_cb(NULL, NULL)"
+
+. auto/feature
+
+if [ $ngx_found = yes ]; then
+    have=T_NGX_HAVE_DTLS . auto/have
+fi

--- a/auto/modules
+++ b/auto/modules
@@ -1462,4 +1462,3 @@ have=T_NGX_HTTP_UPSTREAM_ID . auto/have
 have=T_NGX_HTTP_IMPROVED_REWRITE . auto/have
 have=T_NGX_SHOW_INFO . auto/have
 have=T_NGX_HTTP_IMAGE_FILTER . auto/have
-have=T_NGX_HAVE_DTLS . auto/have


### PR DESCRIPTION
boringssl missing SSL_CTX_set_cookie_generate_cb