### PR TITLE
fix: when tengine open proxy_protocol but client not send proxy_proto…

### DIFF
--- a/src/core/ngx_proxy_protocol.c
+++ b/src/core/ngx_proxy_protocol.c
@@ -115,7 +115,7 @@ ngx_proxy_protocol_read(ngx_connection_t *c, u_char *buf, u_char *last)
     }
 
     if (len < 8 || ngx_strncmp(p, "PROXY ", 6) != 0) {
-        goto invalid;
+        return p;
     }
 
     p += 6;


### PR DESCRIPTION
此修改旨在兼容tengine作为后端服务开启proxy_protocol时，slb等客户端开启和不开启proxy_protocol均运行正常。