### PR TITLE
fix(http2,h3): respect server_tag directive in HTTP/2 and HTTP/3 responses

### DIFF
--- a/modules/ngx_http_xquic_module/ngx_http_xquic_filter_module.c
+++ b/modules/ngx_http_xquic_module/ngx_http_xquic_filter_module.c
@@ -460,8 +460,12 @@ ngx_http_xquic_header_filter(ngx_http_request_t *r)
     /* server */
     if (r->headers_out.server == NULL) {
 #if (T_NGX_SERVER_INFO)
-        if (clcf->server_tag_type != NGX_HTTP_SERVER_TAG_OFF) {
+        if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_OFF) {
+            /* no Server header */
+
+        } else
 #endif
+        {
             h = ngx_list_push(&r->headers_out.headers);
             if (h == NULL) {
                 return NGX_ERROR;
@@ -469,12 +473,14 @@ ngx_http_xquic_header_filter(ngx_http_request_t *r)
 
             h->hash = 1;
             ngx_str_set(&h->key, NGX_HTTP_XQUIC_NAME_SERVER);
+
 #if (T_NGX_SERVER_INFO)
             if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_CUSTOMIZED) {
                 h->value = clcf->server_tag;
 
-            } else {
+            } else
 #endif
+            {
                 if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
 #if (T_NGX_SERVER_INFO)
                     ngx_str_set(&h->value, TENGINE_VER);
@@ -490,13 +496,10 @@ ngx_http_xquic_header_filter(ngx_http_request_t *r)
                 } else {
                     ngx_str_set(&h->value, TENGINE);
                 }
-#if (T_NGX_SERVER_INFO)
             }
-#endif
+
             r->headers_out.server = h;
-#if (T_NGX_SERVER_INFO)
         }
-#endif
     }
 
     /* date */

--- a/modules/ngx_http_xquic_module/ngx_http_xquic_filter_module.c
+++ b/modules/ngx_http_xquic_module/ngx_http_xquic_filter_module.c
@@ -459,29 +459,44 @@ ngx_http_xquic_header_filter(ngx_http_request_t *r)
 
     /* server */
     if (r->headers_out.server == NULL) {
-        h = ngx_list_push(&r->headers_out.headers);
-        if (h == NULL) {
-            return NGX_ERROR;
-        }
+#if (T_NGX_SERVER_INFO)
+        if (clcf->server_tag_type != NGX_HTTP_SERVER_TAG_OFF) {
+#endif
+            h = ngx_list_push(&r->headers_out.headers);
+            if (h == NULL) {
+                return NGX_ERROR;
+            }
 
-        h->hash = 1;
-        ngx_str_set(&h->key, NGX_HTTP_XQUIC_NAME_SERVER);
-        if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
+            h->hash = 1;
+            ngx_str_set(&h->key, NGX_HTTP_XQUIC_NAME_SERVER);
 #if (T_NGX_SERVER_INFO)
-            ngx_str_set(&h->value, TENGINE_VER);
-#else
-            ngx_str_set(&h->value, NGINX_VER);
+            if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_CUSTOMIZED) {
+                h->value = clcf->server_tag;
+
+            } else {
 #endif
-        } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
+                if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
 #if (T_NGX_SERVER_INFO)
-            ngx_str_set(&h->value, TENGINE_VER_BUILD);
+                    ngx_str_set(&h->value, TENGINE_VER);
 #else
-            ngx_str_set(&h->value, NGINX_VER_BUILD);
+                    ngx_str_set(&h->value, NGINX_VER);
 #endif
-        } else {
-            ngx_str_set(&h->value, TENGINE);
+                } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
+#if (T_NGX_SERVER_INFO)
+                    ngx_str_set(&h->value, TENGINE_VER_BUILD);
+#else
+                    ngx_str_set(&h->value, NGINX_VER_BUILD);
+#endif
+                } else {
+                    ngx_str_set(&h->value, TENGINE);
+                }
+#if (T_NGX_SERVER_INFO)
+            }
+#endif
+            r->headers_out.server = h;
+#if (T_NGX_SERVER_INFO)
         }
-        r->headers_out.server = h;
+#endif
     }
 
     /* date */

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -274,8 +274,15 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
 
     if (r->headers_out.server == NULL) {
 #if (T_NGX_SERVER_INFO)
-        if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_ON) {
+        if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_OFF) {
+            /* no Server header */
+
+        } else if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_CUSTOMIZED) {
+            len += 1 + NGX_HTTP_V2_INT_OCTETS + clcf->server_tag.len;
+
+        } else
 #endif
+        {
             if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
                 len += 1 + nginx_ver_len;
 
@@ -285,12 +292,7 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
             } else {
                 len += 1 + sizeof(nginx);
             }
-#if (T_NGX_SERVER_INFO)
-        } else if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_CUSTOMIZED) {
-            len += 1 + NGX_HTTP_V2_INT_OCTETS + clcf->server_tag.len;
         }
-        /* NGX_HTTP_SERVER_TAG_OFF: no Server header */
-#endif
     }
 
     if (r->headers_out.date == NULL) {
@@ -486,61 +488,9 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
 
     if (r->headers_out.server == NULL) {
 #if (T_NGX_SERVER_INFO)
-        if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_ON) {
-#endif
+        if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_OFF) {
+            /* no Server header */
 
-        if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
-            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
-                           "http2 output header: \"server: %s\"",
-                           NGINX_VER);
-
-        } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
-            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
-                           "http2 output header: \"server: %s\"",
-                           NGINX_VER_BUILD);
-
-        } else {
-            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, fc->log, 0,
-                           "http2 output header: \"server: nginx\"");
-        }
-
-        *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-
-        if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
-            if (nginx_ver[0] == '\0') {
-#if (T_NGX_SERVER_INFO)
-                p = ngx_http_v2_write_value(nginx_ver, (u_char *) TENGINE_VER,
-                                            sizeof(TENGINE_VER) - 1, tmp);
-#else
-                p = ngx_http_v2_write_value(nginx_ver, (u_char *) NGINX_VER,
-                                            sizeof(NGINX_VER) - 1, tmp);
-#endif
-                nginx_ver_len = p - nginx_ver;
-            }
-
-            pos = ngx_cpymem(pos, nginx_ver, nginx_ver_len);
-
-        } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
-            if (nginx_ver_build[0] == '\0') {
-#if (T_NGX_SERVER_INFO)
-                p = ngx_http_v2_write_value(nginx_ver_build,
-                                            (u_char *) TENGINE_VER_BUILD,
-                                            sizeof(TENGINE_VER_BUILD) - 1, tmp);
-#else
-                p = ngx_http_v2_write_value(nginx_ver_build,
-                                            (u_char *) NGINX_VER_BUILD,
-                                            sizeof(NGINX_VER_BUILD) - 1, tmp);
-#endif
-                nginx_ver_build_len = p - nginx_ver_build;
-            }
-
-            pos = ngx_cpymem(pos, nginx_ver_build, nginx_ver_build_len);
-
-        } else {
-            pos = ngx_cpymem(pos, nginx, sizeof(nginx));
-        }
-
-#if (T_NGX_SERVER_INFO)
         } else if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_CUSTOMIZED) {
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
                            "http2 output header: \"server: %V\"",
@@ -549,9 +499,61 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
             *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
             pos = ngx_http_v2_write_value(pos, clcf->server_tag.data,
                                           clcf->server_tag.len, tmp);
-        }
-        /* NGX_HTTP_SERVER_TAG_OFF: no Server header */
+
+        } else
 #endif
+        {
+            if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
+                               "http2 output header: \"server: %s\"",
+                               NGINX_VER);
+
+            } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
+                               "http2 output header: \"server: %s\"",
+                               NGINX_VER_BUILD);
+
+            } else {
+                ngx_log_debug0(NGX_LOG_DEBUG_HTTP, fc->log, 0,
+                               "http2 output header: \"server: nginx\"");
+            }
+
+            *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
+
+            if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
+                if (nginx_ver[0] == '\0') {
+#if (T_NGX_SERVER_INFO)
+                    p = ngx_http_v2_write_value(nginx_ver, (u_char *) TENGINE_VER,
+                                                sizeof(TENGINE_VER) - 1, tmp);
+#else
+                    p = ngx_http_v2_write_value(nginx_ver, (u_char *) NGINX_VER,
+                                                sizeof(NGINX_VER) - 1, tmp);
+#endif
+                    nginx_ver_len = p - nginx_ver;
+                }
+
+                pos = ngx_cpymem(pos, nginx_ver, nginx_ver_len);
+
+            } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
+                if (nginx_ver_build[0] == '\0') {
+#if (T_NGX_SERVER_INFO)
+                    p = ngx_http_v2_write_value(nginx_ver_build,
+                                                (u_char *) TENGINE_VER_BUILD,
+                                                sizeof(TENGINE_VER_BUILD) - 1, tmp);
+#else
+                    p = ngx_http_v2_write_value(nginx_ver_build,
+                                                (u_char *) NGINX_VER_BUILD,
+                                                sizeof(NGINX_VER_BUILD) - 1, tmp);
+#endif
+                    nginx_ver_build_len = p - nginx_ver_build;
+                }
+
+                pos = ngx_cpymem(pos, nginx_ver_build, nginx_ver_build_len);
+
+            } else {
+                pos = ngx_cpymem(pos, nginx, sizeof(nginx));
+            }
+        }
     }
 
     if (r->headers_out.date == NULL) {

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -273,16 +273,24 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
     if (r->headers_out.server == NULL) {
+#if (T_NGX_SERVER_INFO)
+        if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_ON) {
+#endif
+            if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
+                len += 1 + nginx_ver_len;
 
-        if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
-            len += 1 + nginx_ver_len;
+            } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
+                len += 1 + nginx_ver_build_len;
 
-        } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
-            len += 1 + nginx_ver_build_len;
-
-        } else {
-            len += 1 + sizeof(nginx);
+            } else {
+                len += 1 + sizeof(nginx);
+            }
+#if (T_NGX_SERVER_INFO)
+        } else if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_CUSTOMIZED) {
+            len += 1 + NGX_HTTP_V2_INT_OCTETS + clcf->server_tag.len;
         }
+        /* NGX_HTTP_SERVER_TAG_OFF: no Server header */
+#endif
     }
 
     if (r->headers_out.date == NULL) {
@@ -477,6 +485,9 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
     }
 
     if (r->headers_out.server == NULL) {
+#if (T_NGX_SERVER_INFO)
+        if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_ON) {
+#endif
 
         if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
@@ -528,6 +539,19 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
         } else {
             pos = ngx_cpymem(pos, nginx, sizeof(nginx));
         }
+
+#if (T_NGX_SERVER_INFO)
+        } else if (clcf->server_tag_type == NGX_HTTP_SERVER_TAG_CUSTOMIZED) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
+                           "http2 output header: \"server: %V\"",
+                           &clcf->server_tag);
+
+            *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
+            pos = ngx_http_v2_write_value(pos, clcf->server_tag.data,
+                                          clcf->server_tag.len, tmp);
+        }
+        /* NGX_HTTP_SERVER_TAG_OFF: no Server header */
+#endif
     }
 
     if (r->headers_out.date == NULL) {


### PR DESCRIPTION
The server_tag directive (off/custom) was ignored in HTTP/2 and HTTP/3 responses because both ngx_http_v2_filter_module and ngx_http_xquic_filter_module only checked server_tokens without considering server_tag_type. This caused the Server header to always appear in HTTP/2 and HTTP/3 responses even with 'server_tag off' configured.

Add T_NGX_SERVER_INFO conditional checks for server_tag_type in both the HTTP/2 header filter and the HTTP/3 (xquic) header filter, consistent with the HTTP/1.x header filter logic.

Fixes #2004