### PR TITLE
ngx_debug_conn: fixed test case failure

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -64,6 +64,7 @@ jobs:
               --add-module=./modules/ngx_backtrace_module \
               --add-module=./modules/ngx_debug_pool \
               --add-module=./modules/ngx_debug_timer \
+              --add-module=./modules/ngx_debug_conn \
               --add-module=./modules/ngx_http_concat_module \
               --add-module=./modules/ngx_http_footer_filter_module \
               --add-module=./modules/ngx_http_lua_module \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
             --add-module=./modules/ngx_backtrace_module \
             --add-module=./modules/ngx_debug_pool \
             --add-module=./modules/ngx_debug_timer \
+            --add-module=./modules/ngx_debug_conn \
             --add-module=./modules/ngx_http_concat_module \
             --add-module=./modules/ngx_http_footer_filter_module \
             --add-module=./modules/ngx_http_lua_module \
@@ -107,6 +108,9 @@ jobs:
          sudo cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
          prove -v -Inginx-tests/lib tengine-tests/
          prove -v -Inginx-tests/lib ../../modules/ngx_http_proxy_connect_module/t
+         prove -v -Inginx-tests/lib ../../modules/ngx_debug_timer/t
+         prove -v -Inginx-tests/lib ../../modules/ngx_debug_conn/t
+         prove -v -Inginx-tests/lib ../../modules/ngx_slab_stat/t
      - name: tengine test cases using test-nginx lib
        working-directory: tests/test-nginx
        run: |

--- a/modules/ngx_debug_conn/ngx_http_debug_conn_module.c
+++ b/modules/ngx_debug_conn/ngx_http_debug_conn_module.c
@@ -10,7 +10,7 @@
 
 
 #if (NGX_DEBUG_POOL)
-extern size_t ngx_pool_size(ngx_pool_t *);
+#define ngx_pool_size(p) ((p)->size)
 #else
 #define ngx_pool_size(p) ((size_t) 0)
 #endif

--- a/modules/ngx_debug_conn/t/test.t
+++ b/modules/ngx_debug_conn/t/test.t
@@ -28,6 +28,7 @@ events {
 }
 
 http {
+    %%TEST_GLOBALS_HTTP%%
     server {
         listen       127.0.0.1:8080;
 

--- a/modules/ngx_debug_pool/t/test.t
+++ b/modules/ngx_debug_pool/t/test.t
@@ -28,6 +28,7 @@ events {
 }
 
 http {
+    %%TEST_GLOBALS_HTTP%%
     server {
         listen       127.0.0.1:8080;
 

--- a/modules/ngx_debug_timer/t/test.t
+++ b/modules/ngx_debug_timer/t/test.t
@@ -28,6 +28,7 @@ events {
 }
 
 http {
+    %%TEST_GLOBALS_HTTP%%
     server {
         listen       127.0.0.1:8080;
 

--- a/modules/ngx_slab_stat/t/test.t
+++ b/modules/ngx_slab_stat/t/test.t
@@ -27,6 +27,7 @@ events {
 }
 
 http {
+    %%TEST_GLOBALS_HTTP%%
 
     limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s;
 


### PR DESCRIPTION
1. compialtion error: not defined ngx_pool_size
2. case failure: cannot find resty.core library
3. ci.yml: enabled this module for testing
4. ci-arm64.yml: enabled this moduel for buidling

(fixes for this merged pr https://github.com/alibaba/tengine/pull/1127)