### PR TITLE
fix: CVE-2026-1642 - SSL upstream injection via premature plain text response

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2663,6 +2663,15 @@ ngx_http_upstream_process_header(ngx_http_request_t *r, ngx_http_upstream_t *u)
             return;
         }
 
+#if (NGX_HTTP_SSL)
+        if (u->ssl && c->ssl == NULL) {
+            ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                          "upstream prematurely sent response");
+            ngx_http_upstream_next(r, u, NGX_HTTP_UPSTREAM_FT_ERROR);
+            return;
+        }
+#endif
+
         u->state->bytes_received += n;
 
         u->buffer.last += n;


### PR DESCRIPTION
## Summary

Backport security fix from nginx 1.28.2 for CVE-2026-1642 affecting SSL upstream connections.

## CVE-2026-1642 - SSL upstream injection (CVSS 4.0: 8.2 High / CVSS 3.1: 5.9 Medium)

When NGINX is configured to proxy to upstream TLS servers, a race condition exists in the event loop: if an upstream response arrives quickly enough, both read and write events can be triggered together within the same iteration. Since SSL initialization happens in the write event handler, the read event handler may process a plain text response before the SSL handshake is initiated.

This allows a man-in-the-middle attacker on the upstream side to inject arbitrary plain text data as a valid response from the proxied server.

**Fix:** Add a check in `ngx_http_upstream_process_header()` to detect when data is received on an SSL-enabled connection before the SSL handshake has been initiated (`u->ssl && c->ssl == NULL`). If detected, reject the response and try the next upstream.

Based on official nginx fix: https://github.com/nginx/nginx/commit/784fa05

## Files Changed

- `src/http/ngx_http_upstream.c`