### PR TITLE
[tengine] StreamSNI: fixed segfault with multi stream server blocks

### DIFF
--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -632,11 +632,12 @@ found:
     if (addr == NULL) {
         return NGX_ERROR;
     }
+
     ngx_memset(addr, 0, sizeof(ngx_stream_conf_addr_t));
     addr->opt = *listen;
     addr->default_server = cscf;
 
-    return ngx_stream_add_server(cf, cscf, &addr[i]);
+    return ngx_stream_add_server(cf, cscf, addr);
 
 #else
 


### PR DESCRIPTION
(issue #1697).

A configuration like

```
stream {
    server {
        listen      unix:/tmp/nginx-test-YIXVQOSR0a/unix.sock proxy_protocol;
        return      $remote_addr;
    }

    server {
        listen      unix:/tmp/nginx-test-YIXVQOSR0a/unix2.sock proxy_protocol;
        return      $remote_addr;
    }
}
```
 resulted in a segmentation fault.