### PR TITLE
default use bbr as cc instead of cubic

### DIFF
--- a/modules/ngx_http_xquic_module/ngx_http_xquic_module.c
+++ b/modules/ngx_http_xquic_module/ngx_http_xquic_module.c
@@ -609,7 +609,7 @@ ngx_http_xquic_init_main_conf(ngx_conf_t *cf, void *conf)
     }
 
     if (qmcf->congestion_control.data == NULL) {
-        ngx_str_set(&(qmcf->congestion_control), "cubic");
+        ngx_str_set(&(qmcf->congestion_control), "bbr");
     }
 
     if (qmcf->pacing_on == NGX_CONF_UNSET) {


### PR DESCRIPTION
default use bbr as cc instead of cubic