### PR TITLE
fix(rewrite): heap buffer overflow with overlapping captures (CVE-2026-9256)

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -1037,6 +1037,8 @@ ngx_http_script_start_args_code(ngx_http_script_engine_t *e)
 void
 ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
 {
+    int                           *cap;
+    u_char                        *p;
     size_t                         len;
     ngx_int_t                      rc;
     ngx_uint_t                     n;
@@ -1143,15 +1145,19 @@ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
     if (code->lengths == NULL) {
         e->buf.len = code->size;
 
-        if (code->uri) {
-            if (r->ncaptures && (r->quoted_uri || r->plus_in_uri)) {
-                e->buf.len += 2 * ngx_escape_uri(NULL, r->uri.data, r->uri.len,
-                                                 NGX_ESCAPE_ARGS);
-            }
-        }
+        cap = r->captures;
+        p = r->captures_data;
 
         for (n = 2; n < r->ncaptures; n += 2) {
-            e->buf.len += r->captures[n + 1] - r->captures[n];
+            e->buf.len += cap[n + 1] - cap[n];
+
+            if (code->uri) {
+                if (r->quoted_uri || r->plus_in_uri) {
+                    e->buf.len += 2 * ngx_escape_uri(NULL, &p[cap[n]],
+                                                     cap[n + 1] - cap[n],
+                                                     NGX_ESCAPE_ARGS);
+                }
+            }
         }
 
     } else {


### PR DESCRIPTION
## Description

Fix a heap buffer overflow vulnerability in the `ngx_http_rewrite_module` (CVE-2026-9256).

## Root Cause

When a `rewrite` directive uses a regex pattern with overlapping PCRE captures (e.g., `^/((.*))$`) and the replacement string references multiple such captures (e.g., `$1$2`), the allocated buffer length could be smaller than the actual replacement string. This occurs when the `redirect` parameter is specified or when query arguments are present in the replacement string.

The original code calculated the URI escape length for the **entire URI** (`r->uri.data`, `r->uri.len`) instead of for each individual capture group. With overlapping captures, the total length of all captures can exceed the original URI length, causing the buffer to be undersized when URI escaping is needed.

## Fix

Iterate through each capture group and calculate the escape length for that specific capture (not the entire URI). This fix is consistent with the nginx official fix (commit `c3f9f23`, PR [#1395](https://github.com/nginx/nginx/pull/1395)).

**Modified file:** `src/http/ngx_http_script.c`

## Vulnerable Configuration Examples

The following configurations result in a heap buffer overflow when accessing URI `/++++++++++++++++++++++++++++++`:

```nginx
# Scenario 1: redirect flag
location / {
    rewrite ^/((.*))$ http://127.0.0.1:8080/$1$2 redirect;
    return 200 foo;
}

# Scenario 2: query arguments in replacement
location / {
    rewrite ^/((.*))$ http://127.0.0.1:8080/?$1$2;
    return 200 foo;
}
```

## tengine vs nginx Code Comparison

The `ngx_http_script_regex_start_code` function in tengine has **identical code structure** to nginx before the fix. The fix can be applied directly with no compatibility issues or code differences.

## References

- nginx PR: https://github.com/nginx/nginx/pull/1395
- nginx commit: https://github.com/nginx/nginx/commit/c3f9f2341ff7e4fd5a31075cd3ec64e789792433
- CVE: [CVE-2026-9256](https://nvd.nist.gov/vuln/detail/CVE-2026-9256)
- CVSS: 8.1 HIGH
- Reporter: Mufeed VH (Winfunc Research)
