### PR TITLE
test-nginx-core.yml: fixed the failure of test case image_filter_finalize.t

### DIFF
--- a/.github/workflows/test-nginx-core.yml
+++ b/.github/workflows/test-nginx-core.yml
@@ -47,9 +47,10 @@ jobs:
 
          # NOTE:
          # For "-D T_NGX_MODIFY_DEFAULT_VALUE=0", we dont compile the source included in this macro, otherwise some nginx-tests cases tests will fail.
-         # For "-D T_NGX_SERVER_INFO=0", it made some cases (userid.t) passed.
+         # For "-D T_NGX_SERVER_INFO=0", it makes some cases pass, such as userid.t.
+         # For "-D T_NGX_HTTP_UPSTREAM_RANDOM=0", it makes some cases pass, such as image_filter_finalize.t.
          ./configure  \
-            --with-cc-opt="-D T_NGX_MODIFY_DEFAULT_VALUE=0 -D T_NGX_HTTP_IMAGE_FILTER=0 -D T_NGX_SERVER_INFO=0" \
+            --with-cc-opt="-D T_NGX_MODIFY_DEFAULT_VALUE=0 -D T_NGX_HTTP_IMAGE_FILTER=0 -D T_NGX_SERVER_INFO=0 -D T_NGX_HTTP_UPSTREAM_RANDOM=0" \
             --with-ld-opt="-Wl,-rpath,/usr/local/lib" \
             --with-openssl-async \
             --with-pcre \


### PR DESCRIPTION
For more details, see https://github.com/alibaba/tengine/issues/1767.

This causes the test cases to have a probability of 4/5 of not running according to the specified behavior, but only a smaller probability of being detected.