### PR TITLE
fix tengine coredump bug with ssl_async on. issues#1793

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -3728,6 +3728,21 @@ ngx_ssl_shutdown(ngx_connection_t *c)
         ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_shutdown: %d", n);
 
         if (n == 1) {
+#if (NGX_SSL && NGX_SSL_ASYNC)
+            if (c->async_enable) {
+                /* Ignore errors from ngx_ssl_async_process_fds as
+                    we want to carry on and close the SSL connection
+                    anyway. */
+                ngx_ssl_async_process_fds(c);
+                if (ngx_del_async_conn) {
+                    if (c->num_async_fds) {
+                        ngx_del_async_conn(c, NGX_DISABLE_EVENT);
+                        c->num_async_fds--;
+                    }
+                }
+                ngx_del_conn(c, NGX_DISABLE_EVENT);
+            }
+#endif
             goto done;
         }
 
@@ -3776,25 +3791,6 @@ ngx_ssl_shutdown(ngx_connection_t *c)
             return NGX_AGAIN;
         }
 
-        if (sslerr == SSL_ERROR_ZERO_RETURN || ERR_peek_error() == 0) {
-#if (NGX_SSL && NGX_SSL_ASYNC)
-            if (c->async_enable) {
-                /* Ignore errors from ngx_ssl_async_process_fds as
-                   we want to carry on and close the SSL connection
-                   anyway. */
-                ngx_ssl_async_process_fds(c);
-                if (ngx_del_async_conn) {
-                    if (c->num_async_fds) {
-                        ngx_del_async_conn(c, NGX_DISABLE_EVENT);
-                        c->num_async_fds--;
-                    }
-                }
-                ngx_del_conn(c, NGX_DISABLE_EVENT);
-            }
-#endif
-            goto done;
-        }
-
 #if (NGX_SSL && NGX_SSL_ASYNC)
     if (c->async_enable) {
         if (sslerr == SSL_ERROR_WANT_ASYNC) {
@@ -3825,6 +3821,10 @@ ngx_ssl_shutdown(ngx_connection_t *c)
         ngx_del_conn(c, NGX_DISABLE_EVENT);
     }
 #endif
+
+        if (sslerr == SSL_ERROR_ZERO_RETURN || ERR_peek_error() == 0) {
+            goto done;
+        }
 
         err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
 


### PR DESCRIPTION
Fix [bug](https://github.com/alibaba/tengine/issues/1793)
Modify "ngx_ssl_shutdown" process:
1. "if (n == 1)" needs "ngx_del_async_conn", so add the code
2. "if (sslerr == SSL_ERROR_ZERO_RETURN || ERR_peek_error() == 0)" move behind "if (sslerr == SSL_ERROR_WANT_ASYNC)",  if job is paused, needs to call "ngx_ssl_shutdown" again.
3. In "if (sslerr == SSL_ERROR_ZERO_RETURN || ERR_peek_error() == 0)" branch, no need "ngx_del_async_conn", because it must be invoked before, so delete the code.