### PR TITLE
proxy_connect: new feature to enable proxy authentication

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -545,7 +545,7 @@ if [ $HTTP = YES ]; then
 
         ngx_module_name=ngx_http_auth_basic_module
         ngx_module_incs=
-        ngx_module_deps=
+        ngx_module_deps=src/http/modules/ngx_http_auth_basic_module.h
         ngx_module_srcs=src/http/modules/ngx_http_auth_basic_module.c
         ngx_module_libs=$CRYPT_LIB
         ngx_module_link=$HTTP_AUTH_BASIC

--- a/docs/modules/ngx_http_proxy_connect_module.md
+++ b/docs/modules/ngx_http_proxy_connect_module.md
@@ -16,6 +16,7 @@ Table of Contents
    * [Directive](#directive)
       * [proxy_connect](#proxy_connect)
       * [proxy_connect_allow](#proxy_connect_allow)
+      * [proxy_connect_auth](#proxy_connect_auth)
       * [proxy_connect_connect_timeout](#proxy_connect_connect_timeout)
       * [proxy_connect_data_timeout](#proxy_connect_data_timeout)
       * [proxy_connect_read_timeout(deprecated)](#proxy_connect_read_timeout)
@@ -190,6 +191,47 @@ The value `port-range` will allow specified range of port to proxy, for example:
 
 ```
 proxy_connect_allow 1000-2000 3000-4000; # allow range of port from 1000 to 2000, from 3000 to 4000.
+```
+
+proxy_connect_auth
+------------------
+
+Syntax: **proxy_connect_auth `<on|off>`**  
+Default: `off`  
+Context: `server`  
+
+Enable "Proxy Authorication" feature. Now, only `Basic` is supported.
+
+Configure example:
+
+```
+ server {
+     listen                         3128;
+
+     # dns resolver used by forward proxying
+     resolver                       8.8.8.8;
+
+     # forward proxy for CONNECT request
+     proxy_connect;
+     proxy_connect_allow            443 563;
+     proxy_connect_connect_timeout  10s;
+     proxy_connect_read_timeout     10s;
+     proxy_connect_send_timeout     10s;
+
+     # proxy auth
+     proxy_connect_auth     on;                 # open proxy auth
+     proxy_set_header Authorization "";         # Eliminate the authentication information.
+     auth_basic             web_proxy;
+     auth_basic_user_file   user_list.htpasswd;
+
+     # forward proxy for non-CONNECT request
+     location / {
+         auth_basic off;                        # close basic auth
+
+         proxy_pass http://$host;
+         proxy_set_header Host $host;
+     }
+ }
 ```
 
 proxy_connect_connect_timeout

--- a/docs/modules/ngx_http_proxy_connect_module_cn.md
+++ b/docs/modules/ngx_http_proxy_connect_module_cn.md
@@ -16,6 +16,7 @@ Table of Contents
    * [Directive](#directive)
       * [proxy_connect](#proxy_connect)
       * [proxy_connect_allow](#proxy_connect_allow)
+      * [proxy_connect_auth](#proxy_connect_auth)
       * [proxy_connect_connect_timeout](#proxy_connect_connect_timeout)
       * [proxy_connect_data_timeout](#proxy_connect_data_timeout)
       * [proxy_connect_read_timeout(deprecated)](#proxy_connect_read_timeout)
@@ -192,6 +193,46 @@ Context: `server`
 
 ```
 proxy_connect_allow 1000-2000 3000-4000; # 允许端口范围1000-2000 和 3000-4000
+```
+
+proxy_connect_auth
+------------------
+
+Syntax: **proxy_connect_auth `<on|off>`**  
+Default: `off`  
+Context: `server`  
+
+设置是否打开代理认证功能。如果开启的话会对客户端进行身份认证，当前仅支持`Basic`。
+要打开认证功能可以修改样例配置：
+
+```
+ server {
+     listen                         3128;
+
+     # dns resolver used by forward proxying
+     resolver                       8.8.8.8;
+
+     # forward proxy for CONNECT request
+     proxy_connect;
+     proxy_connect_allow            443 563;
+     proxy_connect_connect_timeout  10s;
+     proxy_connect_read_timeout     10s;
+     proxy_connect_send_timeout     10s;
+
+     # proxy auth
+     proxy_connect_auth     on;                     # 打开认证功能
+     proxy_set_header Authorization "";             # 去掉认证信息
+     auth_basic             web_proxy;              # 配置认证域
+     auth_basic_user_file   user_list.htpasswd;     # 配置用户名密码
+
+     # forward proxy for non-CONNECT request
+     location / {
+         auth_basic off;                            # 关闭认证：非CONNECT请求无需认证
+
+         proxy_pass http://$host;
+         proxy_set_header Host $host;
+     }
+ }
 ```
 
 proxy_connect_connect_timeout

--- a/modules/ngx_http_proxy_connect_module/ngx_http_proxy_connect_module.c
+++ b/modules/ngx_http_proxy_connect_module/ngx_http_proxy_connect_module.c
@@ -7,6 +7,7 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 #include <nginx.h>
+#include <ngx_http_auth_basic_module.h>
 
 
 #define NGX_HTTP_PROXY_CONNECT_ESTABLISTHED     \
@@ -26,6 +27,7 @@ typedef void (*ngx_http_proxy_connect_upstream_handler_pt)(
 typedef struct {
     ngx_flag_t                           accept_connect;
     ngx_flag_t                           allow_port_all;
+    ngx_flag_t                           auth;
     ngx_array_t                         *allow_ports;
 
     ngx_msec_t                           data_timeout;
@@ -145,7 +147,9 @@ static ngx_int_t ngx_http_proxy_connect_sock_ntop(ngx_http_request_t *r,
     ngx_http_proxy_connect_upstream_t *u);
 static ngx_int_t ngx_http_proxy_connect_create_peer(ngx_http_request_t *r,
     ngx_http_upstream_resolved_t *ur);
-
+static ngx_int_t
+ngx_http_proxy_connect_proxy_auth_basic_set_realm(ngx_http_request_t *r,
+    ngx_str_t *realm);
 
 
 static ngx_command_t  ngx_http_proxy_connect_commands[] = {
@@ -155,6 +159,13 @@ static ngx_command_t  ngx_http_proxy_connect_commands[] = {
       ngx_http_proxy_connect,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_proxy_connect_loc_conf_t, accept_connect),
+      NULL },
+
+    { ngx_string("proxy_connect_auth"),
+      NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_proxy_connect_loc_conf_t, auth),
       NULL },
 
     { ngx_string("proxy_connect_allow"),
@@ -1936,6 +1947,7 @@ ngx_http_proxy_connect_create_loc_conf(ngx_conf_t *cf)
 
     conf->accept_connect = NGX_CONF_UNSET;
     conf->allow_port_all = NGX_CONF_UNSET;
+    conf->auth           = NGX_CONF_UNSET;
     conf->allow_ports = NGX_CONF_UNSET_PTR;
 
     conf->connect_timeout = NGX_CONF_UNSET_MSEC;
@@ -1959,6 +1971,7 @@ ngx_http_proxy_connect_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->accept_connect, prev->accept_connect, 0);
     ngx_conf_merge_value(conf->allow_port_all, prev->allow_port_all, 0);
+    ngx_conf_merge_value(conf->auth, prev->auth, 0);
     ngx_conf_merge_ptr_value(conf->allow_ports, prev->allow_ports, NULL);
 
     ngx_conf_merge_msec_value(conf->connect_timeout,
@@ -2344,6 +2357,31 @@ ngx_http_proxy_connect_post_read_handler(ngx_http_request_t *r)
             return NGX_HTTP_NOT_ALLOWED;
         }
 
+        /* proxy auth */
+
+        if (pclcf->auth) {
+            ngx_str_t realm;
+            ngx_int_t rc;
+
+            rc = ngx_http_auth_basic_get_realm(r, &realm);
+
+            if (rc == NGX_OK) {
+                if (!r->headers_in.proxy_authorization) {
+                    return ngx_http_proxy_connect_proxy_auth_basic_set_realm(
+                        r, &realm);
+                }
+
+                if (!r->headers_in.authorization) {
+                    r->headers_in.authorization = r->headers_in.proxy_authorization;
+                }
+            }
+            else if (rc == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            /* rc == NGX_AGAIN */
+        }
+
         /* init ctx */
 
         ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_proxy_connect_ctx_t));
@@ -2366,6 +2404,38 @@ ngx_http_proxy_connect_post_read_handler(ngx_http_request_t *r)
     return NGX_DECLINED;
 }
 
+static ngx_int_t
+ngx_http_proxy_connect_proxy_auth_basic_set_realm(ngx_http_request_t *r,
+                                                  ngx_str_t          *realm)
+{
+    size_t  len;
+    u_char *basic, *p;
+
+    r->headers_out.proxy_authenticate = ngx_list_push(&r->headers_out.headers);
+    if (r->headers_out.proxy_authenticate == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    len = sizeof("Basic realm=\"\"") - 1 + realm->len;
+
+    basic = ngx_pnalloc(r->pool, len);
+    if (basic == NULL) {
+        r->headers_out.proxy_authenticate->hash = 0;
+        r->headers_out.proxy_authenticate       = NULL;
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    p  = ngx_cpymem(basic, "Basic realm=\"", sizeof("Basic realm=\"") - 1);
+    p  = ngx_cpymem(p, realm->data, realm->len);
+    *p = '"';
+
+    r->headers_out.proxy_authenticate->hash = 1;
+    ngx_str_set(&r->headers_out.proxy_authenticate->key, "Proxy-Authenticate");
+    r->headers_out.proxy_authenticate->value.data = basic;
+    r->headers_out.proxy_authenticate->value.len  = len;
+
+    return NGX_HTTP_PROXY_AUTHENTICATION_REQUIRED;
+}
 
 static ngx_int_t
 ngx_http_proxy_connect_init(ngx_conf_t *cf)

--- a/modules/ngx_http_proxy_connect_module/t/http_proxy_connect.t
+++ b/modules/ngx_http_proxy_connect_module/t/http_proxy_connect.t
@@ -50,6 +50,7 @@ my %aroute_map = (
     'get-default-response.com' => [[300, "127.0.0.1"]],
     'set-response-header.com' => [[300, "127.0.0.1"]],
     'set-response-status.com' => [[300, "127.0.0.1"]],
+    'auth.example.com' => [[300, "127.0.0.1"]],
 );
 
 # AAAA record (ipv6)
@@ -144,6 +145,19 @@ http {
     }
 
     server {
+        listen 127.0.0.1:8080;
+
+        server_name auth.example.com;
+
+        proxy_connect;
+        proxy_connect_auth  on;
+        proxy_connect_allow 443 80 8081;
+
+        auth_basic              web_proxy;
+        auth_basic_user_file    user_list.htpasswd;
+    }
+
+    server {
         listen       127.0.0.1:8080;
         server_name  forbidden.example.com;
 
@@ -155,7 +169,15 @@ http {
 
 EOF
 
+my $user_list = <<'EOF';
+# password is '123456'
+user:$apr1$1Jt/1uYP$bSBtyBO3gRdxsaTXe20td0
+EOF
+
 $t->write_file_expand('nginx.conf', $nginx_conf);
+$t->write_file('user_list.htpasswd', $user_list);
+
+system('chmod', 'o+rx', $t->testdir()); # solve Permission denied
 
 eval {
     $t->run();
@@ -177,6 +199,12 @@ like(http_connect_request('127.0.0.1', '9999', '/'), qr/403/, '200 Connection Es
 like(http_get('/'), qr/backend server/, 'Get method: proxy_pass');
 like(http_get('/hello'), qr/world/, 'Get method: return 200');
 like(http_connect_request('forbidden.example.com', '8080', '/'), qr/405 Not Allowed/, 'forbid CONNECT request without proxy_connect command enabled');
+
+# proxy auth
+like(http_connect_request('auth.example.com', '8081', '/'), qr/407 Proxy Authentication Required/, 'must to carry Proxy-Authorization');
+like(http_connect_request('auth.example.com', '8081', '/'), qr/Proxy-Authenticate: Basic realm="web_proxy"/, 'must to carry Proxy-Authorization');
+like(http_connect_request_carry_authorization('auth.example.com', '8081', '/', "Basic dXNlcjoxMjM0NTY="), qr/backend server/, 'carry valid Proxy-Authorization');
+like(http_connect_request_carry_authorization('auth.example.com', '8081', '/', "Basic abcd"), qr/401 Unauthorized/, 'carry invalid Proxy-Authorization');
 
 # proxy_remote_address directive supports dynamic domain resolving.
 like(http_connect_request('proxy-remote-address-resolve-domain.com', '8081', '/'),
@@ -432,9 +460,25 @@ EOF
     return $r
 }
 
+sub http_connect_request_carry_authorization {
+    my ($host, $port, $url, $credentials) = @_;
+    my $r = http_connect($host, $port, <<EOF, credentials => $credentials);
+GET $url HTTP/1.0
+Host: $host
+Connection: close
+
+EOF
+    return $r
+}
+
 sub http_connect($;%) {
     my ($host, $port, $request, %extra) = @_;
     my $reply;
+
+    my $proxy_authorization = defined $extra{credentials}
+                                ? "Proxy-Authorization: $extra{credentials}"
+                                : "";
+
     eval {
         local $SIG{ALRM} = sub { die "timeout\n" };
         local $SIG{PIPE} = sub { die "sigpipe\n" };
@@ -446,6 +490,7 @@ sub http_connect($;%) {
         $s->print(<<EOF);
 CONNECT $host:$port HTTP/1.1
 Host: $host
+$proxy_authorization
 
 EOF
         select undef, undef, undef, $extra{sleep} if $extra{sleep};

--- a/src/http/modules/ngx_http_auth_basic_module.c
+++ b/src/http/modules/ngx_http_auth_basic_module.c
@@ -7,17 +7,12 @@
 
 #include <ngx_config.h>
 #include <ngx_core.h>
-#include <ngx_http.h>
 #include <ngx_crypt.h>
+#include <ngx_http_auth_basic_module.h>
 
 
 #define NGX_HTTP_AUTH_BUF_SIZE  2048
 
-
-typedef struct {
-    ngx_http_complex_value_t  *realm;
-    ngx_http_complex_value_t  *user_file;
-} ngx_http_auth_basic_loc_conf_t;
 
 
 static ngx_int_t ngx_http_auth_basic_handler(ngx_http_request_t *r);
@@ -428,4 +423,27 @@ ngx_http_auth_basic_user_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     return NGX_CONF_OK;
+}
+
+
+ngx_int_t
+ngx_http_auth_basic_get_realm(ngx_http_request_t *r, ngx_str_t *realm)
+{
+    ngx_http_auth_basic_loc_conf_t *alcf;
+
+    alcf = ngx_http_get_module_loc_conf(r, ngx_http_auth_basic_module);
+
+    if (alcf->realm == NULL || alcf->user_file == NULL) {
+        return NGX_AGAIN;
+    }
+
+    if (ngx_http_complex_value(r, alcf->realm, realm) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    if (realm->len == 3 && ngx_strncmp(realm->data, "off", 3) == 0) {
+        return NGX_AGAIN;
+    }
+
+    return NGX_OK;
 }

--- a/src/http/modules/ngx_http_auth_basic_module.h
+++ b/src/http/modules/ngx_http_auth_basic_module.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Igor Sysoev
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_HTTP_AUTH_BASIC_H_INCLUDED_
+#define _NGX_HTTP_AUTH_BASIC_H_INCLUDED_
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+typedef struct {
+    ngx_http_complex_value_t  *realm;
+    ngx_http_complex_value_t  *user_file;
+} ngx_http_auth_basic_loc_conf_t;
+
+
+ngx_int_t ngx_http_auth_basic_get_realm(ngx_http_request_t *r, ngx_str_t *realm);
+
+
+#endif /* _NGX_HTTP_AUTH_BASIC_H_INCLUDED_ */

--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -92,7 +92,7 @@ static ngx_str_t ngx_http_status_lines[] = {
     ngx_string("404 Not Found"),
     ngx_string("405 Not Allowed"),
     ngx_string("406 Not Acceptable"),
-    ngx_null_string,  /* "407 Proxy Authentication Required" */
+    ngx_string("407 Proxy Authentication Required"),
     ngx_string("408 Request Time-out"),
     ngx_string("409 Conflict"),
     ngx_string("410 Gone"),

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -200,6 +200,15 @@ ngx_http_header_t  ngx_http_headers_in[] = {
                  ngx_http_process_header_line },
 #endif
 
+#if (NGX_HTTP_PROXY_CONNECT)
+
+    { ngx_string("Proxy-Authorization"),
+                offsetof(ngx_http_headers_in_t, proxy_authorization),
+                ngx_http_process_header_line },
+
+#endif
+
+
     { ngx_string("Cookie"), offsetof(ngx_http_headers_in_t, cookies),
                  ngx_http_process_multi_header_lines },
 

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -93,6 +93,11 @@
 #define NGX_HTTP_FORBIDDEN                 403
 #define NGX_HTTP_NOT_FOUND                 404
 #define NGX_HTTP_NOT_ALLOWED               405
+
+#if (NGX_HTTP_PROXY_CONNECT)
+#define NGX_HTTP_PROXY_AUTHENTICATION_REQUIRED 407
+#endif
+
 #define NGX_HTTP_REQUEST_TIME_OUT          408
 #define NGX_HTTP_CONFLICT                  409
 #define NGX_HTTP_LENGTH_REQUIRED           411
@@ -231,6 +236,10 @@ typedef struct {
     ngx_table_elt_t                  *date;
 #endif
 
+#if (NGX_HTTP_PROXY_CONNECT)
+    ngx_table_elt_t                 *proxy_authorization;
+#endif
+
     ngx_str_t                         user;
     ngx_str_t                         passwd;
 
@@ -271,6 +280,10 @@ typedef struct {
     ngx_table_elt_t                  *www_authenticate;
     ngx_table_elt_t                  *expires;
     ngx_table_elt_t                  *etag;
+
+#if (NGX_HTTP_PROXY_CONNECT)
+    ngx_table_elt_t                 *proxy_authenticate;
+#endif
 
     ngx_str_t                        *override_charset;
 


### PR DESCRIPTION
新增功能：代理认证；

目前适配了 Basic类型认证，依赖于“ngx_http_auth_basic_module”

下面试我实际场景中跑测用的配置，具体在提交的手册上有说明。

```
    server {
        listen 10443 ssl;
        listen 10080;
        server_name www.homqyy.cn;

        access_log logs/proxy.log;

        # ssl
        ssl_certificate certs/www.homqyy.cn/fullchain.pem;
        ssl_certificate_key certs/www.homqyy.cn/privkey.pem;

        # auth
        auth_basic web_proxy;
        auth_basic_user_file user_list.htpasswd;       # 设置Basic认证的用户密码
        proxy_set_header Authorization "";              # 去掉认证信息

        # forward proxy for CONNECT request
        proxy_connect;
        proxy_connect_auth              on;                  # 开启代理连接认证功能
        proxy_connect_allow             443 80;
        proxy_connect_connect_timeout   120s;
        proxy_connect_read_timeout      120s;
        proxy_connect_send_timeout      120s;


        # forward proxy for non-CONNECT request
        location / {
	    auth_basic off;
            proxy_pass $scheme://$host;
            proxy_set_header Host               $host;
        }
    }
```