### PR TITLE
nginx-tests: sync official uwsgi test cases

### DIFF
--- a/tests/nginx-tests/nginx-tests/uwsgi_ssl_certificate.t
+++ b/tests/nginx-tests/nginx-tests/uwsgi_ssl_certificate.t
@@ -1,0 +1,145 @@
+#!/usr/bin/perl
+
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for http uwsgi module with client certificate to ssl backend.
+# The uwsgi_ssl_certificate and uwsgi_ssl_password_file directives.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl uwsgi/)
+	->has_daemon('openssl')->plan(5);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        uwsgi_ssl_session_reuse off;
+
+        location /verify {
+            uwsgi_pass suwsgi://127.0.0.1:8081;
+            uwsgi_ssl_certificate 1.example.com.crt;
+            uwsgi_ssl_certificate_key 1.example.com.key;
+        }
+
+        location /fail {
+            uwsgi_pass suwsgi://127.0.0.1:8081;
+            uwsgi_ssl_certificate 2.example.com.crt;
+            uwsgi_ssl_certificate_key 2.example.com.key;
+        }
+
+        location /encrypted {
+            uwsgi_pass suwsgi://127.0.0.1:8082;
+            uwsgi_ssl_certificate 3.example.com.crt;
+            uwsgi_ssl_certificate_key 3.example.com.key;
+            uwsgi_ssl_password_file password;
+        }
+    }
+
+    # stub to implement SSL logic for tests
+
+    server {
+        listen       127.0.0.1:8081 ssl;
+        server_name  localhost;
+
+        ssl_certificate 2.example.com.crt;
+        ssl_certificate_key 2.example.com.key;
+
+        ssl_verify_client optional_no_ca;
+        ssl_trusted_certificate 1.example.com.crt;
+
+        add_header X-Verify $ssl_client_verify always;
+        add_header X-Name   $ssl_client_s_dn   always;
+    }
+
+    server {
+        listen       127.0.0.1:8082 ssl;
+        server_name  localhost;
+
+        ssl_certificate 1.example.com.crt;
+        ssl_certificate_key 1.example.com.key;
+
+        ssl_verify_client optional_no_ca;
+        ssl_trusted_certificate 3.example.com.crt;
+
+        add_header X-Verify $ssl_client_verify always;
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('1.example.com', '2.example.com') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+foreach my $name ('3.example.com') {
+	system("openssl genrsa -out $d/$name.key -passout pass:$name "
+		. "-aes128 2048 >>$d/openssl.out 2>&1") == 0
+		or die "Can't create private key: $!\n";
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt "
+		. "-key $d/$name.key -passin pass:$name"
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+sleep 1 if $^O eq 'MSWin32';
+
+$t->write_file('password', '3.example.com');
+$t->write_file('index.html', '');
+
+$t->run();
+
+###############################################################################
+
+like(http_get('/verify'), qr/X-Verify: SUCCESS/ms, 'verify certificate');
+like(http_get('/fail'), qr/X-Verify: FAILED/ms, 'fail certificate');
+like(http_get('/encrypted'), qr/X-Verify: SUCCESS/ms, 'with encrypted key');
+
+like(http_get('/verify'), qr!X-Name: /?CN=1.example!, 'valid certificate');
+unlike(http_get('/fail'), qr!X-Name: /?CN=1.example!, 'invalid certificate');
+
+###############################################################################

--- a/tests/nginx-tests/nginx-tests/uwsgi_ssl_verify.t
+++ b/tests/nginx-tests/nginx-tests/uwsgi_ssl_verify.t
@@ -1,0 +1,182 @@
+#!/usr/bin/perl
+
+# (C) Maxim Dounin
+# (C) Sergey Kandaurov
+# (C) Nginx, Inc.
+
+# Tests for uwsgi backend with SSL, backend certificate verification.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl uwsgi/)
+	->has_daemon('uwsgi')->has_daemon('openssl')->plan(6)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /verify {
+            uwsgi_pass suwsgi://127.0.0.1:8081;
+            uwsgi_ssl_name example.com;
+            uwsgi_ssl_verify on;
+            uwsgi_ssl_trusted_certificate 1.example.com.crt;
+        }
+
+        location /wildcard {
+            uwsgi_pass suwsgi://127.0.0.1:8081;
+            uwsgi_ssl_name foo.example.com;
+            uwsgi_ssl_verify on;
+            uwsgi_ssl_trusted_certificate 1.example.com.crt;
+        }
+
+        location /fail {
+            uwsgi_pass suwsgi://127.0.0.1:8081;
+            uwsgi_ssl_name no.match.example.com;
+            uwsgi_ssl_verify on;
+            uwsgi_ssl_trusted_certificate 1.example.com.crt;
+        }
+
+        location /cn {
+            uwsgi_pass suwsgi://127.0.0.1:8082;
+            uwsgi_ssl_name 2.example.com;
+            uwsgi_ssl_verify on;
+            uwsgi_ssl_trusted_certificate 2.example.com.crt;
+        }
+
+        location /cn/fail {
+            uwsgi_pass suwsgi://127.0.0.1:8082;
+            uwsgi_ssl_name bad.example.com;
+            uwsgi_ssl_verify on;
+            uwsgi_ssl_trusted_certificate 2.example.com.crt;
+        }
+
+        location /untrusted {
+            uwsgi_pass suwsgi://127.0.0.1:8082;
+            uwsgi_ssl_verify on;
+            uwsgi_ssl_trusted_certificate 1.example.com.crt;
+            uwsgi_ssl_session_reuse off;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('openssl.1.example.com.conf', <<EOF);
+[ req ]
+prompt = no
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+
+[ req_distinguished_name ]
+commonName=no.match.example.com
+
+[ v3_req ]
+subjectAltName = DNS:example.com,DNS:*.example.com
+EOF
+
+$t->write_file('openssl.2.example.com.conf', <<EOF);
+[ req ]
+prompt = no
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+
+[ req_distinguished_name ]
+commonName=2.example.com
+EOF
+
+my $d = $t->testdir();
+my $crt1 = "$d/1.example.com.crt";
+my $crt2 = "$d/2.example.com.crt";
+my $key1 = "$d/1.example.com.key";
+my $key2 = "$d/2.example.com.key";
+
+foreach my $name ('1.example.com', '2.example.com') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.$name.conf "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+$t->write_file('uwsgi_test_app.py', <<END);
+
+def application(env, start_response):
+    start_response('200 OK', [('Content-Type','text/plain')])
+    return b"SEE-THIS"
+
+END
+
+my $uwsgihelp = `uwsgi -h`;
+my @uwsgiopts = ();
+
+if ($uwsgihelp !~ /--wsgi-file/) {
+	# uwsgi has no python support, maybe plugin load is necessary
+	push @uwsgiopts, '--plugin', 'python';
+	push @uwsgiopts, '--plugin', 'python3';
+}
+
+open OLDERR, ">&", \*STDERR; close STDERR;
+$t->run_daemon('uwsgi', @uwsgiopts,
+	'--ssl-socket', '127.0.0.1:' . port(8081) . ",$crt1,$key1",
+	'--wsgi-file', $d . '/uwsgi_test_app.py',
+	'--logto', $d . '/uwsgi_log');
+$t->run_daemon('uwsgi', @uwsgiopts,
+	'--ssl-socket', '127.0.0.1:' . port(8082) . ",$crt2,$key2",
+	'--wsgi-file', $d . '/uwsgi_test_app.py',
+	'--logto', $d . '/uwsgi_log');
+open STDERR, ">&", \*OLDERR;
+
+$t->run();
+
+$t->waitforsocket('127.0.0.1:' . port(8081))
+	or die "Can't start uwsgi";
+$t->waitforsocket('127.0.0.1:' . port(8082))
+	or die "Can't start uwsgi";
+
+###############################################################################
+
+# subjectAltName
+
+like(http_get('/verify'), qr/200 OK/ms, 'verify');
+like(http_get('/wildcard'), qr/200 OK/ms, 'verify wildcard');
+like(http_get('/fail'), qr/502 Bad/ms, 'verify fail');
+
+# commonName
+
+like(http_get('/cn'), qr/200 OK/ms, 'verify cn');
+like(http_get('/cn/fail'), qr/502 Bad/ms, 'verify cn fail');
+
+# untrusted
+
+like(http_get('/untrusted'), qr/502 Bad/ms, 'untrusted');
+
+###############################################################################


### PR DESCRIPTION
* uwsgi_body.t and uwsgi_ssl_certificate_vars.t are not synchronized, which is not supported by current Tengine 2.3.x (nginx 1.8.x).
* synchronized uwsgi.t has fixed environment issue (for python38) , the old case failed on ubuntu 20.08/python3.