### PR TITLE
fixed memory leak of ssl session reuse in dyups and session sticky module

### DIFF
--- a/modules/ngx_http_upstream_dyups_module/ngx_http_dyups_module.c
+++ b/modules/ngx_http_upstream_dyups_module/ngx_http_dyups_module.c
@@ -56,7 +56,8 @@ typedef struct {
     ngx_event_get_peer_pt                get;
     ngx_event_free_peer_pt               free;
 #if (NGX_HTTP_SSL)
-    ngx_ssl_session_t                   *ssl_session;
+    ngx_event_set_peer_session_pt        original_set_session;
+    ngx_event_save_peer_session_pt       original_save_session;
 #endif
 } ngx_http_dyups_ctx_t;
 
@@ -156,6 +157,7 @@ static ngx_int_t ngx_http_dyups_set_peer_session(ngx_peer_connection_t *pc,
     void *data);
 static void ngx_http_dyups_save_peer_session(ngx_peer_connection_t *pc,
     void *data);
+static void ngx_http_dyups_free_peer_sessions(void *data);
 #endif
 
 
@@ -1731,6 +1733,12 @@ ngx_dyups_mark_upstream_delete(ngx_http_dyups_srv_conf_t *duscf)
 #endif
     }
 
+#if (NGX_HTTP_SSL)
+    if (uscf->peer.data) {
+        ngx_http_dyups_free_peer_sessions(uscf->peer.data);
+    }
+#endif
+
     uscfp[duscf->idx] = &ngx_http_dyups_deleted_upstream;
     duscf->deleted = NGX_DYUPS_DELETING;
 }
@@ -1962,6 +1970,8 @@ ngx_http_dyups_init_peer(ngx_http_request_t *r,
     r->upstream->peer.free = ngx_http_dyups_free_peer;
 
 #if (NGX_HTTP_SSL)
+    ctx->original_set_session = r->upstream->peer.set_session;
+    ctx->original_save_session = r->upstream->peer.save_session;
     r->upstream->peer.set_session = ngx_http_dyups_set_peer_session;
     r->upstream->peer.save_session = ngx_http_dyups_save_peer_session;
 #endif
@@ -2371,23 +2381,7 @@ ngx_http_dyups_set_peer_session(ngx_peer_connection_t *pc, void *data)
 {
     ngx_http_dyups_ctx_t  *ctx = data;
 
-    ngx_int_t            rc;
-    ngx_ssl_session_t   *ssl_session;
-
-    ssl_session = ctx->ssl_session;
-    rc = ngx_ssl_set_session(pc->connection, ssl_session);
-
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "set session: %p", ssl_session);
-
-#else
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "set session: %p:%d", ssl_session,
-                   ssl_session ? ssl_session->references : 0);
-#endif
-
-    return rc;
+    return ctx->original_set_session(pc, ctx->data);
 }
 
 
@@ -2396,40 +2390,45 @@ ngx_http_dyups_save_peer_session(ngx_peer_connection_t *pc, void *data)
 {
     ngx_http_dyups_ctx_t  *ctx = data;
 
-    ngx_ssl_session_t   *old_ssl_session, *ssl_session;
+    ctx->original_save_session(pc, ctx->data);
+    return;
+}
 
-    ssl_session = ngx_ssl_get_session(pc->connection);
+static void
+ngx_http_dyups_free_peer_session(void *data)
+{
+    ngx_ssl_session_t               *old_ssl_session;
+    ngx_http_upstream_rr_peer_t     *peer = data;
 
-    if (ssl_session == NULL) {
-        return;
-    }
-
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "save session: %p", ssl_session);
-
-#else
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "save session: %p:%d", ssl_session,
-                   ssl_session->references);
-#endif
-
-    old_ssl_session = ctx->ssl_session;
-    ctx->ssl_session = ssl_session;
+    old_ssl_session = peer->ssl_session;
+    peer->ssl_session = NULL;
 
     if (old_ssl_session) {
-
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                       "old session: %p", old_ssl_session);
-
-#else
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                       "old session: %p:%d", old_ssl_session,
-                       old_ssl_session->references);
-#endif
-
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                       "[dyups] free old session: %p", old_ssl_session);
         ngx_ssl_free_session(old_ssl_session);
+    }
+}
+
+
+static void
+ngx_http_dyups_free_peer_sessions(void *data)
+{
+    ngx_http_upstream_rr_peer_t     *peer;
+    ngx_http_upstream_rr_peers_t    *peers = data;
+
+    if (peers->single) {
+        ngx_http_dyups_free_peer_session(peers->peer);
+
+    } else {
+
+        for (peer = peers->peer; peer; peer = peer->next) {
+            ngx_http_dyups_free_peer_session(peer);
+        }
+    }
+
+    if (peers->next) {
+        ngx_http_dyups_free_peer_sessions(peers->next);
     }
 }
 

--- a/tests/nginx-tests/tengine-tests/dyups.t
+++ b/tests/nginx-tests/tengine-tests/dyups.t
@@ -13,7 +13,7 @@ use Test::Nginx;
 
 my $NGINX = defined $ENV{TEST_NGINX_BINARY} ? $ENV{TEST_NGINX_BINARY}
         : '../nginx/objs/nginx';
-my $t = Test::Nginx->new()->plan(77);
+my $t = Test::Nginx->new()->has(qw/http_ssl dyups with-debug/)->plan(105);
 
 sub mhttp_get($;$;$;%) {
     my ($url, $host, $port, %extra) = @_;
@@ -564,6 +564,172 @@ unlike(mhttp_get('/', 'dyhost', 8080), qr/8088/m, '5/ 5 11:04:42 2014');
 $t->stop();
 unlink("/tmp/dyupssocket");
 
+###############################################################################
+# test ssl session reuse
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+worker_processes 1;
+
+events {
+    accept_mutex off;
+}
+
+error_log %%TESTDIR%%/error_ssl.log debug;
+
+http {
+    resolver_timeout 500ms;
+
+    server {
+        listen 127.0.0.1:8080;
+
+        location / {
+            proxy_pass https://$host;
+            proxy_set_header Connection close;
+            proxy_ssl_session_reuse on;
+            proxy_next_upstream http_500;
+        }
+    }
+
+    server {
+        listen 127.0.0.01:8087 ssl;
+        listen 127.0.0.01:8088 ssl;
+
+        error_log off;
+
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+
+        if ($arg_fail) {
+            return 500;
+        }
+
+        return 200 "$server_port $ssl_session_reused";
+    }
+
+    server {
+        listen 127.0.0.01:8089 ssl;
+        listen 127.0.0.01:8090 ssl;
+
+        error_log off;
+
+        ssl_certificate_key localhost.key;
+        ssl_certificate localhost.crt;
+
+        return 200 "$server_port $ssl_session_reused";
+    }
+
+    server {
+        listen 8081;
+        location / {
+            dyups_interface;
+        }
+    }
+}
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('localhost') {
+    system('openssl req -x509 -new '
+        . "-config '$d/openssl.conf' -subj '/CN=$name/' "
+        . "-out '$d/$name.crt' -keyout '$d/$name.key' "
+        . ">>$d/openssl.out 2>&1") == 0
+        or die "Can't create certificate for $name: $!\n";
+}
+
+mrun($t);
+
+my $count;
+my $errlog;
+
+# test single server
+print("+ ssl session reuse: upstream: single server\n");
+like(mhttp_post('/upstream/dyhost', 'server 127.0.0.1:8088;', 8081), qr/success/m, 'add single server');
+sleep(1);
+like(mhttp_get('/', 'dyhost', 8080), qr/8088 \./m, 'ssl session not reused and saved');
+like(mhttp_get('/', 'dyhost', 8080), qr/8088 r/m, 'ssl session reused');
+like(mhttp_get('/', 'dyhost', 8080), qr/8088 r/m, 'ssl session reused');
+like(mhttp_delete('/upstream/dyhost', 8081), qr/success/m, 'delete upstream of single server');
+sleep(1);
+
+$errlog = $t->read_file("error_ssl.log");
+$count = () = $errlog =~ /\[dyups\] free old session:/g;
+is($count, 1, "debug log: free ssl session");
+
+unlike(mhttp_get('/', 'dyhost', 8080), qr/8088/m, 'single server has been deleted');
+like(mhttp_post('/upstream/dyhost', 'server 127.0.0.1:8088;', 8081), qr/success/m, 'add single server again');
+sleep(1);
+like(mhttp_get('/', 'dyhost', 8080), qr/8088 \./m, 'ssl session not reused (ssl session has been freed)');
+like(mhttp_get('/', 'dyhost', 8080), qr/8088 r/m, 'ssl session reused');
+
+# test single server and single backup server
+
+print("+ ssl session reuse: upstream: single server and single backup server\n");
+like(mhttp_post('/upstream/dyhost', 'server 127.0.0.1:8088 fail_timeout=60s max_fails=1; server 127.0.0.1:8089 backup;', 8081), qr/success/m, 'update upstream dyhost with single server and single backup');
+sleep(1);
+
+$errlog = $t->read_file("error_ssl.log");
+$count = () = $errlog =~ /\[dyups\] free old session:/g;
+is($count, 2, "debug log: free ssl session after updating upstream dyhost");
+
+like(mhttp_get('/', 'dyhost', 8080), qr/8088 \./m, 'ssl session not reused, save ssl session');
+like(mhttp_get('/?fail=yes', 'dyhost', 8080), qr/8089 \./m, 'try backup: ssl session not reused and saved');
+like(mhttp_get('/', 'dyhost', 8080), qr/8089 r/m, 'backup server: ssl session reused');
+like(mhttp_delete('/upstream/dyhost', 8081), qr/success/m, 'delete upstream of single server and single backup server');
+sleep(1);
+
+$errlog = $t->read_file("error_ssl.log");
+$count = () = $errlog =~ /\[dyups\] free old session:/g;
+is($count, 4, "debug log: free ssl session");
+
+# test multiple servers and multiple backup servers
+print("+ ssl session reuse: upstream: multiple servers and multiple backup servers\n");
+like(mhttp_post('/upstream/dyhost2',
+        'server 127.0.0.1:8087 fail_timeout=60s max_fails=1;
+         server 127.0.0.1:8088 fail_timeout=60s max_fails=1;
+         server 127.0.0.1:8089 backup;
+         server 127.0.0.1:8090 backup;',
+         8081),
+     qr/success/m,
+     'add upstream of multiple servers and backups');
+my $r;
+$r = mhttp_get('/', 'dyhost2', 8080) .
+     mhttp_get('/', 'dyhost2', 8080);
+like($r, qr/8087 \./m, 'ssl session not reused, save ssl session');
+like($r, qr/8088 \./m, 'ssl session not reused, save ssl session');
+$r = mhttp_get('/', 'dyhost2', 8080) .
+     mhttp_get('/', 'dyhost2', 8080);
+like($r, qr/8087 r/m, '8087: ssl session reused');
+like($r, qr/8088 r/m, '8088: ssl session reused');
+
+$r = mhttp_get('/?fail=yes', 'dyhost2', 8080) .
+     mhttp_get('/', 'dyhost2', 8080);
+like($r, qr/8089 \./m, 'try backup: ssl session not reused, save ssl session');
+like($r, qr/8090 \./m, 'try backup: ssl session not reused, save ssl session');
+$r = mhttp_get('/', 'dyhost2', 8080);
+$r = $r . mhttp_get('/', 'dyhost2', 8080);
+like($r, qr/8089 r/m, 'backup 8089: ssl session reused');
+like($r, qr/8090 r/m, 'backup 8090: ssl session reused');
+like(mhttp_delete('/upstream/dyhost2', 8081), qr/success/m, 'delete upstream of multiple servers and backups');
+sleep(1);
+$errlog = $t->read_file("error_ssl.log");
+$count = () = $errlog =~ /\[dyups\] free old session:/g;
+is($count, 8, "debug log: free ssl session");
+
+$t->stop();
 
 ###############################################################################
 


### PR DESCRIPTION
try to fix https://github.com/alibaba/tengine/issues/1016

* ~~todo: added test case for session reuse into dyups.t~~
* ~~todo: added test case for session reuse into session_sticky.t~~