### PR TITLE
Add "https" request check  type for ngx_http_upstream_check_module

### DIFF
--- a/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
+++ b/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
@@ -3167,7 +3167,7 @@ ngx_http_upstream_check_set_ssl_name(ngx_http_upstream_check_peer_t *peer)
 
     name.data = p;
 
-    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0,
                    "upstream check SSL server name: \"%s\"", name.data);
 
     if (SSL_set_tlsext_host_name(c->ssl->connection,


### PR DESCRIPTION
In the current tengine implementation, there is ssl_hello check type which can do only do ssl handshake check.
With "https" check type I added, we can do full-featured https request check just like the "http" type.

We can add `check_ssl_ciphers`, `check_ssl_protocols`, `check_ssl_server_name`, `check_ssl_verify`, `check_ssl_verify_depth`, `check_ssl_trusted_certificate`, `check_ssl_crl` config instruction in  upstream block of nginx.conf, and for the config instruction "check", we can use type="https" to enable the https check type. 

The following is an config example:

        upstream backend {
                check type=http interval=3000 rise=2 fall=5 timeout=3000 port=443;
                check_http_send "GET / HTTP/1.1\r\nHost: www.test.com\r\n\r\n";
                check_http_expect_alive http_2xx http_3xx;
                check_ssl_server_name www.test.com;
                check_ssl_verify on;
                check_ssl_verify_depth 1;
                check_ssl_trusted_certificate ca.pem;
                server 111.22.33.44:443;
        }

PS:
    `check_http_send` & `check_http_expect_alive` config instruction is reused from the "http" check type.



