### PR TITLE
Fix compilation failure of grpc module when add ngx_tongsuo_ntls

### DIFF
--- a/.github/workflows/test-ntls.yml
+++ b/.github/workflows/test-ntls.yml
@@ -77,6 +77,7 @@ jobs:
             --with-openssl=../Tongsuo \
             --with-openssl-opt="--api=1.1.1 enable-ntls" \
             --with-http_ssl_module \
+            --with-http_v2_module \
             --with-stream \
             --with-stream_ssl_module \
             --with-stream_sni

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -5057,18 +5057,19 @@ ngx_http_grpc_set_ssl(ngx_conf_t *cf, ngx_http_grpc_loc_conf_t *glcf)
 
 #if (T_NGX_SSL_NTLS)
     glcf->upstream.tls_method = SSL_CTX_get_ssl_method(glcf->upstream.ssl->ctx);
-    if (glcf->enc_certificate.len) {
+    if (glcf->upstream.enc_certificate.len) {
 
-        if (glcf->enc_certificate_key.len == 0) {
+        if (glcf->upstream.enc_certificate_key.len == 0) {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                           "no \"grpc_ssl_enc_certificate_key\" is defined "
-                          "for certificate \"%V\"", &glcf->enc_certificate);
+                          "for certificate \"%V\"",
+                          &glcf->upstream.enc_certificate);
             return NGX_ERROR;
         }
 
         if (ngx_ssl_certificate(cf, glcf->upstream.ssl,
-                                &glcf->upstream.enc_certificate->value,
-                                &glcf->upstream.enc_certificate_key->value,
+                                &glcf->upstream.enc_certificate,
+                                &glcf->upstream.enc_certificate_key,
                                 glcf->upstream.ssl_passwords,
                                 SSL_ENC_CERT)
             != NGX_OK)
@@ -5077,12 +5078,13 @@ ngx_http_grpc_set_ssl(ngx_conf_t *cf, ngx_http_grpc_loc_conf_t *glcf)
         }
     }
 
-    if (glcf->sign_certificate.len) {
+    if (glcf->upstream.sign_certificate.len) {
 
-        if (glcf->sign_certificate_key.len == 0) {
+        if (glcf->upstream.sign_certificate_key.len == 0) {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                           "no \"grpc_ssl_sign_certificate_key\" is defined "
-                          "for certificate \"%V\"", &glcf->sign_certificate);
+                          "for certificate \"%V\"",
+                          &glcf->upstream.sign_certificate);
             return NGX_ERROR;
         }
 


### PR DESCRIPTION
CI test-ntls adds http v2 module, so grpc module is enabled to avoid compilation failure like this.

Fix #1812