### PR TITLE
Fixed segfault in ngx_http_find_virtual_server() within xquic module

### DIFF
--- a/modules/ngx_http_xquic_module/ngx_http_xquic.c
+++ b/modules/ngx_http_xquic_module/ngx_http_xquic.c
@@ -207,6 +207,9 @@ ngx_http_v3_cert_cb(const char *sni, void **chain,
     }
 #endif
 
+    /* The ngx_http_find_virtual_server() function requires ngx_http_connection_t in c->data */
+    c->data = hc;
+
     /*
      * get the server core conf by sni, this is useful when multiple server
      * block listen on the same port. but useless when there is noly a single
@@ -214,6 +217,8 @@ ngx_http_v3_cert_cb(const char *sni, void **chain,
     */
    ret = ngx_http_find_virtual_server_inner(c,
             hc->addr_conf->virtual_names, &host, NULL, &cscf);
+   c->data = qc;
+
     if (ret == NGX_OK) {
         hc->ssl_servername = ngx_palloc(c->pool, sizeof(ngx_str_t));
         if (hc->ssl_servername == NULL) {


### PR DESCRIPTION
A segfault was corrected when calling ngx_http_find_virtual_server in the xquic module. The issue originated from c->data being taken as ngx_http_connection_t while regular expressions were in use. However, for http3 connections, c->data is a pointer to ngx_http_xquic_connection_t