### PR TITLE
Give unique names to the CI workflows

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Linux ARM64 CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Linux AMD64 CI
 
 on:
   push:


### PR DESCRIPTION
In #1699 I forgot to give a unique name to the new CI workflow for Linux ARM64 and now both workflows appear with the same name in the Github UI.