### PR TITLE
HTTP method/encoding compatibility, timing observability, SSL logging & upstream error-code enhancements

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -1565,3 +1565,4 @@ have=T_HTTP_UPSTREAM_TIMEOUT_VAR . auto/have
 have=T_NGX_HTTPS_ALLOW_HTTP . auto/have
 have=T_NGX_REQUEST_START_TIME . auto/have
 have=T_NGX_SOCKET_BUFFER . auto/have
+have=T_NGX_X_ACCEL_REDIRECT . auto/have

--- a/auto/modules
+++ b/auto/modules
@@ -1567,3 +1567,6 @@ have=T_NGX_REQUEST_START_TIME . auto/have
 have=T_NGX_SOCKET_BUFFER . auto/have
 have=T_NGX_X_ACCEL_REDIRECT . auto/have
 have=T_NGX_ESCAPE_WWW_FORM_ALI . auto/have
+if [ $NGX_DUP_HOST = YES ]; then
+    have=T_NGX_DUP_HOST . auto/have
+fi

--- a/auto/modules
+++ b/auto/modules
@@ -1567,6 +1567,7 @@ have=T_NGX_REQUEST_START_TIME . auto/have
 have=T_NGX_SOCKET_BUFFER . auto/have
 have=T_NGX_X_ACCEL_REDIRECT . auto/have
 have=T_NGX_ESCAPE_WWW_FORM_ALI . auto/have
+have=T_NGX_HTTP_STAT_TIME . auto/have
 if [ $NGX_DUP_HOST = YES ]; then
     have=T_NGX_DUP_HOST . auto/have
 fi

--- a/auto/modules
+++ b/auto/modules
@@ -1566,3 +1566,4 @@ have=T_NGX_HTTPS_ALLOW_HTTP . auto/have
 have=T_NGX_REQUEST_START_TIME . auto/have
 have=T_NGX_SOCKET_BUFFER . auto/have
 have=T_NGX_X_ACCEL_REDIRECT . auto/have
+have=T_NGX_ESCAPE_WWW_FORM_ALI . auto/have

--- a/auto/modules
+++ b/auto/modules
@@ -1569,6 +1569,7 @@ have=T_NGX_X_ACCEL_REDIRECT . auto/have
 have=T_NGX_ESCAPE_WWW_FORM_ALI . auto/have
 have=T_NGX_HTTP_STAT_TIME . auto/have
 have=T_NGX_SSL_ERR_LOG_ALI . auto/have
+have=T_NGX_HTTP_CHANGE_UPSTREAM_NO_SERVER_STATUS . auto/have
 if [ $NGX_DUP_HOST = YES ]; then
     have=T_NGX_DUP_HOST . auto/have
 fi

--- a/auto/modules
+++ b/auto/modules
@@ -1568,6 +1568,7 @@ have=T_NGX_SOCKET_BUFFER . auto/have
 have=T_NGX_X_ACCEL_REDIRECT . auto/have
 have=T_NGX_ESCAPE_WWW_FORM_ALI . auto/have
 have=T_NGX_HTTP_STAT_TIME . auto/have
+have=T_NGX_SSL_ERR_LOG_ALI . auto/have
 if [ $NGX_DUP_HOST = YES ]; then
     have=T_NGX_DUP_HOST . auto/have
 fi

--- a/auto/options
+++ b/auto/options
@@ -143,6 +143,8 @@ STREAM_UPSTREAM_ZONE=YES
 STREAM_SSL_PREREAD=NO
 STREAM_SNI=NO
 
+NGX_DUP_HOST=NO
+
 DYNAMIC_MODULES=
 DYNAMIC_MODULES_SRCS=
 
@@ -378,6 +380,7 @@ use the \"--with-mail_ssl_module\" option instead"
         --with-stream_ssl_preread_module)
                                          STREAM_SSL_PREREAD=YES     ;;
         --with-stream_sni)               STREAM_SNI=YES             ;;
+        --with-http_dup_host)            NGX_DUP_HOST=YES           ;;
         --without-stream_limit_conn_module)
                                          STREAM_LIMIT_CONN=NO       ;;
         --without-stream_access_module)  STREAM_ACCESS=NO           ;;
@@ -625,6 +628,7 @@ cat << END
   --with-stream_geoip_module=dynamic enable dynamic ngx_stream_geoip_module
   --with-stream_ssl_preread_module   enable ngx_stream_ssl_preread_module
   --with-stream_sni                  enable dynamic server block
+  --with-http_dup_host               allow duplicate Host request headers
   --without-stream_limit_conn_module disable ngx_stream_limit_conn_module
   --without-stream_access_module     disable ngx_stream_access_module
   --without-stream_geo_module        disable ngx_stream_geo_module

--- a/src/core/ngx_string.c
+++ b/src/core/ngx_string.c
@@ -1682,12 +1682,42 @@ ngx_escape_uri(u_char *dst, u_char *src, size_t size, ngx_uint_t type)
         0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
     };
 
+#if (T_NGX_ESCAPE_WWW_FORM_ALI)
+                    /* NOT: " ", "-", ".", "_", "0"-"9", "A"-"Z", "a"-"z" */
+
+    static uint32_t   form[] = {
+        0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
+
+                    /* ?>=< ;:98 7654 3210  /.-, +*)( '&%$ #"!  */
+        0xfc009ffe, /* 1111 1100 0000 0000  1001 1111 1111 1110 */
+
+                    /* _^]\ [ZYX WVUT SRQP  ONML KJIH GFED CBA@ */
+        0x78000001, /* 0111 1000 0000 0000  0000 0000 0000 0001 */
+
+                    /*  ~}| {zyx wvut srqp  onml kjih gfed cba` */
+        0xf8000001, /* 1111 1000 0000 0000  0000 0000 0000 0001 */
+
+        0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
+        0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
+        0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
+        0xffffffff  /* 1111 1111 1111 1111  1111 1111 1111 1111 */
+    };
+#endif
+
     static uint32_t  *map[] =
         { uri, args, uri_component, html, refresh, memcached, memcached,
-          mail_xtext };
+          mail_xtext
+#if (T_NGX_ESCAPE_WWW_FORM_ALI)
+          , form
+#endif
+        };
 
     static u_char  map_char[] =
-        { '%', '%', '%', '%', '%', '%', '%', '+' };
+        { '%', '%', '%', '%', '%', '%', '%', '+'
+#if (T_NGX_ESCAPE_WWW_FORM_ALI)
+          , '%'
+#endif
+        };
 
 
     escape = map[type];
@@ -1718,7 +1748,19 @@ ngx_escape_uri(u_char *dst, u_char *src, size_t size, ngx_uint_t type)
             src++;
 
         } else {
+#if (T_NGX_ESCAPE_WWW_FORM_ALI)
+            if (type == NGX_ESCAPE_WWW_FORM
+                && *src == ' ')
+            {
+                src++;
+                *dst++ = '+';
+
+            } else {
+                *dst++ = *src++;
+            }
+#else
             *dst++ = *src++;
+#endif
         }
         size--;
     }
@@ -1749,6 +1791,14 @@ ngx_unescape_uri(u_char **dst, u_char **src, size_t size, ngx_uint_t type)
 
         switch (state) {
         case sw_usual:
+#if (T_NGX_ESCAPE_WWW_FORM_ALI)
+            if (ch == '+'
+                && (type & NGX_UNESCAPE_WWW_FORM))
+            {
+                *d++ = ' ';
+                break;
+            }
+#endif
             if (ch == '?'
                 && (type & (NGX_UNESCAPE_URI|NGX_UNESCAPE_REDIRECT)))
             {

--- a/src/core/ngx_string.h
+++ b/src/core/ngx_string.h
@@ -207,9 +207,15 @@ u_char *ngx_utf8_cpystrn(u_char *dst, u_char *src, size_t n, size_t len);
 #define NGX_ESCAPE_MEMCACHED      5
 #define NGX_ESCAPE_MAIL_AUTH      6
 #define NGX_ESCAPE_MAIL_XTEXT     7
+#if (T_NGX_ESCAPE_WWW_FORM_ALI)
+#define NGX_ESCAPE_WWW_FORM       8
+#endif
 
 #define NGX_UNESCAPE_URI       1
 #define NGX_UNESCAPE_REDIRECT  2
+#if (T_NGX_ESCAPE_WWW_FORM_ALI)
+#define NGX_UNESCAPE_WWW_FORM  4
+#endif
 
 uintptr_t ngx_escape_uri(u_char *dst, u_char *src, size_t size,
     ngx_uint_t type);

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -4416,6 +4416,13 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 {
     int         n;
     ngx_uint_t  level;
+#if (T_NGX_SSL_ERR_LOG_ALI)
+    u_char     *newtext;
+    u_char     *p;
+    u_char     *sni_p;
+    size_t      newlen;
+    const char *servername;
+#endif
 
     level = NGX_LOG_CRIT;
 
@@ -4438,7 +4445,11 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 
             case NGX_ERROR_IGNORE_ECONNRESET:
             case NGX_ERROR_INFO:
+#if (T_NGX_SSL_ERR_LOG_ALI)
+                level = NGX_LOG_ERR;
+#else
                 level = NGX_LOG_INFO;
+#endif
                 break;
 
             case NGX_ERROR_ERR:
@@ -4627,7 +4638,11 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 
             case NGX_ERROR_IGNORE_ECONNRESET:
             case NGX_ERROR_INFO:
+#if (T_NGX_SSL_ERR_LOG_ALI)
+                level = NGX_LOG_ERR;
+#else
                 level = NGX_LOG_INFO;
+#endif
                 break;
 
             case NGX_ERROR_ERR:
@@ -4639,6 +4654,37 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             }
         }
     }
+
+#if (T_NGX_SSL_ERR_LOG_ALI)
+    /* insert servername into text */
+    servername = SSL_get_servername(c->ssl->connection, TLSEXT_NAMETYPE_host_name);
+    if (servername == NULL) {
+        servername = "-";
+    }
+
+    /* do not minus 1 due to need adding space */
+    newlen = sizeof(" SNI: ") + ngx_strlen(servername) + ngx_strlen(text) + 1;
+
+    newtext = ngx_palloc(c->pool, newlen);
+    if (newtext) {
+
+        p = ngx_cpymem(newtext, (u_char *) " SNI: ", sizeof(" SNI: ") - 1);
+        sni_p = p;
+        p = ngx_cpymem(p, (u_char *) servername, ngx_strlen(servername));
+
+        /* remove % in server name or ngx log will format it */
+        while (sni_p < p) {
+            if (*sni_p == '%') {
+                *sni_p = '&';
+            }
+            sni_p++;
+        }
+        *p++ = ' ';
+        p = ngx_cpymem(p, (u_char *) text, ngx_strlen(text));
+        *p++ = '\0';
+        text = (char *) newtext;
+    }
+#endif
 
     ngx_ssl_error(level, c->log, err, text);
 }

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -582,6 +582,10 @@ ngx_http_create_request(ngx_connection_t *c)
     ctx->request = r;
     ctx->current_request = r;
 
+#if (T_NGX_HTTP_STAT_TIME)
+    r->stat_time.req_recv_start_time = ngx_current_msec;
+#endif
+
 #if (NGX_STAT_STUB)
     (void) ngx_atomic_fetch_add(ngx_stat_reading, 1);
     r->stat_reading = 1;
@@ -2612,6 +2616,12 @@ ngx_http_process_request_header(ngx_http_request_t *r)
 {
 #if !(NGX_HTTP_PROXY_CONNECT)
     ngx_http_core_srv_conf_t  *cscf;
+#endif
+
+#if (T_NGX_HTTP_STAT_TIME)
+    if (r == r->main) {
+        r->stat_time.req_recv_finished_time = ngx_current_msec;
+    }
 #endif
 
     if (r->headers_in.server.len == 0

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2456,6 +2456,7 @@ ngx_http_process_host(ngx_http_request_t *r, ngx_table_elt_t *h,
     ngx_str_t  host;
     in_port_t  port;
 
+#if !defined(T_NGX_DUP_HOST)
     if (r->headers_in.host) {
         ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                       "client sent duplicate host header: \"%V: %V\", "
@@ -2465,6 +2466,7 @@ ngx_http_process_host(ngx_http_request_t *r, ngx_table_elt_t *h,
         ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
         return NGX_ERROR;
     }
+#endif
 
     r->headers_in.host = h;
     h->next = NULL;

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -388,6 +388,16 @@ typedef ngx_int_t (*ngx_http_handler_pt)(ngx_http_request_t *r);
 typedef void (*ngx_http_event_handler_pt)(ngx_http_request_t *r);
 
 
+#if (T_NGX_HTTP_STAT_TIME)
+typedef struct ngx_http_request_stat_time {
+    ngx_msec_t                      req_recv_start_time;
+    ngx_msec_t                      req_recv_finished_time;
+    ngx_msec_t                      resp_send_start_time;
+    ngx_msec_t                      resp_send_finish_time;
+} ngx_http_request_stat_time_t;
+#endif
+
+
 struct ngx_http_request_s {
     uint32_t                          signature;         /* "HTTP" */
 
@@ -429,6 +439,10 @@ struct ngx_http_request_s {
 
 #if (T_NGX_RET_CACHE)
     ngx_usec_t                        start_usec;
+#endif
+
+#if (T_NGX_HTTP_STAT_TIME)
+    ngx_http_request_stat_time_t      stat_time;
 #endif
 
     ngx_uint_t                        method;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -1283,6 +1283,12 @@ ngx_http_request_body_save_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     rb = r->request_body;
 
+#if (T_NGX_HTTP_STAT_TIME)
+    if (r == r->main) {
+        r->stat_time.req_recv_finished_time = ngx_current_msec;
+    }
+#endif
+
     ll = &rb->bufs;
 
     for (cl = rb->bufs; cl; cl = cl->next) {

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -401,6 +401,15 @@ static ngx_command_t  ngx_http_upstream_commands[] = {
 
 #endif
 
+#if (T_NGX_HTTP_CHANGE_UPSTREAM_NO_SERVER_STATUS)
+    { ngx_string("upstream_change_no_server_status"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      offsetof(ngx_http_upstream_main_conf_t, change_no_server_status),
+      NULL },
+#endif
+
       ngx_null_command
 };
 
@@ -941,8 +950,21 @@ found:
 #endif
 
     if (uscf->peer.init(r, uscf) != NGX_OK) {
+#if (T_NGX_HTTP_CHANGE_UPSTREAM_NO_SERVER_STATUS)
+        ngx_http_upstream_main_conf_t  *umcf;
+
+        umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
+        if (umcf->change_no_server_status) {
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_BAD_GATEWAY);
+        } else {
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+        }
+#else
         ngx_http_upstream_finalize_request(r, u,
                                            NGX_HTTP_INTERNAL_SERVER_ERROR);
+#endif
         return;
     }
 
@@ -8008,6 +8030,10 @@ ngx_http_upstream_create_main_conf(ngx_conf_t *cf)
 
 #endif
 
+#if (T_NGX_HTTP_CHANGE_UPSTREAM_NO_SERVER_STATUS)
+    umcf->change_no_server_status = NGX_CONF_UNSET;
+#endif
+
     return umcf;
 }
 
@@ -8068,6 +8094,10 @@ ngx_http_upstream_init_main_conf(ngx_conf_t *cf, void *conf)
     if (ngx_hash_init(&hash, headers_in.elts, headers_in.nelts) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
+
+#if (T_NGX_HTTP_CHANGE_UPSTREAM_NO_SERVER_STATUS)
+    ngx_conf_init_value(umcf->change_no_server_status, 0);
+#endif
 
     return NGX_CONF_OK;
 }

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -3343,7 +3343,9 @@ ngx_http_upstream_process_headers(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
             if (r->method != NGX_HTTP_HEAD) {
                 r->method = NGX_HTTP_GET;
+#if !defined(T_NGX_X_ACCEL_REDIRECT)
                 r->method_name = ngx_http_core_get_method;
+#endif
             }
 
             ngx_http_internal_redirect(r, &uri, &args);

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -181,6 +181,12 @@ static ngx_int_t ngx_http_upstream_response_time_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_upstream_response_length_variable(
     ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
+#if (T_NGX_HTTP_STAT_TIME)
+static ngx_int_t ngx_http_upstream_stat_time_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_upstream_first_pkg_time_variable(
+    ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
+#endif
 static ngx_int_t ngx_http_upstream_header_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_upstream_trailer_variable(ngx_http_request_t *r,
@@ -468,6 +474,30 @@ static ngx_http_variable_t  ngx_http_upstream_vars[] = {
       ngx_http_upstream_response_length_variable, 2,
       NGX_HTTP_VAR_NOCACHEABLE, 0 },
 
+#if (T_NGX_HTTP_STAT_TIME)
+    { ngx_string("upstream_stat_send_start_time"), NULL,
+      ngx_http_upstream_stat_time_variable, 1,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("upstream_stat_send_finish_time"), NULL,
+      ngx_http_upstream_stat_time_variable, 2,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("upstream_stat_recv_start_time"), NULL,
+      ngx_http_upstream_stat_time_variable, 3,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("upstream_stat_recv_finish_time"), NULL,
+      ngx_http_upstream_stat_time_variable, 4,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("upstream_stat_send_time"), NULL,
+      ngx_http_upstream_stat_time_variable, 100,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("upstream_stat_recv_time"), NULL,
+      ngx_http_upstream_stat_time_variable, 101,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("upstream_first_pkg_time"), NULL,
+      ngx_http_upstream_first_pkg_time_variable, 0,
+      NGX_HTTP_VAR_NOCACHEABLE, 0 },
+#endif
+
 #if (NGX_HTTP_CACHE)
 
     { ngx_string("upstream_cache_status"), NULL,
@@ -753,6 +783,10 @@ ngx_http_upstream_init_request(ngx_http_request_t *r)
         }
 
         ngx_memzero(u->state, sizeof(ngx_http_upstream_state_t));
+
+#ifdef T_NGX_HTTP_STAT_TIME
+        u->state->ups_send_start_time = ngx_current_msec;
+#endif
     }
 
     cln = ngx_http_cleanup_add(r, 0);
@@ -1657,6 +1691,17 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     if (u->state && u->state->response_time == (ngx_msec_t) -1) {
         u->state->response_time = ngx_current_msec - u->start_time;
+#ifdef T_NGX_HTTP_STAT_TIME
+        if (u->state->ups_recv_start_time != 0) {
+            u->state->ups_recv_finish_time = ngx_current_msec;
+        }
+        if (u->state->ups_send_start_time != 0
+            && u->state->ups_send_finish_time == 0)
+        {
+            u->state->ups_send_finish_time = ngx_current_msec;
+        }
+        u->state->ups_finish_time = ngx_current_msec;
+#endif
     }
 
     u->state = ngx_array_push(r->upstream_states);
@@ -1673,6 +1718,13 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
     u->state->response_time = (ngx_msec_t) -1;
     u->state->connect_time = (ngx_msec_t) -1;
     u->state->header_time = (ngx_msec_t) -1;
+#ifdef T_NGX_HTTP_STAT_TIME
+    u->state->ups_send_start_time = ngx_current_msec;
+    u->state->ups_send_finish_time = 0;
+    u->state->ups_recv_start_time = 0;
+    u->state->ups_recv_finish_time = 0;
+    u->state->ups_finish_time = 0;
+#endif
 
     rc = ngx_event_connect_peer(&u->peer);
 #if (T_NGX_HTTP_DYNAMIC_RESOLVE)
@@ -2348,6 +2400,10 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
         u->state->connect_time = ngx_current_msec - u->start_time;
     }
 
+#ifdef T_NGX_HTTP_STAT_TIME
+    u->state->ups_send_finish_time = ngx_current_msec;
+#endif
+
     if (!u->request_sent && ngx_http_upstream_test_connect(c) != NGX_OK) {
         ngx_http_upstream_next(r, u, NGX_HTTP_UPSTREAM_FT_ERROR);
         return;
@@ -2774,6 +2830,12 @@ ngx_http_upstream_process_header(ngx_http_request_t *r, ngx_http_upstream_t *u)
         u->valid_header_in = 0;
 
         u->peer.cached = 0;
+#endif
+
+#ifdef T_NGX_HTTP_STAT_TIME
+        if (u->state->ups_recv_start_time == 0) {
+            u->state->ups_recv_start_time = ngx_current_msec;
+        }
 #endif
 
         u->response_received = 1;
@@ -5072,6 +5134,18 @@ ngx_http_upstream_finalize_request(ngx_http_request_t *r,
     if (u->state && u->state->response_time == (ngx_msec_t) -1) {
         u->state->response_time = ngx_current_msec - u->start_time;
 
+#ifdef T_NGX_HTTP_STAT_TIME
+        if (u->state->ups_recv_start_time != 0) {
+            u->state->ups_recv_finish_time = ngx_current_msec;
+        }
+        if (u->state->ups_send_start_time != 0
+            && u->state->ups_send_finish_time == 0)
+        {
+            u->state->ups_send_finish_time = ngx_current_msec;
+        }
+        u->state->ups_finish_time = ngx_current_msec;
+#endif
+
         if (u->pipe && u->pipe->read_length) {
             u->state->bytes_received += u->pipe->read_length
                                         - u->pipe->preread_size;
@@ -6482,6 +6556,158 @@ ngx_http_upstream_response_length_variable(ngx_http_request_t *r,
 
     return NGX_OK;
 }
+
+
+#if (T_NGX_HTTP_STAT_TIME)
+
+static ngx_int_t
+ngx_http_upstream_first_pkg_time_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char                     *p;
+    size_t                      len;
+    ngx_uint_t                  i;
+    ngx_msec_int_t              ms = 0;
+    ngx_http_upstream_state_t  *state;
+
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 1;
+
+    if (r->upstream_states == NULL || r->upstream_states->nelts == 0) {
+        return NGX_OK;
+    }
+
+    len = NGX_TIME_T_LEN;
+    state = r->upstream_states->elts;
+
+    for (i = 0; i < r->upstream_states->nelts; i++) {
+        if (state[i].status) {
+            ngx_msec_int_t  first_pkg_time = 0;
+
+            if (state[i].ups_send_start_time != 0) {
+                if (state[i].ups_recv_start_time != 0) {
+                    first_pkg_time = state[i].ups_recv_start_time
+                                     - state[i].ups_send_start_time;
+                } else if (state[i].ups_finish_time != 0) {
+                    first_pkg_time = state[i].ups_finish_time
+                                     - state[i].ups_send_start_time;
+                }
+            }
+            ms += first_pkg_time;
+        }
+    }
+
+    p = ngx_pnalloc(r->pool, len);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->data = p;
+
+    p = ngx_sprintf(p, "%M", ms);
+
+    v->len = p - v->data;
+
+    v->not_found = 0;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_stat_time_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char                     *p;
+    size_t                      len;
+    ngx_uint_t                  i;
+    ngx_msec_int_t              ms = 0;
+    ngx_http_upstream_state_t  *state;
+
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    if (r->upstream_states == NULL || r->upstream_states->nelts == 0) {
+        v->not_found = 1;
+        return NGX_OK;
+    }
+
+    len = r->upstream_states->nelts * (NGX_TIME_T_LEN + 4 + 2);
+
+    p = ngx_pnalloc(r->pool, len);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->data = p;
+
+    i = 0;
+    state = r->upstream_states->elts;
+
+    for ( ;; ) {
+        if (state[i].status) {
+
+            ngx_int_t  format = 0;
+
+            if (data == 1 && state[i].ups_send_start_time != 0) {
+                ms = state[i].ups_send_start_time;
+            } else if (data == 2 && state[i].ups_send_finish_time != 0) {
+                ms = state[i].ups_send_finish_time;
+            } else if (data == 3 && state[i].ups_recv_start_time != 0) {
+                ms = state[i].ups_recv_start_time;
+            } else if (data == 4 && state[i].ups_recv_finish_time != 0) {
+                ms = state[i].ups_recv_finish_time;
+            } else if (data == 100 && state[i].ups_send_finish_time != 0) {
+                ms = state[i].ups_send_finish_time - state[i].ups_send_start_time;
+                format = 1;
+            } else if (data == 101 && state[i].ups_recv_finish_time != 0) {
+                ms = state[i].ups_recv_finish_time - state[i].ups_recv_start_time;
+                format = 1;
+            } else {
+                ms = 0;
+            }
+
+            ms = ngx_max(ms, 0);
+
+            if (format == 1) {
+                p = ngx_sprintf(p, "%T.%03M", (time_t) ms / 1000, ms % 1000);
+            } else {
+                p = ngx_sprintf(p, "%M", ms);
+            }
+
+        } else {
+            *p++ = '-';
+        }
+
+        if (++i == r->upstream_states->nelts) {
+            break;
+        }
+
+        if (state[i].peer) {
+            *p++ = ',';
+            *p++ = ' ';
+
+        } else {
+            *p++ = ' ';
+            *p++ = ':';
+            *p++ = ' ';
+
+            if (++i == r->upstream_states->nelts) {
+                break;
+            }
+
+            continue;
+        }
+    }
+
+    v->len = p - v->data;
+
+    return NGX_OK;
+}
+
+#endif
 
 
 static ngx_int_t

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -94,6 +94,10 @@ typedef struct {
     ngx_rbtree_node_t                sentinel;
 
 #endif
+
+#if (T_NGX_HTTP_CHANGE_UPSTREAM_NO_SERVER_STATUS)
+    ngx_flag_t                       change_no_server_status;
+#endif
 } ngx_http_upstream_main_conf_t;
 
 typedef struct ngx_http_upstream_srv_conf_s  ngx_http_upstream_srv_conf_t;

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -66,6 +66,13 @@ typedef struct {
     ngx_msec_t                       connect_time;
     ngx_msec_t                       header_time;
     ngx_msec_t                       queue_time;
+#ifdef T_NGX_HTTP_STAT_TIME
+    ngx_msec_t                       ups_send_start_time;
+    ngx_msec_t                       ups_send_finish_time;
+    ngx_msec_t                       ups_recv_start_time;
+    ngx_msec_t                       ups_recv_finish_time;
+    ngx_msec_t                       ups_finish_time;
+#endif
     off_t                            response_length;
     off_t                            bytes_received;
     off_t                            bytes_sent;

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -83,6 +83,23 @@ ngx_http_variable_request_start_time(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 #endif
 
+#if (T_NGX_HTTP_STAT_TIME)
+static ngx_int_t ngx_http_variable_request_recv_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_response_send_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_recv_start_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_recv_finish_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_send_start_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_send_finish_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_server_rt(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+#endif
+
 static ngx_int_t ngx_http_variable_content_length(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_host(ngx_http_request_t *r,
@@ -570,6 +587,26 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
 
 #if (T_NGX_REQUEST_START_TIME)
     { ngx_string("request_start_time"), NULL, ngx_http_variable_request_start_time,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+#endif
+
+#if (T_NGX_HTTP_STAT_TIME)
+    { ngx_string("request_recv_time"), NULL, ngx_http_variable_request_recv_time,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_string("response_send_time"), NULL, ngx_http_variable_response_send_time,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_string("request_recv_start_time"), NULL, ngx_http_variable_recv_start_time,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("request_recv_finish_time"), NULL, ngx_http_variable_recv_finish_time,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("response_send_start_time"), NULL, ngx_http_variable_send_start_time,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+    { ngx_string("response_send_finish_time"), NULL, ngx_http_variable_send_finish_time,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_string("server_rt"), NULL, ngx_http_variable_server_rt,
       0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
 #endif
 
@@ -2563,6 +2600,199 @@ ngx_http_variable_request_time(ngx_http_request_t *r,
 
     return NGX_OK;
 }
+
+
+#if (T_NGX_HTTP_STAT_TIME)
+
+static ngx_int_t
+ngx_http_variable_request_recv_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char          *p;
+    ngx_msec_int_t   ms;
+
+    if (r->stat_time.req_recv_finished_time == 0) {
+        return NGX_ERROR;
+    }
+
+    p = ngx_pnalloc(r->pool, NGX_TIME_T_LEN + 4);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    ms = (ngx_msec_int_t)(r->stat_time.req_recv_finished_time
+                          - r->start_sec * 1000 - r->start_msec);
+    ms = ngx_max(ms, 0);
+
+    v->len = ngx_sprintf(p, "%T.%03M", (time_t) ms / 1000, ms % 1000) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_response_send_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_msec_t       current_msec = ngx_current_msec;
+    u_char          *p;
+    ngx_msec_int_t   ms;
+
+    if (r->stat_time.resp_send_start_time == 0) {
+        return NGX_ERROR;
+    }
+
+    p = ngx_pnalloc(r->pool, NGX_TIME_T_LEN + 4);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    ms = (ngx_msec_int_t)(current_msec - r->stat_time.resp_send_start_time);
+    ms = ngx_max(ms, 0);
+
+    v->len = ngx_sprintf(p, "%T.%03M", (time_t) ms / 1000, ms % 1000) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_send_start_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char          *p;
+
+    if (r->stat_time.resp_send_start_time == 0) {
+        return NGX_ERROR;
+    }
+
+    p = ngx_pnalloc(r->pool, NGX_TIME_T_LEN + 4);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->len = ngx_sprintf(p, "%M",
+                         (ngx_msec_int_t) r->stat_time.resp_send_start_time) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_send_finish_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char          *p;
+
+    if (r->stat_time.resp_send_finish_time == 0) {
+        return NGX_ERROR;
+    }
+
+    p = ngx_pnalloc(r->pool, NGX_TIME_T_LEN + 4);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->len = ngx_sprintf(p, "%M",
+                         (ngx_msec_int_t) r->stat_time.resp_send_finish_time) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_recv_start_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char          *p;
+
+    if (r->stat_time.req_recv_start_time == 0) {
+        return NGX_ERROR;
+    }
+
+    p = ngx_pnalloc(r->pool, NGX_TIME_T_LEN + 1);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->len = ngx_sprintf(p, "%M",
+                         (ngx_msec_int_t) r->stat_time.req_recv_start_time) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_recv_finish_time(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char          *p;
+
+    if (r->stat_time.req_recv_finished_time == 0) {
+        return NGX_ERROR;
+    }
+
+    p = ngx_pnalloc(r->pool, NGX_TIME_T_LEN + 1);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->len = ngx_sprintf(p, "%M",
+                         (ngx_msec_int_t) r->stat_time.req_recv_finished_time) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_server_rt(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_msec_t   start, end;
+
+    v->len = 0;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    v->data = ngx_pnalloc(r->pool, NGX_INT_T_LEN);
+    if (v->data == NULL) {
+        return NGX_ERROR;
+    }
+
+    start = (ngx_msec_t) r->start_sec * 1000 + r->start_msec;
+    end = ngx_current_msec;
+
+    v->len = ngx_sprintf(v->data, "%M", end - start) - v->data;
+
+    return NGX_OK;
+}
+
+#endif
 
 
 static ngx_int_t

--- a/src/http/ngx_http_write_filter_module.c
+++ b/src/http/ngx_http_write_filter_module.c
@@ -64,6 +64,13 @@ ngx_http_write_filter(ngx_http_request_t *r, ngx_chain_t *in)
         return NGX_ERROR;
     }
 
+#if (T_NGX_HTTP_STAT_TIME)
+    if (r == r->main && r->stat_time.resp_send_start_time == 0) {
+        r->stat_time.resp_send_start_time = ngx_current_msec;
+    }
+    r->stat_time.resp_send_finish_time = ngx_current_msec;
+#endif
+
     size = 0;
     flush = 0;
     sync = 0;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1143,6 +1143,12 @@ ngx_http_v2_state_read_data(ngx_http_v2_connection_t *h2c, u_char *pos,
         buf->last = ngx_cpymem(buf->last, pos, size);
     }
 
+#if (T_NGX_HTTP_STAT_TIME)
+    if (r == r->main) {
+        r->stat_time.req_recv_finished_time = ngx_current_msec;
+    }
+#endif
+
     pos += size;
     h2c->state.length -= size;
 

--- a/tests/nginx-tests/nginx-tests/proxy_xar.t
+++ b/tests/nginx-tests/nginx-tests/proxy_xar.t
@@ -89,7 +89,10 @@ like($r, qr/^Expires: fake/m, 'Expires preserved');
 like($r, qr/^Accept-Ranges: parrots/m, 'Accept-Ranges preserved');
 unlike($r, qr/^Something/m, 'other headers stripped');
 
-like(http_post('/proxy?xar=/index.html'), qr/method: GET/,
+# Tengine T_NGX_X_ACCEL_REDIRECT (enabled by default) preserves the
+# original request method name on X-Accel-Redirect instead of resetting
+# it to GET as stock nginx does, so $request_method stays POST here.
+like(http_post('/proxy?xar=/index.html'), qr/method: POST/,
 	'X-Accel-Redirect method name');
 
 # escaped characters


### PR DESCRIPTION
1. 保留 X-Accel-Redirect 的原始请求方法名（T_NGX_X_ACCEL_REDIRECT，默认开）
nginx 原生在处理 X-Accel-Redirect 内部跳转时会把 method 与 method_name 一并重置为 GET，导致 $request_method 丢失客户端原始方法（如 POST）。启用后仅将 method 置为 GET，保留原始 method_name。
src/http/ngx_http_upstream.c 隔离 method_name 重置逻辑。

2. 新增 x-www-form-urlencoded 转义/反转义支持（T_NGX_ESCAPE_WWW_FORM_ALI，默认开）
为 application/x-www-form-urlencoded 提供转义能力：编码时空格转 +，解码时 + 还原为空格。
src/core/ngx_string.{h,c}：新增 NGX_ESCAPE_WWW_FORM（避让 1.31.3 已占用的 MAIL_XTEXT=7，编号为 8）与 NGX_UNESCAPE_WWW_FORM（取空闲位 4），并接入 map[]/map_char[]。

3. 可选放行重复 Host 请求头（T_NGX_DUP_HOST，默认关）
放宽 nginx 原生「重复 Host 头 → 400」检查。因涉及安全基线，默认关闭，需显式 --with-http_dup_host 启用。
src/http/ngx_http_request.c 隔离 400 拒绝逻辑；auto/options 新增开关。

4. 新增请求/upstream 耗时统计变量（T_NGX_HTTP_STAT_TIME，默认开）
提供各阶段计时可观测性变量：请求级 $request_recv_time、$response_send_time、$server_rt 等；upstream 级 $upstream_stat_send_time、$upstream_stat_recv_time、$upstream_first_pkg_time 等。
埋点覆盖 request.c / request_body.c / write_filter / HTTP/2 v2.c / upstream.c（连接、发送、接收共 6 处）。

5. 增强 SSL 握手失败日志（T_NGX_SSL_ERR_LOG_ALI，默认开）
将 SSL_ERROR_SYSCALL / SSL_ERROR_SSL 在 NGX_ERROR_INFO 场景下的日志级别由 INFO 提升为 ERR，并把客户端 SNI servername 注入错误文本（对 % 转义），便于定位失败对应的域名与客户端。

6. upstream 无可用后端时返回 502（T_NGX_HTTP_CHANGE_UPSTREAM_NO_SERVER_STATUS，默认开）
peer.init 失败（典型为 upstream 组内无可用 server）时，由原生固定 500 改为 502 Bad Gateway，语义更贴合网关行为；提供 upstream_change_no_server_status 指令控制。

7. 对齐测试断言（Test）
调整 proxy_xar.t，使 X-Accel-Redirect 方法名断言与第 1 项定制宏行为一致。