### PR TITLE
Fix bitfield width in ngx_http_conf_addr_t

### DIFF
--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -311,7 +311,7 @@ typedef struct {
 typedef struct {
     ngx_http_listen_opt_t      opt;
 
-    unsigned                   protocols:3;
+    unsigned                   protocols:5;
     unsigned                   protocols_set:1;
     unsigned                   protocols_changed:1;
 


### PR DESCRIPTION
In `src/http/ngx_http.c` function `ngx_http_add_addresses`, the following code is present:

```c
#if (NGX_HTTP_SSL)
        ssl = lsopt->ssl || addr[i].opt.ssl;
        protocols |= lsopt->ssl << 1;
        protocols_prev |= addr[i].opt.ssl << 1;
#endif
#if (NGX_HTTP_V2)
        http2 = lsopt->http2 || addr[i].opt.http2;
        protocols |= lsopt->http2 << 2;
        protocols_prev |= addr[i].opt.http2 << 2;
#endif
#if (T_NGX_XQUIC)
        xquic = lsopt->xquic || addr[i].opt.xquic;
        protocols |= lsopt->xquic << 3;
        protocols_prev |= addr[i].opt.xquic << 3;
#endif
#if (T_NGX_HAVE_XUDP)
        xudp = lsopt->xudp || addr[i].opt.xudp || port->xudp;
        protocols |= lsopt->xudp << 4;
        protocols_prev |= addr[i].opt.xudp << 4;
#endif
#if (T_NGX_HTTPS_ALLOW_HTTP)
        https_allow_http = lsopt->https_allow_http || addr[i].opt.https_allow_http;
#endif

// ...

            addr[i].protocols = protocols;
            addr[i].protocols_set = 1;
```

This assumes the `protocols` field has width 5 but it is only width 3. This corrupts the next field and causes strange errors. This is fixed by increasing the width to 5 bits.