### PR TITLE
Add CI workflow for Linux ARM64

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -35,7 +35,7 @@ jobs:
           install: |
             set -x
             apt-get update -q -y
-            apt-get install -q -y make gcc g++ clang libgd-dev libgeoip-dev libxslt1-dev libpcre++0v5 libpcre++-dev liblua5.1-0-dev lua5.1 libperl-dev cpanminus libssl-dev
+            apt-get install -q -y make gcc g++ clang libgd-dev libgeoip-dev libxslt1-dev libpcre++0v5 libpcre++-dev liblua5.1-0-dev lua5.1 libperl-dev cpanminus libssl-dev file
           run: |
             set -x
             cd /tengine
@@ -85,13 +85,4 @@ jobs:
               --without-http_upstream_keepalive_module
             make -j2
             make install
-            echo "Test..."
-            cd tests/nginx-tests
-            export TEST_NGINX_BINARY=/usr/local/nginx/sbin/nginx
-            cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
-            prove -v -Inginx-tests/lib $(ls -d tengine-tests/* | grep -v resolver_file)
-            prove -v -Inginx-tests/lib tengine-tests/resolver_file.t
-            cd ../test-nginx
-            cpanm --notest Shell Test::Base Test::LongString List::MoreUtils LWP::UserAgent HTTP::Response  > build.log 2>&1 || (cat build.log && exit 1)
-            mkdir t
-            PATH=/usr/local/nginx/sbin:$PATH prove -v -Itest-nginx/lib cases/
+            file /usr/local/nginx/sbin/nginx | grep aarch64

--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build-arm64:
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+         - { compiler: GNU,  CC: gcc,  CXX: g++}
+         - { compiler: LLVM, CC: clang, CXX: clang++}
+    steps:
+      - name: Checkout Tengine
+        uses: actions/checkout@v3
+
+      - name: 'checkout luajit2'
+        uses: actions/checkout@v3
+        with:
+          repository: openresty/luajit2
+          path: luajit2
+
+      - name: Compile with ${{ matrix.compiler.compiler }}
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          dockerRunArgs: |
+            --volume "${PWD}:/tengine"
+          install: |
+            set -x
+            apt-get update -q -y
+            apt-get install -q -y make gcc g++ clang libgd-dev libgeoip-dev libxslt1-dev libpcre++0v5 libpcre++-dev liblua5.1-0-dev lua5.1 libperl-dev cpanminus libssl-dev
+          run: |
+            set -x
+            cd /tengine
+            echo "Build luajit2"
+            cd luajit2
+            make -j2
+            make install
+            cd ..
+            echo "Build tengine"
+            export CC=${{ matrix.compiler.CC }}
+            export CXX=${{ matrix.compiler.CXX }}
+            export LUAJIT_LIB=/usr/local/lib
+            export LUAJIT_INC=/usr/local/include/luajit-2.1
+            ./configure \
+              --with-ld-opt="-Wl,-rpath,/usr/local/lib" \
+              --with-ipv6 \
+              --with-http_ssl_module \
+              --with-http_v2_module \
+              --with-http_addition_module \
+              --with-stream \
+              --with-stream_ssl_module \
+              --with-stream_realip_module \
+              --with-stream_geoip_module \
+              --with-stream_ssl_preread_module \
+              --with-stream_sni \
+              --add-module=./modules/ngx_backtrace_module \
+              --add-module=./modules/ngx_debug_pool \
+              --add-module=./modules/ngx_debug_timer \
+              --add-module=./modules/ngx_http_concat_module \
+              --add-module=./modules/ngx_http_footer_filter_module \
+              --add-module=./modules/ngx_http_lua_module \
+              --add-module=./modules/ngx_http_proxy_connect_module \
+              --add-module=./modules/ngx_http_reqstat_module \
+              --add-module=./modules/ngx_http_slice_module \
+              --add-module=./modules/ngx_http_sysguard_module \
+              --add-module=./modules/ngx_http_trim_filter_module \
+              --add-module=./modules/ngx_http_upstream_check_module \
+              --add-module=./modules/ngx_http_upstream_consistent_hash_module \
+              --add-module=./modules/ngx_http_upstream_dynamic_module \
+              --add-module=./modules/ngx_http_upstream_dyups_module \
+              --add-module=./modules/ngx_http_upstream_keepalive_module \
+              --add-module=./modules/ngx_http_upstream_session_sticky_module \
+              --add-module=./modules/ngx_http_upstream_vnswrr_module \
+              --add-module=./modules/ngx_http_user_agent_module \
+              --add-module=./modules/ngx_multi_upstream_module \
+              --add-module=./modules/ngx_slab_stat \
+              --without-http_upstream_keepalive_module
+            make -j2
+            make install
+            echo "Test..."
+            cd tests/nginx-tests
+            export TEST_NGINX_BINARY=/usr/local/nginx/sbin/nginx
+            cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
+            prove -v -Inginx-tests/lib $(ls -d tengine-tests/* | grep -v resolver_file)
+            prove -v -Inginx-tests/lib tengine-tests/resolver_file.t
+            cd ../test-nginx
+            cpanm --notest Shell Test::Base Test::LongString List::MoreUtils LWP::UserAgent HTTP::Response  > build.log 2>&1 || (cat build.log && exit 1)
+            mkdir t
+            PATH=/usr/local/nginx/sbin:$PATH prove -v -Itest-nginx/lib cases/


### PR DESCRIPTION
This CI workflow is adapted from the Linux x86_64 [one](https://github.com/alibaba/tengine/blob/master/.github/workflows/ci.yml).

Follow-up of: https://github.com/alibaba/tengine/pull/1538 

The build passes but some of the tests fail.
Results could be seen in my fork: https://github.com/martin-g/tengine/actions