### PR TITLE
open ngx_http_upstream_rbtree_lookup as api

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -209,10 +209,6 @@ static ngx_int_t ngx_http_upstream_ssl_certificate(ngx_http_request_t *r,
 #if (NGX_HTTP_UPSTREAM_RBTREE)
 static void ngx_http_upstream_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
-
-static ngx_http_upstream_srv_conf_t *
-ngx_http_upstream_rbtree_lookup(ngx_http_upstream_main_conf_t *umcf,
-    ngx_str_t *host);
 #endif
 
 static ngx_http_upstream_header_t  ngx_http_upstream_headers_in[] = {
@@ -6847,7 +6843,7 @@ ngx_http_upstream_rbtree_insert_value(ngx_rbtree_node_t *temp,
 }
 
 
-static ngx_http_upstream_srv_conf_t *
+ngx_http_upstream_srv_conf_t *
 ngx_http_upstream_rbtree_lookup(ngx_http_upstream_main_conf_t *umcf,
     ngx_str_t *host)
 {

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -504,6 +504,12 @@ void ngx_http_upstream_check_delete_dynamic_peer(ngx_str_t *name,
 
 #endif
 
+#if (NGX_HTTP_UPSTREAM_RBTREE)
+ngx_http_upstream_srv_conf_t *
+ngx_http_upstream_rbtree_lookup(ngx_http_upstream_main_conf_t *umcf,
+    ngx_str_t *host);
+#endif
+
 extern ngx_module_t        ngx_http_upstream_module;
 extern ngx_conf_bitmask_t  ngx_http_upstream_cache_method_mask[];
 extern ngx_conf_bitmask_t  ngx_http_upstream_ignore_headers_masks[];


### PR DESCRIPTION
Sometimes, we need to optimize RBTREE in the area of other files. At this time, this function needs to be exposed.

有时候，我们需要在其他文件的区域内，进行RBTREE的优化，此时，这个函数需要暴露出去

eg:https://github.com/lhanjian/lua-upstream-nginx-module/commit/70f73110397f23e6a4b4e70e8bf7cd7b62154caa