### PR TITLE
[tengine] Resolver: fixed compliation failure when missing /etc/resolv.conf file

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -1085,8 +1085,6 @@ ngx_feature_test='int fd;
 
 # Auto read nameserver from /etc/resolv.conf.
  if [ -f "/etc/resolv.conf" ]; then
-    have=NGX_RESOLVER_FILE
-    value=\"/etc/resolv.conf\"
-    . auto/define
+    have=NGX_RESOLVER_FILE value="\"/etc/resolv.conf\"" . auto/define
 fi
 

--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -141,28 +141,28 @@ ngx_resolver_parse_resolv_address(ngx_conf_t *cf, ngx_file_t *file,
      ssize_t         n;
      ngx_str_t      *address;
      ngx_array_t     addrs;
- 
+
      if (ngx_array_init(&addrs, cf->pool, 2, sizeof(ngx_str_t)) != NGX_OK) {
          return NGX_ERROR;
      }
- 
+
      if (ngx_fd_info(file->fd, &file->info) == NGX_FILE_ERROR) {
          ngx_log_error(NGX_LOG_EMERG, cf->log, ngx_errno,
                        ngx_fd_info_n " \"%s\" failed", file->name.data);
      }
- 
+
      file_size = ngx_file_size(&file->info);
- 
+
      buf = ngx_pnalloc(cf->pool, file_size + 1);
      if (buf == NULL) {
          return NGX_ERROR;
      }
- 
+
      n = ngx_read_file(file, buf, file_size, 0);
      if (n == NGX_ERROR) {
          return NGX_ERROR;
      }
- 
+
      if (n != file_size) {
          ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                             ngx_read_file_n " returned "
@@ -170,29 +170,29 @@ ngx_resolver_parse_resolv_address(ngx_conf_t *cf, ngx_file_t *file,
                             n, file_size);
          return NGX_ERROR;
      }
- 
+
      p = buf;
      end = buf + file_size;
      line = p;
- 
+
      for (/* void */; p < end; p++) {
          if (*p == CR || *p == LF || p == (end - 1) || *(p + 1) == '#') {
- 
+
              while (*line == ' ' || *line == '\t') {
                  line++;
              }
- 
+
              if (ngx_strncmp(line, "nameserver", sizeof("nameserver") - 1)
                  == 0)
              {
                  line += sizeof("nameserver") - 1;
- 
+
                  while (*line == ' ' || *line == '\t') {
                      line++;
                  }
- 
+
                  line_end = p;
- 
+
                  while (*line_end == ' ' || *line_end == '\t'
                         || *line_end == CR || *line_end == LF)
                  {
@@ -200,14 +200,14 @@ ngx_resolver_parse_resolv_address(ngx_conf_t *cf, ngx_file_t *file,
                  }
                  /* put a null character for string parse */
                  *++line_end = '\0';
- 
+
                  address = ngx_array_push(&addrs);
                  if (address == NULL) {
                      return NGX_ERROR;
                  }
- 
+
  #if (NGX_HAVE_INET6)
- 
+
                  if (ngx_strlchr(line, line_end, ':')) {
                      address->len = line_end - line + 2;
                      address->data = ngx_palloc(cf->pool, address->len + 2);
@@ -217,7 +217,7 @@ ngx_resolver_parse_resolv_address(ngx_conf_t *cf, ngx_file_t *file,
                      address->data[0] = '[';
                      ngx_memcpy(address->data + 1, line, address->len - 2);
                      address->data[address->len - 1] = ']';
- 
+
                  } else {
  #endif
                      address->data = line;
@@ -226,41 +226,41 @@ ngx_resolver_parse_resolv_address(ngx_conf_t *cf, ngx_file_t *file,
                  }
  #endif
              }
- 
+
              line = p + 1;
          }
      }
- 
+
      *names = addrs.elts;
      *num = addrs.nelts;
- 
+
      return NGX_OK;
  }
- 
- 
+
+
  ngx_int_t
  ngx_resolver_read_resolv_file(ngx_conf_t *cf, ngx_str_t *filename, ngx_str_t **names, ngx_uint_t *n)
  {
      ngx_int_t       rc;
      ngx_file_t      file;
- 
+
      ngx_memzero(&file, sizeof(ngx_file_t));
- 
+
      file.name.data = filename->data;
      file.name.len = filename->len;
      file.log = cf->log;
- 
+
      file.fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY,
                              NGX_FILE_OPEN, NGX_FILE_DEFAULT_ACCESS);
- 
+
      if (file.fd == NGX_INVALID_FILE) {
          ngx_log_error(NGX_LOG_ERR, cf->log, ngx_errno,
                        ngx_open_file_n " \"%s\" failed", file.name.data);
          return NGX_ERROR;
      }
- 
+
      rc = ngx_resolver_parse_resolv_address(cf, &file, names, n);
- 
+
      if (ngx_close_file(file.fd) == NGX_FILE_ERROR) {
          ngx_log_error(NGX_LOG_ALERT, cf->log, ngx_errno,
                        ngx_close_file_n " \"%s\" failed", file.name.data);
@@ -280,7 +280,11 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
     ngx_pool_cleanup_t         *cln;
     ngx_resolver_connection_t  *rec;
 #if (T_NGX_RESOLVER_FILE)
+#if defined(NGX_RESOLVER_FILE)
     ngx_str_t default_file = ngx_string(NGX_RESOLVER_FILE);
+#else
+    ngx_str_t default_file = ngx_null_string;
+#endif
 #endif
 
     r = ngx_pcalloc(cf->pool, sizeof(ngx_resolver_t));
@@ -345,9 +349,11 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
 
 #if (T_NGX_RESOLVER_FILE)
     if (names == NULL) {
-        if (ngx_resolver_read_resolv_file(cf, &default_file, &names, &n) != NGX_OK) {
+        if (default_file.len != 0
+            && ngx_resolver_read_resolv_file(cf, &default_file, &names, &n) != NGX_OK)
+        {
             return NULL;
-         }
+        }
      }
  #endif
 


### PR DESCRIPTION
error info:

``` shell
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -Wno-deprecated-declarations                          -fsanitize=address -g3 -O0 -DNDK_SET_VAR -I ./modules/ngx_debug_pool -I src/core -I src/event -I src/event/modules -I src/os/unix -I src/proc -I ./modules/ngx_http_lua_module/src/api -I ./modules/ngx_http_upstream_check_module -I /data/openssl/.openssl/include -I objs \
        -o objs/src/core/ngx_resolver.o \
        src/core/ngx_resolver.c
In file included from src/core/ngx_core.h:55,
                 from src/core/ngx_resolver.c:9:
src/core/ngx_resolver.c: In function ‘ngx_resolver_create’:
src/core/ngx_resolver.c:283:41: error: ‘NGX_RESOLVER_FILE’ undeclared (first use in this function); did you mean ‘T_NGX_RESOLVER_FILE’?
  283 |     ngx_str_t default_file = ngx_string(NGX_RESOLVER_FILE);
      |                                         ^~~~~~~~~~~~~~~~~
src/core/ngx_string.h:40:38: note: in definition of macro ‘ngx_string’
   40 | #define ngx_string(str)     { sizeof(str) - 1, (u_char *) str }
      |                                      ^~~
src/core/ngx_resolver.c:283:41: note: each undeclared identifier is reported only once for each function it appears in
  283 |     ngx_str_t default_file = ngx_string(NGX_RESOLVER_FILE);
      |                                         ^~~~~~~~~~~~~~~~~
src/core/ngx_string.h:40:38: note: in definition of macro ‘ngx_string’
   40 | #define ngx_string(str)     { sizeof(str) - 1, (u_char *) str }
      |                                      ^~~
make[1]: *** [objs/Makefile:876: objs/src/core/ngx_resolver.o] Error 1
make[1]: Leaving directory '/data/nandsky-tengine'
make: *** [Makefile:8: build] Error 2
```