### PR TITLE
fix: Security patches for CVE-2026-42945, CVE-2026-42946, CVE-2026-42934, CVE-2026-40701

### DIFF
--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -111,6 +111,7 @@ struct ngx_ssl_ocsp_ctx_s {
 
     ngx_resolver_t              *resolver;
     ngx_msec_t                   resolver_timeout;
+    ngx_resolver_ctx_t          *resolve;
 
     ngx_msec_t                   timeout;
 
@@ -1303,6 +1304,10 @@ ngx_ssl_ocsp_done(ngx_ssl_ocsp_ctx_t *ctx)
     ngx_log_debug0(NGX_LOG_DEBUG_EVENT, ctx->log, 0,
                    "ssl ocsp done");
 
+    if (ctx->resolve) {
+        ngx_resolve_name_done(ctx->resolve);
+    }
+
     if (ctx->peer.connection) {
         ngx_close_connection(ctx->peer.connection);
     }
@@ -1395,7 +1400,10 @@ ngx_ssl_ocsp_request(ngx_ssl_ocsp_ctx_t *ctx)
         resolve->data = ctx;
         resolve->timeout = ctx->resolver_timeout;
 
+        ctx->resolve = resolve;
+
         if (ngx_resolve_name(resolve) != NGX_OK) {
+            ctx->resolve = NULL;
             ngx_ssl_ocsp_error(ctx);
             return;
         }
@@ -1484,6 +1492,7 @@ ngx_ssl_ocsp_resolve_handler(ngx_resolver_ctx_t *resolve)
     }
 
     ngx_resolve_name_done(resolve);
+    ctx->resolve = NULL;
 
     ngx_ssl_ocsp_connect(ctx);
     return;
@@ -1491,6 +1500,8 @@ ngx_ssl_ocsp_resolve_handler(ngx_resolver_ctx_t *resolve)
 failed:
 
     ngx_resolve_name_done(resolve);
+    ctx->resolve = NULL;
+
     ngx_ssl_ocsp_error(ctx);
 }
 

--- a/src/http/modules/ngx_http_charset_filter_module.c
+++ b/src/http/modules/ngx_http_charset_filter_module.c
@@ -689,7 +689,6 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
     u_char        c, *p, *src, *dst, *saved, **table;
     uint32_t      n;
     ngx_buf_t    *b;
-    ngx_uint_t    i;
     ngx_chain_t  *out, *cl, **ll;
 
     src = buf->pos;
@@ -783,18 +782,12 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pool->log, 0,
                    "http charset utf saved: %z", ctx->saved_len);
 
-    p = src;
-
-    for (i = ctx->saved_len; i < NGX_UTF_LEN; i++) {
-        ctx->saved[i] = *p++;
-
-        if (p == buf->last) {
-            break;
-        }
-    }
+    len = ngx_min(NGX_UTF_LEN - ctx->saved_len, (size_t) (buf->last - src));
+    ngx_memcpy(&ctx->saved[ctx->saved_len], src, len);
+    len += ctx->saved_len;
 
     saved = ctx->saved;
-    n = ngx_utf8_decode(&saved, i);
+    n = ngx_utf8_decode(&saved, len);
 
     c = '\0';
 
@@ -810,7 +803,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
 
         /* incomplete UTF-8 symbol */
 
-        if (i < NGX_UTF_LEN) {
+        if (len < NGX_UTF_LEN) {
             out = ngx_http_charset_get_buf(pool, ctx);
             if (out == NULL) {
                 return NULL;
@@ -823,8 +816,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
             b->sync = 1;
             b->shadow = buf;
 
-            ngx_memcpy(&ctx->saved[ctx->saved_len], src, i);
-            ctx->saved_len += i;
+            ctx->saved_len = len;
 
             return out;
         }

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -1030,6 +1030,10 @@ ngx_http_scgi_process_status_line(ngx_http_request_t *r)
 
     u = r->upstream;
 
+    if (r->state == 0) {
+        r->header_name_start = u->buffer.pos;
+    }
+
     rc = ngx_http_parse_status_line(r, &u->buffer, status);
 
     if (rc == NGX_AGAIN) {
@@ -1038,6 +1042,8 @@ ngx_http_scgi_process_status_line(ngx_http_request_t *r)
 
     if (rc == NGX_ERROR) {
         u->process_header = ngx_http_scgi_process_header;
+        u->buffer.pos = r->header_name_start;
+        r->state = 0;
         return ngx_http_scgi_process_header(r);
     }
 

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -1294,6 +1294,10 @@ ngx_http_uwsgi_process_status_line(ngx_http_request_t *r)
 
     u = r->upstream;
 
+    if (r->state == 0) {
+        r->header_name_start = u->buffer.pos;
+    }
+
     rc = ngx_http_parse_status_line(r, &u->buffer, status);
 
     if (rc == NGX_AGAIN) {
@@ -1302,6 +1306,8 @@ ngx_http_uwsgi_process_status_line(ngx_http_request_t *r)
 
     if (rc == NGX_ERROR) {
         u->process_header = ngx_http_uwsgi_process_header;
+        u->buffer.pos = r->header_name_start;
+        r->state = 0;
         return ngx_http_uwsgi_process_header(r);
     }
 

--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -1202,6 +1202,7 @@ ngx_http_script_regex_end_code(ngx_http_script_engine_t *e)
 
     r = e->request;
 
+    e->is_args = 0;
     e->quote = 0;
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,


### PR DESCRIPTION
## Summary

Backport security fixes from nginx 1.30.1 for four CVEs affecting the nginx core used in Tengine.

## CVEs Fixed

### CVE-2026-42945 - Heap buffer overflow in ngx_http_rewrite_module (Critical, CVSS 9.2)

If there were arguments in a rewrite's replacement string, the `is_args` flag was set and never cleared. This caused escaping to be incorrectly applied to captures evaluated in subsequent `set` or `if` directives. Since the buffer was allocated without expecting escaping, this resulted in a heap buffer overrun and possible remote code execution.

**Fix:** Reset `e->is_args` to 0 in `ngx_http_script_regex_end_code()`.

Based on: https://github.com/nginx/nginx/commit/524977e

### CVE-2026-42946 - Buffer overread in ngx_http_scgi_module and ngx_http_uwsgi_module (High, CVSS 8.3)

When the first response line from an SCGI/uWSGI backend was not a valid HTTP status line, the fallback to header parsing could start with a wrong parsing state. Additionally, if the status line was split across reads, the already-processed portion was lost on fallback, leading to buffer overread.

**Fix:** Reset `r->state` to 0 on fallback, save buffer position before parsing using `r->header_name_start`, and restore `u->buffer.pos` for proper backtracking.

Based on: https://github.com/nginx/nginx/commit/baef7fd and https://github.com/nginx/nginx/commit/39d7d0b

### CVE-2026-42934 - Buffer overread in ngx_http_charset_module (Low)

When a multi-byte UTF-8 character was split across 3+ single-byte buffers, `ngx_utf8_decode()` was called with the wrong byte count (last saved-array index instead of total length), and the subsequent `ngx_memcpy()` could read past the input buffer boundary.

**Fix:** Replace the for-loop with a direct `ngx_memcpy()` using `ngx_min()` to calculate the correct copy length, and pass the proper total length to `ngx_utf8_decode()`.

Based on: https://github.com/nginx/nginx/commit/54b7945

### CVE-2026-40701 - Use-after-free in OCSP resolver (Medium, CVSS 6.3)

When a client SSL connection was terminated while resolving an OCSP responder hostname, the OCSP context was freed but the resolver context was not. This resulted in use-after-free when the DNS resolution completed.

**Fix:** Track the resolver context in `ngx_ssl_ocsp_ctx_s` and cancel any pending resolution in `ngx_ssl_ocsp_done()`.

Based on: https://github.com/nginx/nginx/commit/d2b8d47

## Files Changed

- `src/http/ngx_http_script.c`
- `src/http/modules/ngx_http_scgi_module.c`
- `src/http/modules/ngx_http_uwsgi_module.c`
- `src/http/modules/ngx_http_charset_filter_module.c`
- `src/event/ngx_event_openssl_stapling.c`

## Testing

All fixes are minimal and match the official nginx 1.30.1 patches. No functional behavior changes beyond the security fixes.