### PR TITLE
Configure: fixed compilation error in stream_set module

### DIFF
--- a/auto/options
+++ b/auto/options
@@ -130,6 +130,7 @@ STREAM_GEOIP=NO
 STREAM_MAP=YES
 STREAM_SPLIT_CLIENTS=YES
 STREAM_RETURN=YES
+STREAM_SET=YES
 STREAM_UPSTREAM_HASH=YES
 STREAM_UPSTREAM_LEAST_CONN=YES
 STREAM_UPSTREAM_RANDOM=YES
@@ -353,6 +354,7 @@ use the \"--with-mail_ssl_module\" option instead"
         --without-stream_split_clients_module)
                                          STREAM_SPLIT_CLIENTS=NO    ;;
         --without-stream_return_module)  STREAM_RETURN=NO           ;;
+        --without-stream_set_module)     STREAM_SET=NO              ;;
         --without-stream_upstream_hash_module)
                                          STREAM_UPSTREAM_HASH=NO    ;;
         --without-stream_upstream_least_conn_module)


### PR DESCRIPTION
The complete patch of the auto/options file was not imported upon updating nginx core to 1.22.1.

For original commit of updating stream_set module, please refer to https://github.com/nginx/nginx/commit/c85d6fec217d1b17291779542de20ad77ae68661