### PR TITLE
openssl async: fix test case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
          ./configure \
             --with-ld-opt="-Wl,-rpath,/usr/local/lib" \
             --with-ipv6 \
+            --with-openssl-async \
             --with-http_ssl_module \
             --with-http_v2_module \
             --with-http_addition_module \

--- a/auto/options
+++ b/auto/options
@@ -627,7 +627,7 @@ cat << END
 
   --with-openssl=DIR                 set path to OpenSSL library sources
   --with-openssl-opt=OPTIONS         set additional build options for OpenSSL
-
+  --with-openssl-async               enable asynchronous SSL/TLS mode for OpenSSL library
   --with-debug                       enable debug logging
 
 END

--- a/tests/nginx-tests/tengine-tests/http_ssl_asynchronous_mode.t
+++ b/tests/nginx-tests/tengine-tests/http_ssl_asynchronous_mode.t
@@ -25,7 +25,7 @@ eval {
     require IO::Socket::SSL;
 };
 
-my $t = Test::Nginx->new()->has(qw/http http_ssl/)
+my $t = Test::Nginx->new()->has(qw/http http_ssl openssl-async/)
     ->has_daemon('openssl');
 
 $t->plan(2)->write_file_expand('nginx.conf', <<'EOF');


### PR DESCRIPTION
1. added configuration check for test case
2. move case to tengine-tests/
3. added description of help usage of --with-openssl-async
4. enable --with-openssl-async in ci.yml to test this feature