### PR TITLE
Fix the ngx_http_lua_module build against PCRE2

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: openresty/luajit2
+          # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.
+          ref: v2.1-20260724
           path: luajit2
 
       - name: Compile with ${{ matrix.compiler.compiler }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
        uses: actions/checkout@v3
        with:
          repository: openresty/lua-resty-core
-         ref: v0.1.27
+         # lua-resty-core pins the ngx_lua version with a strict equality check
+         # (lib/resty/core/base.lua), so it must match modules/ngx_http_lua_module
+         # exactly: 0.10.29 only accepts v0.1.32. Keep in sync with
+         # packages/build/deps.env, which pins the same pair for the packages.
+         ref: v0.1.32
          path: lua-resty-core
      - name: 'build lua-resty-core'
        working-directory: lua-resty-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
        uses: actions/checkout@v3
        with:
          repository: openresty/luajit2
+         # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.
+         ref: v2.1-20260724
          path: luajit2
      - name: 'build luajit2'
        working-directory: luajit2
@@ -40,6 +42,8 @@ jobs:
        uses: actions/checkout@v3
        with:
          repository: openresty/lua-resty-lrucache
+         # Pinned (resty.core's dependency); keep in sync with packages/build/deps.env.
+         ref: v0.15
          path: lua-resty-lrucache
      - name: 'build lua-resty-lrucache'
        working-directory: lua-resty-lrucache

--- a/.github/workflows/test-nginx-core.yml
+++ b/.github/workflows/test-nginx-core.yml
@@ -34,6 +34,8 @@ jobs:
        uses: actions/checkout@v3
        with:
          repository: openresty/luajit2
+         # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.
+         ref: v2.1-20260724
          path: luajit2
      - name: 'build luajit2'
        working-directory: luajit2
@@ -44,6 +46,8 @@ jobs:
        uses: actions/checkout@v3
        with:
          repository: openresty/lua-resty-lrucache
+         # Pinned (resty.core's dependency); keep in sync with packages/build/deps.env.
+         ref: v0.15
          path: lua-resty-lrucache
      - name: 'build lua-resty-lrucache'
        working-directory: lua-resty-lrucache

--- a/.github/workflows/test-nginx-core.yml
+++ b/.github/workflows/test-nginx-core.yml
@@ -53,7 +53,11 @@ jobs:
        uses: actions/checkout@v3
        with:
          repository: openresty/lua-resty-core
-         ref: v0.1.27
+         # lua-resty-core pins the ngx_lua version with a strict equality check
+         # (lib/resty/core/base.lua), so it must match modules/ngx_http_lua_module
+         # exactly: 0.10.29 only accepts v0.1.32. Keep in sync with
+         # packages/build/deps.env, which pins the same pair for the packages.
+         ref: v0.1.32
          path: lua-resty-core
      - name: 'build lua-resty-core'
        working-directory: lua-resty-core

--- a/.github/workflows/test-ntls.yml
+++ b/.github/workflows/test-ntls.yml
@@ -49,7 +49,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: openresty/lua-resty-core
-          ref: v0.1.27
+          # lua-resty-core pins the ngx_lua version with a strict equality check
+          # (lib/resty/core/base.lua), so it must match modules/ngx_http_lua_module
+          # exactly: 0.10.29 only accepts v0.1.32. Keep in sync with
+          # packages/build/deps.env, which pins the same pair for the packages.
+          ref: v0.1.32
           path: lua-resty-core
       - name: 'build lua-resty-core'
         working-directory: lua-resty-core

--- a/.github/workflows/test-ntls.yml
+++ b/.github/workflows/test-ntls.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: openresty/luajit2
+          # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.
+          ref: v2.1-20260724
           path: luajit2
       - name: 'build luajit2'
         working-directory: luajit2
@@ -40,6 +42,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: openresty/lua-resty-lrucache
+          # Pinned (resty.core's dependency); keep in sync with packages/build/deps.env.
+          ref: v0.15
           path: lua-resty-lrucache
       - name: 'build lua-resty-lrucache'
         working-directory: lua-resty-lrucache

--- a/CHANGES.cn
+++ b/CHANGES.cn
@@ -25,6 +25,7 @@ Tengine 3.2.0 [2026-07-31]
 * Feature: 新增发行版软件包(rpm、deb和apk)与多架构容器镜像，默认构建完备功能集——Tongsuo、xquic和Lua (lianglli)
 * Feature: 新增configure选项--with-xquic-rpath，将xquic运行时查找路径与链接路径解耦 (lianglli)
 * Change: 升级core代码到Nginx-1.31.3版本 (lianglli)
+* Change: 升级ngx_http_lua_module到0.10.29版本，支持PCRE2并与pin的lua-resty-core版本匹配，此前仅有PCRE2的环境下编译失败 (lianglli)
 * Change: 默认拥塞控制算法由CUBIC改为BBR [XQUIC] (lurker-Chen)
 * Change: ngx_http_tunnel_module改为可选编译，避免与ngx_http_proxy_connect_module冲突 (lianglli)
 * Change: 合入nginx官方测试集并补充Tengine定制测试用例 (lianglli)

--- a/CHANGES.te
+++ b/CHANGES.te
@@ -81,6 +81,10 @@ Changes with Tengine 3.2.0                                         31 Jul 2026
 
     *) Change: update core to Nginx-1.31.3 (lianglli)
 
+    *) Change: update ngx_http_lua_module to 0.10.29, which adds PCRE2
+       support and matches the pinned lua-resty-core; a build against PCRE2
+       alone previously failed (lianglli)
+
     *) Change: use BBR instead of CUBIC as the default congestion control
        [XQUIC] (lurker-Chen)
 

--- a/modules/ngx_http_lua_module/config
+++ b/modules/ngx_http_lua_module/config
@@ -289,12 +289,14 @@ HTTP_LUA_SRCS=" \
             $ngx_addon_dir/src/ngx_http_lua_worker.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_client_helloby.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_certby.c \
+            $ngx_addon_dir/src/ngx_http_lua_ssl_export_keying_material.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_ocsp.c \
             $ngx_addon_dir/src/ngx_http_lua_lex.c \
             $ngx_addon_dir/src/ngx_http_lua_balancer.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_session_storeby.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_session_fetchby.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl.c \
+            $ngx_addon_dir/src/ngx_http_lua_proxy_ssl_verifyby.c \
             $ngx_addon_dir/src/ngx_http_lua_log_ringbuf.c \
             $ngx_addon_dir/src/ngx_http_lua_input_filters.c \
             $ngx_addon_dir/src/ngx_http_lua_pipe.c \
@@ -354,9 +356,11 @@ HTTP_LUA_DEPS=" \
             $ngx_addon_dir/src/ngx_http_lua_ssl_certby.h \
             $ngx_addon_dir/src/ngx_http_lua_lex.h \
             $ngx_addon_dir/src/ngx_http_lua_balancer.h \
+            $ngx_addon_dir/src/ngx_http_lua_ssl_export_keying_material.h \
             $ngx_addon_dir/src/ngx_http_lua_ssl_session_storeby.h \
             $ngx_addon_dir/src/ngx_http_lua_ssl_session_fetchby.h \
             $ngx_addon_dir/src/ngx_http_lua_ssl.h \
+            $ngx_addon_dir/src/ngx_http_lua_proxy_ssl_verifyby.h \
             $ngx_addon_dir/src/ngx_http_lua_log_ringbuf.h \
             $ngx_addon_dir/src/ngx_http_lua_input_filters.h \
             $ngx_addon_dir/src/ngx_http_lua_pipe.h \
@@ -460,7 +464,8 @@ ngx_feature_libs=
 ngx_feature_name="NGX_HTTP_LUA_HAVE_SIGNALFD"
 ngx_feature_run=no
 ngx_feature_incs="#include <sys/signalfd.h>"
-ngx_feature_test="sigset_t set; signalfd(-1, &set, SFD_NONBLOCK|SFD_CLOEXEC);"
+ngx_feature_test="sigset_t set = { 0 };
+                  signalfd(-1, &set, SFD_NONBLOCK|SFD_CLOEXEC);"
 SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
 CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
 

--- a/modules/ngx_http_lua_module/src/api/ngx_http_lua_api.h
+++ b/modules/ngx_http_lua_module/src/api/ngx_http_lua_api.h
@@ -19,7 +19,8 @@
 /* Public API for other Nginx modules */
 
 
-#define ngx_http_lua_version  10025
+#define ngx_http_lua_version  10029
+#define NGX_HTTP_LUA_EXPORT_CO_CTX_CLEANUP 1
 
 
 typedef struct ngx_http_lua_co_ctx_s  ngx_http_lua_co_ctx_t;
@@ -65,6 +66,13 @@ void ngx_http_lua_set_cur_co_ctx(ngx_http_request_t *r,
     ngx_http_lua_co_ctx_t *coctx);
 
 lua_State *ngx_http_lua_get_co_ctx_vm(ngx_http_lua_co_ctx_t *coctx);
+
+
+void *ngx_http_lua_get_co_ctx_data(ngx_http_lua_co_ctx_t *coctx);
+void ngx_http_lua_set_co_ctx_cleanup(ngx_http_lua_co_ctx_t *coctx,
+    ngx_http_cleanup_pt cleanup, void *data);
+void ngx_http_lua_cleanup_co_ctx_pending_operation(
+    ngx_http_lua_co_ctx_t *coctx);
 
 void ngx_http_lua_co_ctx_resume_helper(ngx_http_lua_co_ctx_t *coctx, int nrets);
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_accessby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_accessby.c
@@ -95,6 +95,7 @@ ngx_http_lua_access_handler(ngx_http_request_t *r)
 
     dd("entered? %d", (int) ctx->entered_access_phase);
 
+
     if (ctx->entered_access_phase) {
         dd("calling wev handler");
         rc = ctx->resume_handler(r);
@@ -105,7 +106,9 @@ ngx_http_lua_access_handler(ngx_http_request_t *r)
         }
 
         if (rc == NGX_OK) {
-            if (r->header_sent) {
+            if (r->header_sent
+                || (r->headers_out.status != 0 && ctx->out != NULL))
+            {
                 dd("header already sent");
 
                 /* response header was already generated in access_by_lua*,
@@ -170,6 +173,10 @@ ngx_http_lua_access_handler_inline(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->access_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->access_src.value.data,
@@ -210,6 +217,10 @@ ngx_http_lua_access_handler_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->access_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
@@ -377,7 +388,8 @@ ngx_http_lua_access_by_chunk(lua_State *L, ngx_http_request_t *r)
 
 #if 1
     if (rc == NGX_OK) {
-        if (r->header_sent) {
+        if (r->header_sent || (r->headers_out.status != 0 && ctx->out != NULL))
+        {
             dd("header already sent");
 
             /* response header was already generated in access_by_lua*,

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_api.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_api.c
@@ -221,7 +221,7 @@ ngx_http_lua_get_cur_co_ctx(ngx_http_request_t *r)
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 
-    return ctx->cur_co_ctx;
+    return ctx == NULL ? NULL : ctx->cur_co_ctx;
 }
 
 
@@ -242,6 +242,29 @@ lua_State *
 ngx_http_lua_get_co_ctx_vm(ngx_http_lua_co_ctx_t *coctx)
 {
     return coctx->co;
+}
+
+
+void *
+ngx_http_lua_get_co_ctx_data(ngx_http_lua_co_ctx_t *coctx)
+{
+    return coctx ? coctx->data : NULL;
+}
+
+
+void
+ngx_http_lua_set_co_ctx_cleanup(ngx_http_lua_co_ctx_t *coctx,
+    ngx_http_cleanup_pt cleanup, void *data)
+{
+    coctx->cleanup = cleanup;
+    coctx->data = data;
+}
+
+
+void
+ngx_http_lua_cleanup_co_ctx_pending_operation(ngx_http_lua_co_ctx_t *coctx)
+{
+    ngx_http_lua_cleanup_pending_operation(coctx);
 }
 
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_balancer.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_balancer.c
@@ -15,10 +15,35 @@
 #include "ngx_http_lua_util.h"
 #include "ngx_http_lua_directive.h"
 
+#define NGX_BALANCER_DEF_HOST_LEN  32
+typedef struct {
+    ngx_queue_t                    queue;
+    ngx_queue_t                    hnode;
+    ngx_uint_t                     hash;
+    ngx_http_lua_srv_conf_t       *lscf;
+    ngx_connection_t              *connection;
+    socklen_t                      socklen;
+    ngx_sockaddr_t                 sockaddr;
+    ngx_sockaddr_t                 local_sockaddr;
+    ngx_str_t                      host;
+    /* try to avoid allocating memory from the connection pool */
+    u_char                         host_data[NGX_BALANCER_DEF_HOST_LEN];
+} ngx_http_lua_balancer_ka_item_t; /*balancer keepalive item*/
+
 
 struct ngx_http_lua_balancer_peer_data_s {
-    /* the round robin data must be first */
-    ngx_http_upstream_rr_peer_data_t    rrp;
+    ngx_uint_t                          keepalive_requests;
+    ngx_msec_t                          keepalive_timeout;
+
+    void                               *data;
+
+    ngx_event_get_peer_pt               original_get_peer;
+    ngx_event_free_peer_pt              original_free_peer;
+
+#if (NGX_HTTP_SSL)
+    ngx_event_set_peer_session_pt       original_set_session;
+    ngx_event_save_peer_session_pt      original_save_session;
+#endif
 
     ngx_http_lua_srv_conf_t            *conf;
     ngx_http_request_t                 *request;
@@ -28,15 +53,18 @@ struct ngx_http_lua_balancer_peer_data_s {
 
     struct sockaddr                    *sockaddr;
     socklen_t                           socklen;
+    ngx_addr_t                         *local;
 
-    ngx_str_t                          *host;
-    in_port_t                           port;
+    ngx_str_t                           host;
+    ngx_str_t                          *addr_text;
 
     int                                 last_peer_state;
 
 #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
-    unsigned                            cloned_upstream_conf;  /* :1 */
+    unsigned                            cloned_upstream_conf:1;
 #endif
+
+    unsigned                            keepalive:1;
 };
 
 
@@ -45,6 +73,9 @@ static ngx_int_t ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc,
     void *data);
 static void ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc,
     void *data);
+static ngx_int_t
+ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
+    ngx_http_upstream_t *u);
 #endif
 static ngx_int_t ngx_http_lua_balancer_init(ngx_conf_t *cf,
     ngx_http_upstream_srv_conf_t *us);
@@ -56,6 +87,18 @@ static ngx_int_t ngx_http_lua_balancer_by_chunk(lua_State *L,
     ngx_http_request_t *r);
 static void ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc,
     void *data, ngx_uint_t state);
+static void ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc,
+    void *data, ngx_uint_t type);
+static void ngx_http_lua_balancer_close(ngx_connection_t *c);
+static void ngx_http_lua_balancer_dummy_handler(ngx_event_t *ev);
+static void ngx_http_lua_balancer_close_handler(ngx_event_t *ev);
+static ngx_connection_t *ngx_http_lua_balancer_get_cached_item(
+    ngx_http_lua_srv_conf_t *lscf, ngx_peer_connection_t *pc, ngx_str_t *name);
+static ngx_uint_t ngx_http_lua_balancer_calc_hash(ngx_str_t *name,
+    struct sockaddr *sockaddr, socklen_t socklen, ngx_addr_t *local);
+
+
+static struct sockaddr  *ngx_http_lua_balancer_default_server_sockaddr;
 
 
 ngx_int_t
@@ -131,8 +174,10 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
     u_char                      *name;
     ngx_str_t                   *value;
     ngx_http_lua_srv_conf_t     *lscf = conf;
+    ngx_url_t                    url;
 
     ngx_http_upstream_srv_conf_t      *uscf;
+    ngx_http_upstream_server_t        *us;
 
     dd("enter");
 
@@ -188,11 +233,42 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
     lscf->balancer.src_key = cache_key;
 
+    /* balancer setup */
+
     uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
+
+    if (uscf->servers->nelts == 0) {
+        us = ngx_array_push(uscf->servers);
+        if (us == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
+        ngx_memzero(&url, sizeof(ngx_url_t));
+
+        ngx_str_set(&url.url, "0.0.0.1");
+        url.default_port = 80;
+
+        if (ngx_parse_url(cf->pool, &url) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+
+        us->name = url.url;
+        us->addrs = url.addrs;
+        us->naddrs = url.naddrs;
+
+        ngx_http_lua_balancer_default_server_sockaddr = us->addrs[0].sockaddr;
+    }
 
     if (uscf->peer.init_upstream) {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                            "load balancing method redefined");
+
+        lscf->balancer.original_init_upstream = uscf->peer.init_upstream;
+
+    } else {
+        lscf->balancer.original_init_upstream =
+            ngx_http_upstream_init_round_robin;
     }
 
     uscf->peer.init_upstream = ngx_http_lua_balancer_init;
@@ -208,15 +284,57 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
 
 static ngx_int_t
-ngx_http_lua_balancer_init(ngx_conf_t *cf,
-    ngx_http_upstream_srv_conf_t *us)
+ngx_http_lua_balancer_init(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
 {
-    if (ngx_http_upstream_init_round_robin(cf, us) != NGX_OK) {
+    ngx_uint_t                            i;
+    ngx_uint_t                            bucket_cnt;
+    ngx_queue_t                          *buckets;
+    ngx_http_lua_srv_conf_t              *lscf;
+    ngx_http_lua_balancer_ka_item_t      *cached;
+
+    lscf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
+
+    ngx_conf_init_uint_value(lscf->balancer.max_cached, 32);
+
+    if (lscf->balancer.original_init_upstream(cf, us) != NGX_OK) {
         return NGX_ERROR;
     }
 
-    /* this callback is called upon individual requests */
+    lscf->balancer.original_init_peer = us->peer.init;
+
     us->peer.init = ngx_http_lua_balancer_init_peer;
+
+    /* allocate cache items and add to free queue */
+
+    cached = ngx_pcalloc(cf->pool,
+                         sizeof(ngx_http_lua_balancer_ka_item_t)
+                         * lscf->balancer.max_cached);
+    if (cached == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_queue_init(&lscf->balancer.cache);
+    ngx_queue_init(&lscf->balancer.free);
+
+    for (i = 0; i < lscf->balancer.max_cached; i++) {
+        ngx_queue_insert_head(&lscf->balancer.free, &cached[i].queue);
+        cached[i].lscf = lscf;
+    }
+
+    bucket_cnt = lscf->balancer.max_cached / 2;
+    bucket_cnt = bucket_cnt > 0 ? bucket_cnt : 1;
+    buckets = ngx_pcalloc(cf->pool, sizeof(ngx_queue_t) * bucket_cnt);
+
+    if (buckets == NULL) {
+        return NGX_ERROR;
+    }
+
+    for (i = 0; i < bucket_cnt; i++) {
+        ngx_queue_init(&buckets[i]);
+    }
+
+    lscf->balancer.buckets = buckets;
+    lscf->balancer.bucket_cnt = bucket_cnt;
 
     return NGX_OK;
 }
@@ -226,32 +344,38 @@ static ngx_int_t
 ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
     ngx_http_upstream_srv_conf_t *us)
 {
-    ngx_http_lua_srv_conf_t            *bcf;
+    ngx_http_lua_srv_conf_t            *lscf;
     ngx_http_lua_balancer_peer_data_t  *bp;
+
+    lscf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
+
+    if (lscf->balancer.original_init_peer(r, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     bp = ngx_pcalloc(r->pool, sizeof(ngx_http_lua_balancer_peer_data_t));
     if (bp == NULL) {
         return NGX_ERROR;
     }
 
-    r->upstream->peer.data = &bp->rrp;
+    bp->conf = lscf;
+    bp->request = r;
+    bp->data = r->upstream->peer.data;
+    bp->original_get_peer = r->upstream->peer.get;
+    bp->original_free_peer = r->upstream->peer.free;
 
-    if (ngx_http_upstream_init_round_robin_peer(r, us) != NGX_OK) {
-        return NGX_ERROR;
-    }
-
+    r->upstream->peer.data = bp;
     r->upstream->peer.get = ngx_http_lua_balancer_get_peer;
     r->upstream->peer.free = ngx_http_lua_balancer_free_peer;
+    r->upstream->peer.notify = ngx_http_lua_balancer_notify_peer;
 
 #if (NGX_HTTP_SSL)
+    bp->original_set_session = r->upstream->peer.set_session;
+    bp->original_save_session = r->upstream->peer.save_session;
+
     r->upstream->peer.set_session = ngx_http_lua_balancer_set_session;
     r->upstream->peer.save_session = ngx_http_lua_balancer_save_session;
 #endif
-
-    bcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
-
-    bp->conf = bcf;
-    bp->request = r;
 
     return NGX_OK;
 }
@@ -260,25 +384,30 @@ ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
 static ngx_int_t
 ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
 {
+    void                               *pdata;
     lua_State                          *L;
     ngx_int_t                           rc;
+    ngx_connection_t                   *c;
     ngx_http_request_t                 *r;
+#if (NGX_HTTP_SSL)
+    ngx_http_upstream_t                *u;
+#endif
     ngx_http_lua_ctx_t                 *ctx;
     ngx_http_lua_srv_conf_t            *lscf;
-    ngx_http_lua_main_conf_t           *lmcf;
     ngx_http_lua_balancer_peer_data_t  *bp = data;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "lua balancer peer, tries: %ui", pc->tries);
-
-    lscf = bp->conf;
+                   "lua balancer: get peer, tries: %ui", pc->tries);
 
     r = bp->request;
+#if (NGX_HTTP_SSL)
+    u = r->upstream;
+#endif
+    lscf = bp->conf;
 
     ngx_http_lua_assert(lscf->balancer.handler && r);
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
-
     if (ctx == NULL) {
         ctx = ngx_http_lua_create_ctx(r);
         if (ctx == NULL) {
@@ -299,17 +428,17 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
     bp->sockaddr = NULL;
     bp->socklen = 0;
     bp->more_tries = 0;
+    bp->keepalive_requests = 0;
+    bp->keepalive_timeout = 0;
+    bp->keepalive = 0;
     bp->total_tries++;
 
-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
-
-    /* balancer_by_lua does not support yielding and
-     * there cannot be any conflicts among concurrent requests,
-     * thus it is safe to store the peer data in the main conf.
-     */
-    lmcf->balancer_peer_data = bp;
+    pdata = r->upstream->peer.data;
+    r->upstream->peer.data = bp;
 
     rc = lscf->balancer.handler(r, lscf, L);
+
+    r->upstream->peer.data = pdata;
 
     if (rc == NGX_ERROR) {
         return NGX_ERROR;
@@ -332,25 +461,60 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
         }
     }
 
+    if (bp->local != NULL) {
+        pc->local = bp->local;
+    }
+
     if (bp->sockaddr && bp->socklen) {
         pc->sockaddr = bp->sockaddr;
         pc->socklen = bp->socklen;
+        pc->name = bp->addr_text;
         pc->cached = 0;
         pc->connection = NULL;
-        pc->name = bp->host;
-
-        bp->rrp.peers->single = 0;
 
         if (bp->more_tries) {
             r->upstream->peer.tries += bp->more_tries;
         }
 
-        dd("tries: %d", (int) r->upstream->peer.tries);
+        if (bp->keepalive) {
+#if (NGX_HTTP_SSL)
+            if (bp->host.len == 0 && u->ssl) {
+                ngx_http_lua_upstream_get_ssl_name(r, u);
+                bp->host = u->ssl_name;
+            }
+#endif
+
+            c = ngx_http_lua_balancer_get_cached_item(lscf, pc, &bp->host);
+
+            if (c) {
+                ngx_log_debug3(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                               "lua balancer: keepalive reusing connection %p,"
+                               " host: %V, name: %V",
+                               c, bp->addr_text, &bp->host);
+                return NGX_DONE;
+            }
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "lua balancer: keepalive no free connection, "
+                           "host: %V, name: %v",  bp->addr_text, &bp->host);
+        }
 
         return NGX_OK;
     }
 
-    return ngx_http_upstream_get_round_robin_peer(pc, &bp->rrp);
+    rc = bp->original_get_peer(pc, bp->data);
+    if (rc == NGX_ERROR) {
+        return rc;
+    }
+
+    if (pc->sockaddr == ngx_http_lua_balancer_default_server_sockaddr) {
+        ngx_log_error(NGX_LOG_ERR, pc->log, 0,
+                      "lua balancer: no peer set");
+
+        return NGX_ERROR;
+    }
+
+    return rc;
 }
 
 
@@ -413,10 +577,20 @@ static void
 ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
     ngx_uint_t state)
 {
-    ngx_http_lua_balancer_peer_data_t  *bp = data;
+    ngx_uint_t                                  hash;
+    ngx_str_t                                  *host;
+    ngx_queue_t                                *q;
+    ngx_connection_t                           *c;
+    ngx_http_upstream_t                        *u;
+    ngx_http_lua_balancer_ka_item_t            *item;
+    ngx_http_lua_balancer_peer_data_t          *bp = data;
+    ngx_http_lua_srv_conf_t                    *lscf = bp->conf;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "lua balancer free peer, tries: %ui", pc->tries);
+                   "lua balancer: free peer, tries: %ui", pc->tries);
+
+    u = bp->request->upstream;
+    c = pc->connection;
 
     if (bp->sockaddr && bp->socklen) {
         bp->last_peer_state = (int) state;
@@ -425,12 +599,229 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
             pc->tries--;
         }
 
+        if (bp->keepalive) {
+            if (state & NGX_PEER_FAILED
+                || c == NULL
+                || c->read->eof
+                || c->read->error
+                || c->read->timedout
+                || c->write->error
+                || c->write->timedout)
+            {
+                goto invalid;
+            }
+
+            if (bp->keepalive_requests
+                && c->requests >= bp->keepalive_requests)
+            {
+                goto invalid;
+            }
+
+            if (!u->keepalive) {
+                goto invalid;
+            }
+
+            if (!u->request_body_sent) {
+                goto invalid;
+            }
+
+            if (ngx_terminate || ngx_exiting) {
+                goto invalid;
+            }
+
+            if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+                goto invalid;
+            }
+
+            if (ngx_queue_empty(&lscf->balancer.free)) {
+                q = ngx_queue_last(&lscf->balancer.cache);
+
+                item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t,
+                                      queue);
+                ngx_queue_remove(q);
+                ngx_queue_remove(&item->hnode);
+
+                ngx_http_lua_balancer_close(item->connection);
+
+            } else {
+                q = ngx_queue_head(&lscf->balancer.free);
+                ngx_queue_remove(q);
+
+                item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t,
+                                      queue);
+            }
+
+            host = &bp->host;
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "lua balancer: keepalive saving connection %p, "
+                           "host: %V, name: %V",
+                           c, bp->addr_text, host);
+
+            ngx_queue_insert_head(&lscf->balancer.cache, q);
+            hash = ngx_http_lua_balancer_calc_hash(host,
+                                                   bp->sockaddr, bp->socklen,
+                                                   bp->local);
+            item->hash = hash;
+            hash %= lscf->balancer.bucket_cnt;
+            ngx_queue_insert_head(&lscf->balancer.buckets[hash], &item->hnode);
+            item->connection = c;
+            pc->connection = NULL;
+
+            c->read->delayed = 0;
+            ngx_add_timer(c->read, bp->keepalive_timeout);
+
+            if (c->write->timer_set) {
+                ngx_del_timer(c->write);
+            }
+
+            c->write->handler = ngx_http_lua_balancer_dummy_handler;
+            c->read->handler = ngx_http_lua_balancer_close_handler;
+
+            c->data = item;
+            c->idle = 1;
+            c->log = ngx_cycle->log;
+            c->read->log = ngx_cycle->log;
+            c->write->log = ngx_cycle->log;
+            c->pool->log = ngx_cycle->log;
+
+            item->socklen = pc->socklen;
+            ngx_memcpy(&item->sockaddr, pc->sockaddr, pc->socklen);
+            if (pc->local) {
+                ngx_memcpy(&item->local_sockaddr,
+                           pc->local->sockaddr, pc->local->socklen);
+
+            } else {
+                ngx_memzero(&item->local_sockaddr,
+                            sizeof(item->local_sockaddr));
+            }
+
+            if (host->data && host->len) {
+                if (host->len <= sizeof(item->host_data)) {
+                    ngx_memcpy(item->host_data, host->data, host->len);
+                    item->host.data = item->host_data;
+                    item->host.len = host->len;
+
+                } else {
+                    item->host.data = ngx_pstrdup(c->pool, host);
+                    if (item->host.data == NULL) {
+                        ngx_http_lua_balancer_close(c);
+
+                        ngx_queue_remove(&item->queue);
+                        ngx_queue_remove(&item->hnode);
+                        ngx_queue_insert_head(&item->lscf->balancer.free,
+                                              &item->queue);
+                        return;
+                    }
+
+                    item->host.len = host->len;
+                }
+
+            } else {
+                ngx_str_null(&item->host);
+            }
+
+            if (c->read->ready) {
+                ngx_http_lua_balancer_close_handler(c->read);
+            }
+
+            return;
+
+invalid:
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "lua balancer: keepalive not saving connection %p",
+                           c);
+        }
+
         return;
     }
 
-    /* fallback */
+    bp->original_free_peer(pc, bp->data, state);
+}
 
-    ngx_http_upstream_free_round_robin_peer(pc, data, state);
+
+static void
+ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t type)
+{
+#ifdef NGX_HTTP_UPSTREAM_NOTIFY_CACHED_CONNECTION_ERROR
+    if (type == NGX_HTTP_UPSTREAM_NOTIFY_CACHED_CONNECTION_ERROR) {
+        pc->tries--;
+    }
+#endif
+}
+
+
+static void
+ngx_http_lua_balancer_close(ngx_connection_t *c)
+{
+#if (NGX_HTTP_SSL)
+    if (c->ssl) {
+        c->ssl->no_wait_shutdown = 1;
+        c->ssl->no_send_shutdown = 1;
+
+        if (ngx_ssl_shutdown(c) == NGX_AGAIN) {
+            c->ssl->handler = ngx_http_lua_balancer_close;
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "lua balancer: keepalive shutdown "
+                           "connection %p failed", c);
+            return;
+        }
+    }
+#endif
+
+    ngx_destroy_pool(c->pool);
+    ngx_close_connection(c);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "lua balancer: keepalive closing connection %p", c);
+}
+
+
+static void
+ngx_http_lua_balancer_dummy_handler(ngx_event_t *ev)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0,
+                   "lua balancer: dummy handler");
+}
+
+
+static void
+ngx_http_lua_balancer_close_handler(ngx_event_t *ev)
+{
+    ngx_http_lua_balancer_ka_item_t     *item;
+
+    int                n;
+    char               buf[1];
+    ngx_connection_t  *c;
+
+    c = ev->data;
+    if (c->close || c->read->timedout) {
+        goto close;
+    }
+
+    n = recv(c->fd, buf, 1, MSG_PEEK);
+
+    if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
+        ev->ready = 0;
+
+        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+            goto close;
+        }
+
+        return;
+    }
+
+close:
+
+    item = c->data;
+    c->log = ev->log;
+
+    ngx_http_lua_balancer_close(c);
+
+    ngx_queue_remove(&item->queue);
+    ngx_queue_remove(&item->hnode);
+    ngx_queue_insert_head(&item->lscf->balancer.free, &item->queue);
 }
 
 
@@ -446,7 +837,7 @@ ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc, void *data)
         return NGX_OK;
     }
 
-    return ngx_http_upstream_set_round_robin_peer_session(pc, &bp->rrp);
+    return bp->original_set_session(pc, bp->data);
 }
 
 
@@ -460,8 +851,7 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
         return;
     }
 
-    ngx_http_upstream_save_round_robin_peer_session(pc, &bp->rrp);
-    return;
+    bp->original_save_session(pc, bp->data);
 }
 
 #endif
@@ -469,13 +859,14 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
 
 int
 ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
-    const u_char *addr, size_t addr_len, int port, char **err)
+    const u_char *addr, size_t addr_len, int port,
+    const u_char *host, size_t host_len,
+    char **err)
 {
     ngx_url_t              url;
     ngx_http_lua_ctx_t    *ctx;
     ngx_http_upstream_t   *u;
 
-    ngx_http_lua_main_conf_t           *lmcf;
     ngx_http_lua_balancer_peer_data_t  *bp;
 
     if (r == NULL) {
@@ -498,18 +889,6 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
 
     if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
         *err = "API disabled in the current context";
-        return NGX_ERROR;
-    }
-
-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
-
-    /* we cannot read r->upstream->peer.data here directly because
-     * it could be overridden by other modules like
-     * ngx_http_upstream_keepalive_module.
-     */
-    bp = lmcf->balancer_peer_data;
-    if (bp == NULL) {
-        *err = "no upstream peer data found";
         return NGX_ERROR;
     }
 
@@ -536,14 +915,36 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
+
     if (url.addrs && url.addrs[0].sockaddr) {
         bp->sockaddr = url.addrs[0].sockaddr;
         bp->socklen = url.addrs[0].socklen;
-        bp->host = &url.addrs[0].name;
+        bp->addr_text = &url.addrs[0].name;
 
     } else {
         *err = "no host allowed";
         return NGX_ERROR;
+    }
+
+    if (host && host_len) {
+        bp->host.data = ngx_palloc(r->pool, host_len);
+        if (bp->host.data == NULL) {
+            *err = "no memory";
+            return NGX_ERROR;
+        }
+
+        ngx_memcpy(bp->host.data, host, host_len);
+        bp->host.len = host_len;
+
+#if (NGX_HTTP_SSL)
+        if (u->ssl) {
+            u->ssl_name = bp->host;
+        }
+#endif
+
+    } else {
+        ngx_str_null(&bp->host);
     }
 
     return NGX_OK;
@@ -551,18 +952,78 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
 
 
 int
-ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
-    long connect_timeout, long send_timeout, long read_timeout,
-    char **err)
+ngx_http_lua_ffi_balancer_bind_to_local_addr(ngx_http_request_t *r,
+    const u_char *addr, size_t addr_len,
+    u_char *errbuf, size_t *errbuf_size)
 {
+    u_char                *p;
     ngx_http_lua_ctx_t    *ctx;
     ngx_http_upstream_t   *u;
+    ngx_int_t              rc;
 
-#if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
-    ngx_http_upstream_conf_t           *ucf;
-#endif
-    ngx_http_lua_main_conf_t           *lmcf;
     ngx_http_lua_balancer_peer_data_t  *bp;
+
+    if (r == NULL) {
+        p = ngx_snprintf(errbuf, *errbuf_size, "no request found");
+        *errbuf_size = p - errbuf;
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+
+    if (u == NULL) {
+        p = ngx_snprintf(errbuf, *errbuf_size, "no upstream found");
+        *errbuf_size = p - errbuf;
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        p = ngx_snprintf(errbuf, *errbuf_size, "no ctx found");
+        *errbuf_size = p - errbuf;
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
+        p = ngx_snprintf(errbuf, *errbuf_size,
+                         "API disabled in the current context");
+        *errbuf_size = p - errbuf;
+        return NGX_ERROR;
+    }
+
+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
+
+    if (bp->local == NULL) {
+        bp->local = ngx_palloc(r->pool, sizeof(ngx_addr_t) + addr_len);
+        if (bp->local == NULL) {
+            p = ngx_snprintf(errbuf, *errbuf_size, "no memory");
+            *errbuf_size = p - errbuf;
+            return NGX_ERROR;
+        }
+    }
+
+    rc = ngx_parse_addr_port(r->pool, bp->local, (u_char *) addr, addr_len);
+    if (rc == NGX_ERROR) {
+        p = ngx_snprintf(errbuf, *errbuf_size, "invalid addr %s", addr);
+        *errbuf_size = p - errbuf;
+        return NGX_ERROR;
+    }
+
+    bp->local->name.len = addr_len;
+    bp->local->name.data = (u_char *) (bp->local + 1);
+    ngx_memcpy(bp->local->name.data, addr, addr_len);
+
+    return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+    unsigned long timeout, unsigned int max_requests, char **err)
+{
+    ngx_http_upstream_t                     *u;
+    ngx_http_lua_ctx_t                      *ctx;
+    ngx_http_lua_balancer_peer_data_t       *bp;
 
     if (r == NULL) {
         *err = "no request found";
@@ -587,15 +1048,60 @@ ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
 
-    bp = lmcf->balancer_peer_data;
-    if (bp == NULL) {
-        *err = "no upstream peer data found";
+    if (!(bp->sockaddr && bp->socklen)) {
+        *err = "no current peer set";
+        return NGX_ERROR;
+    }
+
+    bp->keepalive_timeout = (ngx_msec_t) timeout;
+    bp->keepalive_requests = (ngx_uint_t) max_requests;
+    bp->keepalive = 1;
+
+    return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
+    long connect_timeout, long send_timeout, long read_timeout,
+    char **err)
+{
+    ngx_http_lua_ctx_t                 *ctx;
+    ngx_http_upstream_t                *u;
+
+#if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
+    ngx_http_upstream_conf_t           *ucf;
+    ngx_http_lua_balancer_peer_data_t  *bp;
+#endif
+
+    if (r == NULL) {
+        *err = "no request found";
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
         return NGX_ERROR;
     }
 
 #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
+
     if (!bp->cloned_upstream_conf) {
         /* we clone the upstream conf for the current request so that
          * we do not affect other requests at all. */
@@ -650,12 +1156,10 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
     int count, char **err)
 {
 #if (nginx_version >= 1007005)
-    ngx_uint_t             max_tries, total;
+    ngx_uint_t                          max_tries, total;
 #endif
-    ngx_http_lua_ctx_t    *ctx;
-    ngx_http_upstream_t   *u;
-
-    ngx_http_lua_main_conf_t           *lmcf;
+    ngx_http_lua_ctx_t                 *ctx;
+    ngx_http_upstream_t                *u;
     ngx_http_lua_balancer_peer_data_t  *bp;
 
     if (r == NULL) {
@@ -681,13 +1185,7 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
-
-    bp = lmcf->balancer_peer_data;
-    if (bp == NULL) {
-        *err = "no upstream peer data found";
-        return NGX_ERROR;
-    }
+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
 
 #if (nginx_version >= 1007005)
     max_tries = r->upstream->conf->next_upstream_tries;
@@ -713,12 +1211,10 @@ int
 ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
     int *status, char **err)
 {
-    ngx_http_lua_ctx_t         *ctx;
-    ngx_http_upstream_t        *u;
-    ngx_http_upstream_state_t  *state;
-
+    ngx_http_lua_ctx_t                 *ctx;
+    ngx_http_upstream_t                *u;
+    ngx_http_upstream_state_t          *state;
     ngx_http_lua_balancer_peer_data_t  *bp;
-    ngx_http_lua_main_conf_t           *lmcf;
 
     if (r == NULL) {
         *err = "no request found";
@@ -743,13 +1239,7 @@ ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
-
-    bp = lmcf->balancer_peer_data;
-    if (bp == NULL) {
-        *err = "no upstream peer data found";
-        return NGX_ERROR;
-    }
+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
 
     if (r->upstream_states && r->upstream_states->nelts > 1) {
         state = r->upstream_states->elts;
@@ -802,11 +1292,221 @@ ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
         /* u->request_bufs already contains a valid request buffer
          * remove it from chain first
          */
-        u->request_bufs = u->request_bufs->next;
+        u->request_bufs = r->request_body->bufs;
     }
 
     return u->create_request(r);
 }
 
+
+int
+ngx_http_lua_ffi_balancer_set_upstream_tls(ngx_http_request_t *r, int on,
+    char **err)
+{
+    ngx_http_lua_ctx_t    *ctx;
+    ngx_http_upstream_t   *u;
+
+    if (r == NULL) {
+        *err = "no request found";
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
+
+    if (on == 0) {
+        u->ssl = 0;
+        u->schema.len = sizeof("http://") - 1;
+
+    } else {
+        u->ssl = 1;
+        u->schema.len = sizeof("https://") - 1;
+    }
+
+    return NGX_OK;
+}
+
+
+char *
+ngx_http_lua_balancer_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_int_t    n;
+    ngx_str_t   *value;
+
+#if 0
+    ngx_http_upstream_srv_conf_t            *uscf;
+#endif
+    ngx_http_lua_srv_conf_t                 *lscf = conf;
+
+    if (lscf->balancer.max_cached != NGX_CONF_UNSET_UINT) {
+        return "is duplicate";
+    }
+
+    /* read options */
+
+    value = cf->args->elts;
+
+    n = ngx_atoi(value[1].data, value[1].len);
+
+    if (n == NGX_ERROR || n == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid value \"%V\" in \"%V\" directive",
+                           &value[1], &cmd->name);
+        return NGX_CONF_ERROR;
+    }
+
+    lscf->balancer.max_cached = n;
+
+    return NGX_CONF_OK;
+}
+
+
+#if (NGX_HTTP_SSL)
+static ngx_int_t
+ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
+    ngx_http_upstream_t *u)
+{
+    u_char     *p, *last;
+    ngx_str_t   name;
+
+    if (u->conf->ssl_name) {
+        if (ngx_http_complex_value(r, u->conf->ssl_name, &name) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+    } else {
+        name = u->ssl_name;
+    }
+
+    if (name.len == 0) {
+        goto done;
+    }
+
+    /*
+     * ssl name here may contain port, notably if derived from $proxy_host
+     * or $http_host; we have to strip it. eg: www.example.com:443
+     */
+
+    p = name.data;
+    last = name.data + name.len;
+
+    if (*p == '[') {
+        p = ngx_strlchr(p, last, ']');
+
+        if (p == NULL) {
+            p = name.data;
+        }
+    }
+
+    p = ngx_strlchr(p, last, ':');
+
+    if (p != NULL) {
+        name.len = p - name.data;
+    }
+
+done:
+
+    u->ssl_name = name;
+
+    return NGX_OK;
+}
+#endif
+
+
+static ngx_uint_t
+ngx_http_lua_balancer_calc_hash(ngx_str_t *name,
+    struct sockaddr *sockaddr, socklen_t socklen, ngx_addr_t *local)
+{
+    ngx_uint_t hash;
+
+    hash = ngx_hash_key_lc(name->data, name->len);
+    hash ^= ngx_hash_key((u_char *) sockaddr, socklen);
+    if (local != NULL) {
+        hash ^= ngx_hash_key((u_char *) local->sockaddr, local->socklen);
+    }
+
+    return hash;
+}
+
+
+static ngx_connection_t *
+ngx_http_lua_balancer_get_cached_item(ngx_http_lua_srv_conf_t *lscf,
+    ngx_peer_connection_t *pc, ngx_str_t *name)
+{
+    ngx_uint_t                         hash;
+    ngx_queue_t                       *q;
+    ngx_queue_t                       *head;
+    ngx_connection_t                  *c;
+    struct sockaddr                   *sockaddr;
+    socklen_t                          socklen;
+    ngx_addr_t                        *local;
+    ngx_http_lua_balancer_ka_item_t   *item;
+
+    sockaddr = pc->sockaddr;
+    socklen = pc->socklen;
+    local = pc->local;
+
+    hash = ngx_http_lua_balancer_calc_hash(name, sockaddr, socklen, pc->local);
+    head = &lscf->balancer.buckets[hash % lscf->balancer.bucket_cnt];
+
+    c = NULL;
+    for (q = ngx_queue_head(head);
+        q != ngx_queue_sentinel(head);
+        q = ngx_queue_next(q))
+    {
+        item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t, hnode);
+        if (item->hash != hash) {
+            continue;
+        }
+
+        if (name->len == item->host.len
+            && ngx_memn2cmp((u_char *) &item->sockaddr,
+                            (u_char *) sockaddr,
+                            item->socklen, socklen) == 0
+            && ngx_strncasecmp(name->data,
+                               item->host.data, name->len) == 0
+            && (local == NULL
+                || ngx_memn2cmp((u_char *) &item->local_sockaddr,
+                                (u_char *) local->sockaddr,
+                                socklen, local->socklen) == 0))
+        {
+            c = item->connection;
+            ngx_queue_remove(q);
+            ngx_queue_remove(&item->queue);
+            ngx_queue_insert_head(&lscf->balancer.free, &item->queue);
+            c->idle = 0;
+            c->sent = 0;
+            c->log = pc->log;
+            c->read->log = pc->log;
+            c->write->log = pc->log;
+            c->pool->log = pc->log;
+
+            if (c->read->timer_set) {
+                ngx_del_timer(c->read);
+            }
+
+            pc->cached = 1;
+            pc->connection = c;
+            return c;
+        }
+    }
+
+    return NULL;
+}
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_balancer.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_balancer.h
@@ -23,5 +23,7 @@ char *ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 char *ngx_http_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
+char *ngx_http_lua_balancer_keepalive(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
 
 #endif /* _NGX_HTTP_LUA_BALANCER_H_INCLUDED_ */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_bodyfilterby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_bodyfilterby.c
@@ -155,6 +155,10 @@ ngx_http_lua_body_filter_inline(ngx_http_request_t *r, ngx_chain_t *in)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->body_filter_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->body_filter_src.value.data,
@@ -205,6 +209,10 @@ ngx_http_lua_body_filter_file(ngx_http_request_t *r, ngx_chain_t *in)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->body_filter_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
@@ -368,6 +376,7 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         }
 
     } else {
+        ctx->context = old_context;
         out = NULL;
     }
 
@@ -532,9 +541,23 @@ ngx_http_lua_body_filter_param_set(lua_State *L, ngx_http_request_t *r,
         if (last) {
             ctx->seen_last_in_filter = 1;
 
-            /* the "in" chain cannot be NULL and we set the "last_buf" or
-             * "last_in_chain" flag in the last buf of "in" */
+            /* the "in" chain cannot be NULL except that we set arg[1] = ""
+             * before arg[2] = true
+             */
+            if (in == NULL) {
+                in = ngx_http_lua_chain_get_free_buf(r->connection->log,
+                                                     r->pool,
+                                                     &ctx->free_bufs, 0);
+                if (in == NULL) {
+                    return luaL_error(L, "no memory");
+                }
 
+                in->buf->tag = (ngx_buf_tag_t) &ngx_http_lua_body_filter;
+                lmcf->body_filter_chain = in;
+            }
+
+            /* we set the "last_buf" or "last_in_chain" flag
+             * in the last buf of "in" */
             for (cl = in; cl; cl = cl->next) {
                 if (cl->next == NULL) {
                     if (r == r->main) {

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_clfactory.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_clfactory.c
@@ -91,7 +91,7 @@
  * | Int               | At which line this function is defined
  * | [linedefined]     |
  * ---------------------
- * | Int               | At while line this function definition ended
+ * | Int               | At which line this function definition ended
  * | [lastlinedefined] |
  * ---------------------
  * | Char              | Number of upvalues referenced by this function
@@ -128,7 +128,7 @@
  * | Vector            | Debug lineinfo vector
  * | [lineinfo]        | Empty vector here if debug info is stripped
  * ---------------------
- * | Int               | Number of local variable in this function
+ * | Int               | Number of local variables in this function
  * | [sizelocvars]     | 0 if debug info is stripped
  * ---------------------
  * | String            | ------------------------------------

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_common.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_common.h
@@ -55,11 +55,17 @@ typedef struct {
 
 
 #if (NGX_PCRE)
-#include <pcre.h>
-#   if (PCRE_MAJOR > 8) || (PCRE_MAJOR == 8 && PCRE_MINOR >= 21)
+#   if (NGX_PCRE2)
 #       define LUA_HAVE_PCRE_JIT 1
 #   else
-#       define LUA_HAVE_PCRE_JIT 0
+
+#include <pcre.h>
+
+#       if (PCRE_MAJOR > 8) || (PCRE_MAJOR == 8 && PCRE_MINOR >= 21)
+#           define LUA_HAVE_PCRE_JIT 1
+#       else
+#           define LUA_HAVE_PCRE_JIT 0
+#       endif
 #   endif
 #endif
 
@@ -125,23 +131,27 @@ typedef struct {
     (NGX_HTTP_LUA_FILE_TAG_LEN + 2 * MD5_DIGEST_LENGTH)
 
 
-/* must be within 16 bit */
-#define NGX_HTTP_LUA_CONTEXT_SET                0x0001
-#define NGX_HTTP_LUA_CONTEXT_REWRITE            0x0002
-#define NGX_HTTP_LUA_CONTEXT_ACCESS             0x0004
-#define NGX_HTTP_LUA_CONTEXT_CONTENT            0x0008
-#define NGX_HTTP_LUA_CONTEXT_LOG                0x0010
-#define NGX_HTTP_LUA_CONTEXT_HEADER_FILTER      0x0020
-#define NGX_HTTP_LUA_CONTEXT_BODY_FILTER        0x0040
-#define NGX_HTTP_LUA_CONTEXT_TIMER              0x0080
-#define NGX_HTTP_LUA_CONTEXT_INIT_WORKER        0x0100
-#define NGX_HTTP_LUA_CONTEXT_BALANCER           0x0200
-#define NGX_HTTP_LUA_CONTEXT_SSL_CERT           0x0400
-#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE     0x0800
-#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH     0x1000
-#define NGX_HTTP_LUA_CONTEXT_EXIT_WORKER        0x2000
-#define NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO   0x4000
-#define NGX_HTTP_LUA_CONTEXT_SERVER_REWRITE     0x8000
+/* must be within 32 bits */
+#define NGX_HTTP_LUA_CONTEXT_SET                0x00000001
+#define NGX_HTTP_LUA_CONTEXT_REWRITE            0x00000002
+#define NGX_HTTP_LUA_CONTEXT_ACCESS             0x00000004
+#define NGX_HTTP_LUA_CONTEXT_CONTENT            0x00000008
+#define NGX_HTTP_LUA_CONTEXT_LOG                0x00000010
+#define NGX_HTTP_LUA_CONTEXT_HEADER_FILTER      0x00000020
+#define NGX_HTTP_LUA_CONTEXT_BODY_FILTER        0x00000040
+#define NGX_HTTP_LUA_CONTEXT_TIMER              0x00000080
+#define NGX_HTTP_LUA_CONTEXT_INIT_WORKER        0x00000100
+#define NGX_HTTP_LUA_CONTEXT_BALANCER           0x00000200
+#define NGX_HTTP_LUA_CONTEXT_SSL_CERT           0x00000400
+#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE     0x00000800
+#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH     0x00001000
+#define NGX_HTTP_LUA_CONTEXT_EXIT_WORKER        0x00002000
+#define NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO   0x00004000
+#define NGX_HTTP_LUA_CONTEXT_SERVER_REWRITE     0x00008000
+
+#ifdef HAVE_PROXY_SSL_PATCH
+#define NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY   0x00010000
+#endif
 
 
 #define NGX_HTTP_LUA_FFI_NO_REQ_CTX         -100
@@ -161,9 +171,11 @@ typedef struct ngx_http_lua_co_ctx_s  ngx_http_lua_co_ctx_t;
 
 typedef struct ngx_http_lua_sema_mm_s  ngx_http_lua_sema_mm_t;
 
-typedef union ngx_http_lua_srv_conf_u  ngx_http_lua_srv_conf_t;
+typedef struct ngx_http_lua_srv_conf_s  ngx_http_lua_srv_conf_t;
 
 typedef struct ngx_http_lua_main_conf_s  ngx_http_lua_main_conf_t;
+
+typedef struct ngx_http_lua_loc_conf_s  ngx_http_lua_loc_conf_t;
 
 typedef struct ngx_http_lua_header_val_s  ngx_http_lua_header_val_t;
 
@@ -177,6 +189,9 @@ typedef ngx_int_t (*ngx_http_lua_main_conf_handler_pt)(ngx_log_t *log,
 
 typedef ngx_int_t (*ngx_http_lua_srv_conf_handler_pt)(ngx_http_request_t *r,
     ngx_http_lua_srv_conf_t *lscf, lua_State *L);
+
+typedef ngx_int_t (*ngx_http_lua_loc_conf_handler_pt)(ngx_http_request_t *r,
+    ngx_http_lua_loc_conf_t *llcf, lua_State *L);
 
 typedef ngx_int_t (*ngx_http_lua_set_header_pt)(ngx_http_request_t *r,
     ngx_http_lua_header_val_t *hv, ngx_str_t *value);
@@ -221,9 +236,14 @@ struct ngx_http_lua_main_conf_s {
     ngx_int_t            regex_cache_entries;
     ngx_int_t            regex_cache_max_entries;
     ngx_int_t            regex_match_limit;
-#   if (LUA_HAVE_PCRE_JIT)
+#endif
+
+#if (LUA_HAVE_PCRE_JIT)
+#if (NGX_PCRE2)
+    pcre2_jit_stack     *jit_stack;
+#else
     pcre_jit_stack      *jit_stack;
-#   endif
+#endif
 #endif
 
     ngx_array_t         *shm_zones;  /* of ngx_shm_zone_t* */
@@ -246,13 +266,6 @@ struct ngx_http_lua_main_conf_s {
     ngx_http_lua_main_conf_handler_pt    exit_worker_handler;
     ngx_str_t                            exit_worker_src;
     u_char                              *exit_worker_chunkname;
-
-    ngx_http_lua_balancer_peer_data_t      *balancer_peer_data;
-                    /* neither yielding nor recursion is possible in
-                     * balancer_by_lua*, so there cannot be any races among
-                     * concurrent requests and it is safe to store the peer
-                     * data pointer in the main conf.
-                     */
 
     ngx_chain_t                            *body_filter_chain;
                     /* neither yielding nor recursion is possible in
@@ -312,7 +325,7 @@ struct ngx_http_lua_main_conf_s {
 };
 
 
-union ngx_http_lua_srv_conf_u {
+struct ngx_http_lua_srv_conf_s {
     struct {
 #if (NGX_HTTP_SSL)
         ngx_http_lua_srv_conf_handler_pt     ssl_cert_handler;
@@ -348,6 +361,14 @@ union ngx_http_lua_srv_conf_u {
     } srv;
 
     struct {
+        ngx_uint_t                           max_cached;
+        ngx_queue_t                          cache;
+        ngx_queue_t                          free;
+        ngx_queue_t                         *buckets;
+        ngx_uint_t                           bucket_cnt;
+        ngx_http_upstream_init_pt            original_init_upstream;
+        ngx_http_upstream_init_peer_pt       original_init_peer;
+
         ngx_http_lua_srv_conf_handler_pt     handler;
         ngx_str_t                            src;
         u_char                              *src_key;
@@ -357,17 +378,30 @@ union ngx_http_lua_srv_conf_u {
 };
 
 
-typedef struct {
+struct ngx_http_lua_loc_conf_s {
 #if (NGX_HTTP_SSL)
     ngx_ssl_t              *ssl;  /* shared by SSL cosockets */
+    ngx_array_t            *ssl_certificates;
+    ngx_array_t            *ssl_certificate_keys;
     ngx_uint_t              ssl_protocols;
     ngx_str_t               ssl_ciphers;
     ngx_uint_t              ssl_verify_depth;
     ngx_str_t               ssl_trusted_certificate;
     ngx_str_t               ssl_crl;
+    ngx_str_t               ssl_key_log;
 #if (nginx_version >= 1019004)
     ngx_array_t            *ssl_conf_commands;
 #endif
+
+#ifdef HAVE_PROXY_SSL_PATCH
+    ngx_http_lua_loc_conf_handler_pt       proxy_ssl_verify_handler;
+    ngx_str_t                              proxy_ssl_verify_src;
+    u_char                                *proxy_ssl_verify_src_key;
+    u_char                                *proxy_ssl_verify_chunkname;
+    int                                    proxy_ssl_verify_src_ref;
+    ngx_flag_t                             upstream_skip_openssl_default_verify;
+#endif
+
 #endif
 
     ngx_flag_t              force_read_body; /* whether force request body to
@@ -449,7 +483,7 @@ typedef struct {
     ngx_flag_t                       log_socket_errors;
     ngx_flag_t                       check_client_abort;
     ngx_flag_t                       use_default_type;
-} ngx_http_lua_loc_conf_t;
+};
 
 
 typedef enum {
@@ -613,7 +647,7 @@ typedef struct ngx_http_lua_ctx_s {
 
     int                      uthreads; /* number of active user threads */
 
-    uint16_t                 context;   /* the current running directive context
+    uint32_t                 context;   /* the current running directive context
                                            (or running phase) for the current
                                            Lua chunk */
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_contentby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_contentby.c
@@ -274,6 +274,10 @@ ngx_http_lua_content_handler_file(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->content_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
                                      &llcf->content_src_ref,
@@ -303,6 +307,10 @@ ngx_http_lua_content_handler_inline(ngx_http_request_t *r)
     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->content_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_control.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_control.c
@@ -280,6 +280,9 @@ ngx_http_lua_ngx_redirect(lua_State *L)
 
     h->value.len = len;
     h->value.data = uri;
+#if defined(nginx_version) && nginx_version >= 1023000
+    h->next = NULL;
+#endif
     ngx_str_set(&h->key, "Location");
 
     r->headers_out.status = rc;
@@ -381,6 +384,9 @@ ngx_http_lua_ffi_exit(ngx_http_request_t *r, int status, u_char *err,
                                        | NGX_HTTP_LUA_CONTEXT_TIMER
                                        | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER
                                        | NGX_HTTP_LUA_CONTEXT_BALANCER
+#ifdef HAVE_PROXY_SSL_PATCH
+                                       | NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY
+#endif
                                        | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                        | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                        | NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE
@@ -392,6 +398,9 @@ ngx_http_lua_ffi_exit(ngx_http_request_t *r, int status, u_char *err,
     }
 
     if (ctx->context & (NGX_HTTP_LUA_CONTEXT_SSL_CERT
+#ifdef HAVE_PROXY_SSL_PATCH
+                        | NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY
+#endif
                         | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                         | NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE
                         | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH))

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_headerfilterby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_headerfilterby.c
@@ -165,6 +165,10 @@ ngx_http_lua_header_filter_inline(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->header_filter_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->header_filter_src.value.data,
@@ -209,6 +213,10 @@ ngx_http_lua_header_filter_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->header_filter_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_headers_in.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_headers_in.c
@@ -280,6 +280,9 @@ new_header:
 
     h->key = hv->key;
     h->value = *value;
+#if defined(nginx_version) && nginx_version >= 1023000
+    h->next = NULL;
+#endif
 
     h->lowcase_key = ngx_pnalloc(r->pool, h->key.len);
     if (h->lowcase_key == NULL) {
@@ -594,13 +597,14 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     if (!hv->no_override && *headers != NULL) {
 #if defined(DDEBUG) && (DDEBUG)
         int  nelts = 0;
-        
+
         for (h = *headers; h; h = h->next) {
             nelts++;
         }
 
         dd("clear multi-value headers: %d", nelts);
 #endif
+
         *headers = NULL;
     }
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_headers_out.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_headers_out.c
@@ -229,6 +229,9 @@ new_header:
 
     h->key = hv->key;
     h->value = *value;
+#if defined(nginx_version) && nginx_version >= 1023000
+    h->next = NULL;
+#endif
 
     h->lowcase_key = ngx_pnalloc(r->pool, h->key.len);
     if (h->lowcase_key == NULL) {

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_initworkerby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_initworkerby.c
@@ -297,6 +297,8 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
 
     (void) lmcf->init_worker_handler(cycle->log, lmcf, lmcf->lua);
 
+    ngx_http_lua_set_req(lmcf->lua, NULL);
+
     ngx_destroy_pool(c->pool);
     return NGX_OK;
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_logby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_logby.c
@@ -149,6 +149,10 @@ ngx_http_lua_log_handler_inline(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->log_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->log_src.value.data,
@@ -187,6 +191,10 @@ ngx_http_lua_log_handler_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->log_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_misc.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_misc.c
@@ -64,8 +64,11 @@ ngx_http_lua_ffi_get_resp_status(ngx_http_request_t *r)
 
 
 int
-ngx_http_lua_ffi_set_resp_status(ngx_http_request_t *r, int status)
+ngx_http_lua_ffi_set_resp_status_and_reason(ngx_http_request_t *r, int status,
+    const char *reason, size_t reason_len)
 {
+    u_char *buf;
+
     if (r->connection->fd == (ngx_socket_t) -1) {
         return NGX_HTTP_LUA_FFI_BAD_CONTEXT;
     }
@@ -74,6 +77,14 @@ ngx_http_lua_ffi_set_resp_status(ngx_http_request_t *r, int status)
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "attempt to set ngx.status after sending out "
                       "response headers");
+        return NGX_DECLINED;
+    }
+
+    /* per RFC-7230 sec 3.1.2, the status line must be 3 digits, it also makes
+     * buffer size calculation easier */
+    if (status < 100 || status > 999) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "invalid HTTP status code %d", status);
         return NGX_DECLINED;
     }
 
@@ -91,11 +102,30 @@ ngx_http_lua_ffi_set_resp_status(ngx_http_request_t *r, int status)
 
         ngx_str_set(&r->headers_out.status_line, "101 Switching Protocols");
 
+    } else if (reason != NULL && reason_len > 0) {
+        reason_len += 4; /* "ddd <reason>" */
+        buf = ngx_palloc(r->pool, reason_len);
+        if (buf == NULL) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "no memory");
+            return NGX_DECLINED;
+        }
+
+        ngx_snprintf(buf, reason_len, "%d %s", status, reason);
+        r->headers_out.status_line.len = reason_len;
+        r->headers_out.status_line.data = buf;
+
     } else {
         r->headers_out.status_line.len = 0;
     }
 
     return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_set_resp_status(ngx_http_request_t *r, int status)
+{
+    return ngx_http_lua_ffi_set_resp_status_and_reason(r, status, NULL, 0);
 }
 
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_module.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_module.c
@@ -31,9 +31,16 @@
 #include "ngx_http_lua_ssl_certby.h"
 #include "ngx_http_lua_ssl_session_storeby.h"
 #include "ngx_http_lua_ssl_session_fetchby.h"
+
+#ifdef HAVE_PROXY_SSL_PATCH
+#include "ngx_http_lua_proxy_ssl_verifyby.h"
+#endif
+
 #include "ngx_http_lua_headers.h"
 #include "ngx_http_lua_headers_out.h"
+#if !(NGX_WIN32)
 #include "ngx_http_lua_pipe.h"
+#endif
 
 
 static void *ngx_http_lua_create_main_conf(ngx_conf_t *cf);
@@ -48,8 +55,15 @@ static char *ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent,
 static ngx_int_t ngx_http_lua_init(ngx_conf_t *cf);
 static char *ngx_http_lua_lowat_check(ngx_conf_t *cf, void *post, void *data);
 #if (NGX_HTTP_SSL)
+static ngx_int_t ngx_http_lua_merge_ssl(ngx_conf_t *cf,
+    ngx_http_lua_loc_conf_t *conf, ngx_http_lua_loc_conf_t *prev);
 static ngx_int_t ngx_http_lua_set_ssl(ngx_conf_t *cf,
     ngx_http_lua_loc_conf_t *llcf);
+static void key_log_callback(const ngx_ssl_conn_t *ssl_conn,
+    const char *line);
+static void ngx_http_lua_ssl_cleanup_key_log(void *data);
+static ngx_int_t ngx_http_lua_ssl_key_log(ngx_conf_t *cf, ngx_ssl_t *ssl,
+    ngx_str_t *file);
 #if (nginx_version >= 1019004)
 static char *ngx_http_lua_ssl_conf_command_check(ngx_conf_t *cf, void *post,
     void *data);
@@ -57,6 +71,9 @@ static char *ngx_http_lua_ssl_conf_command_check(ngx_conf_t *cf, void *post,
 #endif
 static char *ngx_http_lua_malloc_trim(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+#if (NGX_PCRE2)
+extern void ngx_http_lua_regex_cleanup(void *data);
+#endif
 
 
 static ngx_conf_post_t  ngx_http_lua_lowat_post =
@@ -489,6 +506,13 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       0,
       (void *) ngx_http_lua_balancer_handler_file },
 
+    { ngx_string("balancer_keepalive"),
+      NGX_HTTP_UPS_CONF|NGX_CONF_TAKE1,
+      ngx_http_lua_balancer_keepalive,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_lua_srv_conf_t, balancer.max_cached),
+      NULL },
+
     { ngx_string("lua_socket_keepalive_timeout"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF
           |NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
@@ -641,11 +665,49 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       0,
       (void *) ngx_http_lua_ssl_sess_fetch_handler_file },
 
+#ifdef HAVE_PROXY_SSL_PATCH
+    /* same context as proxy_pass directive */
+    { ngx_string("proxy_ssl_verify_by_lua_block"),
+      NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+      ngx_http_lua_proxy_ssl_verify_by_lua_block,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      (void *) ngx_http_lua_proxy_ssl_verify_handler_inline },
+
+    { ngx_string("proxy_ssl_verify_by_lua_file"),
+      NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
+      ngx_http_lua_proxy_ssl_verify_by_lua,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      (void *) ngx_http_lua_proxy_ssl_verify_handler_file },
+
+    { ngx_string("lua_upstream_skip_openssl_default_verify"),
+      NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_loc_conf_t, upstream_skip_openssl_default_verify),
+      NULL },
+#endif
+
     { ngx_string("lua_ssl_verify_depth"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_num_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_lua_loc_conf_t, ssl_verify_depth),
+      NULL },
+
+    { ngx_string("lua_ssl_certificate"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_array_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_loc_conf_t, ssl_certificates),
+      NULL },
+
+    { ngx_string("lua_ssl_certificate_key"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_array_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_loc_conf_t, ssl_certificate_keys),
       NULL },
 
     { ngx_string("lua_ssl_trusted_certificate"),
@@ -660,6 +722,13 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       ngx_conf_set_str_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_lua_loc_conf_t, ssl_crl),
+      NULL },
+
+    { ngx_string("lua_ssl_key_log"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_loc_conf_t, ssl_key_log),
       NULL },
 
 #if (nginx_version >= 1019004)
@@ -839,6 +908,17 @@ ngx_http_lua_init(ngx_conf_t *cf)
     cln->data = lmcf;
     cln->handler = ngx_http_lua_sema_mm_cleanup;
 
+#if (NGX_PCRE2)
+    /* add the cleanup of pcre2 regex */
+    cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        return NGX_ERROR;
+    }
+
+    cln->data = lmcf;
+    cln->handler = ngx_http_lua_regex_cleanup;
+#endif
+
 #ifdef HAVE_NGX_LUA_PIPE
     ngx_http_lua_pipe_init();
 #endif
@@ -991,6 +1071,13 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
      *      lmcf->shm_zones = NULL;
      *      lmcf->init_handler = NULL;
      *      lmcf->init_src = { 0, NULL };
+     *      lmcf->init_chunkname = NULL;
+     *      lmcf->init_worker_handler = NULL;
+     *      lmcf->init_worker_src = { 0, NULL };
+     *      lmcf->init_worker_chunkname = NULL;
+     *      lmcf->exit_worker_handler = NULL;
+     *      lmcf->exit_worker_src = { 0, NULL };
+     *      lmcf->exit_worker_chunkname = NULL;
      *      lmcf->shm_zones_inited = 0;
      *      lmcf->shdict_zones = NULL;
      *      lmcf->preload_hooks = NULL;
@@ -1111,7 +1198,7 @@ ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf)
 #endif
 
     if (lmcf->worker_thread_vm_pool_size == NGX_CONF_UNSET_UINT) {
-        lmcf->worker_thread_vm_pool_size = 100;
+        lmcf->worker_thread_vm_pool_size = 10;
     }
 
     if (ngx_http_lua_init_builtin_headers_out(cf, lmcf) != NGX_OK) {
@@ -1148,16 +1235,23 @@ ngx_http_lua_create_srv_conf(ngx_conf_t *cf)
      *      lscf->srv.ssl_cert_chunkname = NULL;
      *      lscf->srv.ssl_cert_src_key = NULL;
      *
-     *      lscf->srv.ssl_session_store_handler = NULL;
-     *      lscf->srv.ssl_session_store_src = { 0, NULL };
-     *      lscf->srv.ssl_session_store_chunkname = NULL;
-     *      lscf->srv.ssl_session_store_src_key = NULL;
+     *      lscf->srv.ssl_sess_store_handler = NULL;
+     *      lscf->srv.ssl_sess_store_src = { 0, NULL };
+     *      lscf->srv.ssl_sess_store_chunkname = NULL;
+     *      lscf->srv.ssl_sess_store_src_key = NULL;
      *
-     *      lscf->srv.ssl_session_fetch_handler = NULL;
-     *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
-     *      lscf->srv.ssl_session_fetch_chunkname = NULL;
-     *      lscf->srv.ssl_session_fetch_src_key = NULL;
+     *      lscf->srv.ssl_sess_fetch_handler = NULL;
+     *      lscf->srv.ssl_sess_fetch_src = { 0, NULL };
+     *      lscf->srv.ssl_sess_fetch_chunkname = NULL;
+     *      lscf->srv.ssl_sess_fetch_src_key = NULL;
      *
+     *      lscf->srv.server_rewrite_handler = NULL;
+     *      lscf->srv.server_rewrite_src = { 0, NULL };
+     *      lscf->srv.server_rewrite_chunkname = NULL;
+     *      lscf->srv.server_rewrite_src_key = NULL;
+     *
+     *      lscf->balancer.original_init_upstream = NULL;
+     *      lscf->balancer.original_init_peer = NULL;
      *      lscf->balancer.handler = NULL;
      *      lscf->balancer.src = { 0, NULL };
      *      lscf->balancer.chunkname = NULL;
@@ -1171,8 +1265,9 @@ ngx_http_lua_create_srv_conf(ngx_conf_t *cf)
     lscf->srv.ssl_sess_fetch_src_ref = LUA_REFNIL;
 #endif
 
+    lscf->srv.server_rewrite_src_ref = LUA_REFNIL;
     lscf->balancer.src_ref = LUA_REFNIL;
-
+    lscf->balancer.max_cached = NGX_CONF_UNSET_UINT;
     return lscf;
 }
 
@@ -1346,31 +1441,45 @@ ngx_http_lua_create_loc_conf(ngx_conf_t *cf)
     /* set by ngx_pcalloc:
      *      conf->access_src  = {{ 0, NULL }, NULL, NULL, NULL};
      *      conf->access_src_key = NULL
+     *      conf->access_handler = NULL;
+     *      conf->access_chunkname = NULL;
+     *
      *      conf->rewrite_src = {{ 0, NULL }, NULL, NULL, NULL};
      *      conf->rewrite_src_key = NULL;
      *      conf->rewrite_handler = NULL;
+     *      conf->rewrite_chunkname = NULL;
      *
      *      conf->content_src = {{ 0, NULL }, NULL, NULL, NULL};
      *      conf->content_src_key = NULL;
      *      conf->content_handler = NULL;
+     *      conf->content_chunkname = NULL;
      *
      *      conf->log_src = {{ 0, NULL }, NULL, NULL, NULL};
      *      conf->log_src_key = NULL;
      *      conf->log_handler = NULL;
+     *      conf->log_chunkname = NULL;
      *
      *      conf->header_filter_src = {{ 0, NULL }, NULL, NULL, NULL};
      *      conf->header_filter_src_key = NULL;
      *      conf->header_filter_handler = NULL;
+     *      conf->header_filter_chunkname = NULL;
      *
      *      conf->body_filter_src = {{ 0, NULL }, NULL, NULL, NULL};
      *      conf->body_filter_src_key = NULL;
      *      conf->body_filter_handler = NULL;
+     *      conf->body_filter_chunkname = NULL;
      *
      *      conf->ssl = 0;
      *      conf->ssl_protocols = 0;
      *      conf->ssl_ciphers = { 0, NULL };
      *      conf->ssl_trusted_certificate = { 0, NULL };
      *      conf->ssl_crl = { 0, NULL };
+     *      conf->ssl_key_log = { 0, NULL };
+     *
+     *      conf->proxy_ssl_verify_handler = NULL;
+     *      conf->proxy_ssl_verify_src = { 0, NULL };
+     *      conf->proxy_ssl_verify_chunkname = NULL;
+     *      conf->proxy_ssl_verify_src_key = NULL;
      */
 
     conf->force_read_body    = NGX_CONF_UNSET;
@@ -1399,8 +1508,14 @@ ngx_http_lua_create_loc_conf(ngx_conf_t *cf)
 
 #if (NGX_HTTP_SSL)
     conf->ssl_verify_depth = NGX_CONF_UNSET_UINT;
+    conf->ssl_certificates = NGX_CONF_UNSET_PTR;
+    conf->ssl_certificate_keys = NGX_CONF_UNSET_PTR;
 #if (nginx_version >= 1019004)
     conf->ssl_conf_commands = NGX_CONF_UNSET_PTR;
+#endif
+#ifdef HAVE_PROXY_SSL_PATCH
+    conf->proxy_ssl_verify_src_ref = LUA_REFNIL;
+    conf->upstream_skip_openssl_default_verify = NGX_CONF_UNSET;
 #endif
 #endif
 
@@ -1464,23 +1579,55 @@ ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
 #if (NGX_HTTP_SSL)
 
+    if (ngx_http_lua_merge_ssl(cf, conf, prev) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
     ngx_conf_merge_bitmask_value(conf->ssl_protocols, prev->ssl_protocols,
-                                 (NGX_CONF_BITMASK_SET|NGX_SSL_SSLv3
+                                 (NGX_CONF_BITMASK_SET
                                   |NGX_SSL_TLSv1|NGX_SSL_TLSv1_1
-                                  |NGX_SSL_TLSv1_2));
+                                  |NGX_SSL_TLSv1_2
+#ifdef NGX_SSL_TLSv1_3
+                                  |NGX_SSL_TLSv1_3
+#endif
+                                  ));
 
     ngx_conf_merge_str_value(conf->ssl_ciphers, prev->ssl_ciphers,
                              "DEFAULT");
 
     ngx_conf_merge_uint_value(conf->ssl_verify_depth,
                               prev->ssl_verify_depth, 1);
+    ngx_conf_merge_ptr_value(conf->ssl_certificates,
+                             prev->ssl_certificates, NULL);
+    ngx_conf_merge_ptr_value(conf->ssl_certificate_keys,
+                             prev->ssl_certificate_keys, NULL);
     ngx_conf_merge_str_value(conf->ssl_trusted_certificate,
                              prev->ssl_trusted_certificate, "");
     ngx_conf_merge_str_value(conf->ssl_crl, prev->ssl_crl, "");
+    ngx_conf_merge_str_value(conf->ssl_key_log, prev->ssl_key_log, "");
 
 #if (nginx_version >= 1019004)
     ngx_conf_merge_ptr_value(conf->ssl_conf_commands, prev->ssl_conf_commands,
                              NULL);
+#endif
+
+#ifdef HAVE_PROXY_SSL_PATCH
+    if (conf->proxy_ssl_verify_src.len == 0) {
+        conf->proxy_ssl_verify_src = prev->proxy_ssl_verify_src;
+        conf->proxy_ssl_verify_handler = prev->proxy_ssl_verify_handler;
+        conf->proxy_ssl_verify_src_ref = prev->proxy_ssl_verify_src_ref;
+        conf->proxy_ssl_verify_src_key = prev->proxy_ssl_verify_src_key;
+        conf->proxy_ssl_verify_chunkname = prev->proxy_ssl_verify_chunkname;
+    }
+
+    if (conf->proxy_ssl_verify_src.len) {
+        if (ngx_http_lua_proxy_ssl_verify_set_callback(cf) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    ngx_conf_merge_value(conf->upstream_skip_openssl_default_verify,
+                         prev->upstream_skip_openssl_default_verify, 0);
 #endif
 
     if (ngx_http_lua_set_ssl(cf, conf) != NGX_OK) {
@@ -1528,16 +1675,77 @@ ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 #if (NGX_HTTP_SSL)
 
 static ngx_int_t
+ngx_http_lua_merge_ssl(ngx_conf_t *cf,
+    ngx_http_lua_loc_conf_t *conf, ngx_http_lua_loc_conf_t *prev)
+{
+    ngx_uint_t  preserve;
+
+    if (conf->ssl_protocols == 0
+        && conf->ssl_ciphers.data == NULL
+        && conf->ssl_verify_depth == NGX_CONF_UNSET_UINT
+        && conf->ssl_certificates == NGX_CONF_UNSET_PTR
+        && conf->ssl_certificate_keys == NGX_CONF_UNSET_PTR
+        && conf->ssl_trusted_certificate.data == NULL
+        && conf->ssl_crl.data == NULL
+        && conf->ssl_key_log.data == NULL
+#if (nginx_version >= 1019004)
+        && conf->ssl_conf_commands == NGX_CONF_UNSET_PTR
+#endif
+       )
+    {
+        if (prev->ssl) {
+            conf->ssl = prev->ssl;
+            return NGX_OK;
+        }
+
+        preserve = 1;
+
+    } else {
+        preserve = 0;
+    }
+
+    conf->ssl = ngx_pcalloc(cf->pool, sizeof(ngx_ssl_t));
+    if (conf->ssl == NULL) {
+        return NGX_ERROR;
+    }
+
+    conf->ssl->log = cf->log;
+
+    /*
+     * special handling to preserve conf->ssl_* in the "http" section
+     * to inherit it to all servers
+     */
+
+    if (preserve) {
+        prev->ssl = conf->ssl;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
 ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
 {
     ngx_pool_cleanup_t  *cln;
 
-    llcf->ssl = ngx_pcalloc(cf->pool, sizeof(ngx_ssl_t));
-    if (llcf->ssl == NULL) {
-        return NGX_ERROR;
+    if (llcf->ssl->ctx) {
+        return NGX_OK;
     }
 
-    llcf->ssl->log = cf->log;
+    if (llcf->ssl_certificates) {
+        if (llcf->ssl_certificate_keys == NULL
+            || llcf->ssl_certificate_keys->nelts
+            < llcf->ssl_certificates->nelts)
+        {
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "no \"lua_ssl_certificate_key\" is defined "
+                          "for certificate \"%V\"",
+                          ((ngx_str_t *) llcf->ssl_certificates->elts)
+                          + llcf->ssl_certificates->nelts - 1);
+            return NGX_ERROR;
+        }
+    }
 
     if (ngx_ssl_create(llcf->ssl, llcf->ssl_protocols, NULL) != NGX_OK) {
         return NGX_ERROR;
@@ -1562,6 +1770,16 @@ ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
         return NGX_ERROR;
     }
 
+    if (llcf->ssl_certificates
+        && ngx_ssl_certificates(cf, llcf->ssl,
+                                llcf->ssl_certificates,
+                                llcf->ssl_certificate_keys,
+                                NULL)
+        != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
     if (llcf->ssl_trusted_certificate.len
         && ngx_ssl_trusted_certificate(cf, llcf->ssl,
                                        &llcf->ssl_trusted_certificate,
@@ -1577,6 +1795,12 @@ ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
         return NGX_ERROR;
     }
 
+    if (ngx_http_lua_ssl_key_log(cf, llcf->ssl, &llcf->ssl_key_log)
+        != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
 #if (nginx_version >= 1019004)
     if (ngx_ssl_conf_commands(cf, llcf->ssl, llcf->ssl_conf_commands)
         != NGX_OK)
@@ -1587,6 +1811,102 @@ ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
 
     return NGX_OK;
 }
+
+
+static void
+key_log_callback(const ngx_ssl_conn_t *ssl_conn, const char *line)
+{
+    ngx_http_lua_ssl_key_log_t  *ssl_key_log;
+    ngx_connection_t            *c;
+
+    ssl_key_log = SSL_CTX_get_ex_data(SSL_get_SSL_CTX(ssl_conn),
+                                      ngx_http_lua_ssl_key_log_index);
+    if (ssl_key_log == NULL) {
+        c = ngx_ssl_get_connection((ngx_ssl_conn_t *) ssl_conn);
+        ngx_ssl_error(NGX_LOG_DEBUG, c->log, 0, "get ssl key log failed");
+
+        return;
+    }
+
+    (void) ngx_write_fd(ssl_key_log->fd, (void *) line, ngx_strlen(line));
+    (void) ngx_write_fd(ssl_key_log->fd, (void *) "\n", 1);
+}
+
+
+static void
+ngx_http_lua_ssl_cleanup_key_log(void *data)
+{
+    ngx_http_lua_ssl_key_log_t  *ssl_key_log = data;
+
+    if (ngx_close_file(ssl_key_log->fd) == NGX_FILE_ERROR) {
+        ngx_ssl_error(NGX_LOG_ALERT, ssl_key_log->ssl->log, 0,
+                      ngx_close_file_n "(\"%V\") failed", ssl_key_log->name);
+    }
+}
+
+
+static ngx_int_t
+ngx_http_lua_ssl_key_log(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *file)
+{
+    ngx_fd_t                     fd;
+    ngx_http_lua_ssl_key_log_t  *ssl_key_log;
+    ngx_pool_cleanup_t          *cln;
+
+    if (!file->len) {
+        return NGX_OK;
+    }
+
+    if (ngx_conf_full_name(cf->cycle, file, 1) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    if (ngx_http_lua_ssl_init(cf->log) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    /*
+     * append so that existing keylog file contents can be preserved
+     */
+    fd = ngx_open_file(file->data, NGX_FILE_APPEND, NGX_FILE_CREATE_OR_OPEN,
+                       NGX_FILE_DEFAULT_ACCESS);
+    if (fd == NGX_INVALID_FILE) {
+        ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0, ngx_open_file_n
+                      "(\"%V\") failed", file);
+        return NGX_ERROR;
+    }
+
+    ssl_key_log = ngx_palloc(cf->pool, sizeof(ngx_http_lua_ssl_key_log_t));
+    if (ssl_key_log == NULL) {
+        ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0, "ngx_pcalloc() failed");
+        return NGX_ERROR;
+    }
+
+    ssl_key_log->ssl = ssl;
+    ssl_key_log->fd = fd;
+    ssl_key_log->name = *file;
+
+    if (SSL_CTX_set_ex_data(ssl->ctx, ngx_http_lua_ssl_key_log_index,
+                            ssl_key_log) == 0)
+    {
+        ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
+                      "SSL_CTX_set_ex_data() failed");
+        return NGX_ERROR;
+    }
+
+    cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        ngx_http_lua_ssl_cleanup_key_log(ssl_key_log);
+        return NGX_ERROR;
+    }
+
+    cln->handler = ngx_http_lua_ssl_cleanup_key_log;
+    cln->data = ssl_key_log;
+
+    SSL_CTX_set_keylog_callback(ssl->ctx, key_log_callback);
+
+    return NGX_OK;
+}
+
 
 #if (nginx_version >= 1019004)
 static char *

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_output.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_output.c
@@ -722,16 +722,14 @@ ngx_http_lua_ngx_send_headers(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT);
 
-    if (!r->header_sent && !ctx->header_sent) {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "lua send headers");
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua send headers");
 
-        rc = ngx_http_lua_send_header_if_needed(r, ctx);
-        if (rc == NGX_ERROR || rc > NGX_OK) {
-            lua_pushnil(L);
-            lua_pushliteral(L, "nginx output filter error");
-            return 2;
-        }
+    rc = ngx_http_lua_send_header_if_needed(r, ctx);
+    if (rc == NGX_ERROR || rc > NGX_OK) {
+        lua_pushnil(L);
+        lua_pushliteral(L, "nginx output filter error");
+        return 2;
     }
 
     lua_pushinteger(L, 1);

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_pcrefix.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_pcrefix.c
@@ -18,15 +18,61 @@
 
 static ngx_pool_t *ngx_http_lua_pcre_pool = NULL;
 
+
+#if (NGX_PCRE2)
+static ngx_uint_t  ngx_regex_direct_alloc;
+#else
 static void *(*old_pcre_malloc)(size_t);
 static void (*old_pcre_free)(void *ptr);
+#endif
 
 
 /* XXX: work-around to nginx regex subsystem, must init a memory pool
  * to use PCRE functions. As PCRE still has memory-leaking problems,
  * and nginx overwrote pcre_malloc/free hooks with its own static
  * functions, so nobody else can reuse nginx regex subsystem... */
-static void *
+#if (NGX_PCRE2)
+
+void *
+ngx_http_lua_pcre_malloc(size_t size, void *data)
+{
+    dd("lua pcre pool is %p", ngx_http_lua_pcre_pool);
+
+    if (ngx_http_lua_pcre_pool) {
+        return ngx_palloc(ngx_http_lua_pcre_pool, size);
+    }
+
+    if (ngx_regex_direct_alloc) {
+        return ngx_alloc(size, ngx_cycle->log);
+    }
+
+    fprintf(stderr, "error: lua pcre malloc failed due to empty pcre pool");
+
+    return NULL;
+}
+
+
+void
+ngx_http_lua_pcre_free(void *ptr, void *data)
+{
+    dd("lua pcre pool is %p", ngx_http_lua_pcre_pool);
+
+    if (ngx_http_lua_pcre_pool) {
+        ngx_pfree(ngx_http_lua_pcre_pool, ptr);
+        return;
+    }
+
+    if (ngx_regex_direct_alloc) {
+        ngx_free(ptr);
+        return;
+    }
+
+    fprintf(stderr, "error: lua pcre free failed due to empty pcre pool");
+}
+
+#else
+
+void *
 ngx_http_lua_pcre_malloc(size_t size)
 {
     dd("lua pcre pool is %p", ngx_http_lua_pcre_pool);
@@ -54,6 +100,41 @@ ngx_http_lua_pcre_free(void *ptr)
     fprintf(stderr, "error: lua pcre free failed due to empty pcre pool");
 }
 
+#endif
+
+
+#if (NGX_PCRE2)
+
+ngx_pool_t *
+ngx_http_lua_pcre_malloc_init(ngx_pool_t *pool)
+{
+    ngx_pool_t          *old_pool;
+
+    dd("lua pcre pool was %p", ngx_http_lua_pcre_pool);
+
+    ngx_regex_direct_alloc = (pool == NULL) ? 1 : 0;
+
+    old_pool = ngx_http_lua_pcre_pool;
+    ngx_http_lua_pcre_pool = pool;
+
+    dd("lua pcre pool is %p", ngx_http_lua_pcre_pool);
+
+    return old_pool;
+}
+
+
+void
+ngx_http_lua_pcre_malloc_done(ngx_pool_t *old_pool)
+{
+    dd("lua pcre pool was %p", ngx_http_lua_pcre_pool);
+
+    ngx_http_lua_pcre_pool = old_pool;
+    ngx_regex_direct_alloc = 0;
+
+    dd("lua pcre pool is %p", ngx_http_lua_pcre_pool);
+}
+
+#else
 
 ngx_pool_t *
 ngx_http_lua_pcre_malloc_init(ngx_pool_t *pool)
@@ -101,6 +182,7 @@ ngx_http_lua_pcre_malloc_done(ngx_pool_t *old_pool)
     }
 }
 
+#endif
 #endif /* NGX_PCRE */
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_pcrefix.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_pcrefix.h
@@ -13,8 +13,15 @@
 
 
 #if (NGX_PCRE)
+
 ngx_pool_t *ngx_http_lua_pcre_malloc_init(ngx_pool_t *pool);
 void ngx_http_lua_pcre_malloc_done(ngx_pool_t *old_pool);
+
+#if NGX_PCRE2
+void *ngx_http_lua_pcre_malloc(size_t size, void *data);
+void ngx_http_lua_pcre_free(void *ptr, void *data);
+#endif
+
 #endif
 
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_proxy_ssl_verifyby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_proxy_ssl_verifyby.c
@@ -1,0 +1,877 @@
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+
+#if (NGX_HTTP_SSL)
+
+
+#include "ngx_http_lua_cache.h"
+#include "ngx_http_lua_initworkerby.h"
+#include "ngx_http_lua_util.h"
+#include "ngx_http_ssl_module.h"
+#include "ngx_http_lua_contentby.h"
+#include "ngx_http_lua_directive.h"
+#include "ngx_http_lua_ssl.h"
+
+#ifdef HAVE_PROXY_SSL_PATCH
+#include "ngx_http_lua_proxy_ssl_verifyby.h"
+
+
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x30000020uL)
+static void ngx_http_lua_proxy_ssl_verify_done(void *data);
+static void ngx_http_lua_proxy_ssl_verify_aborted(void *data);
+#endif
+static ngx_int_t ngx_http_lua_proxy_ssl_verify_by_chunk(lua_State *L,
+    ngx_http_request_t *r);
+
+
+ngx_int_t
+ngx_http_lua_proxy_ssl_verify_set_callback(ngx_conf_t *cf)
+{
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  "LibreSSL does not support by proxy_ssl_verify_by_lua*");
+
+    return NGX_ERROR;
+
+#elif defined(OPENSSL_IS_BORINGSSL)
+
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  "BoringSSL does not support by proxy_ssl_verify_by_lua*");
+
+    return NGX_ERROR;
+
+#else
+
+    void                      *plcf;
+    ngx_http_upstream_conf_t  *ucf;
+    ngx_ssl_t                 *ssl;
+
+    /*
+     * Nginx doesn't export ngx_http_proxy_loc_conf_t, so we can't directly
+     * get plcf here, but the first member of plcf is ngx_http_upstream_conf_t
+     */
+    plcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_proxy_module);
+    ucf = plcf;
+
+    ssl = ucf->ssl;
+
+    if (!ssl->ctx) {
+        ngx_log_error(NGX_LOG_EMERG, cf->log, 0, "proxy_ssl_verify_by_lua* "
+                      "should be used with proxy_pass https url");
+
+        return NGX_ERROR;
+    }
+
+#if (!defined SSL_ERROR_WANT_RETRY_VERIFY                                    \
+     || OPENSSL_VERSION_NUMBER < 0x30000020L)
+
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0, "OpenSSL too old to support "
+                  "proxy_ssl_verify_by_lua*");
+
+    return NGX_ERROR;
+
+#else
+
+    SSL_CTX_set_cert_verify_callback(ssl->ctx,
+                                     ngx_http_lua_proxy_ssl_verify_handler,
+                                     NULL);
+    return NGX_OK;
+
+#endif
+
+#endif
+}
+
+
+ngx_int_t
+ngx_http_lua_proxy_ssl_verify_handler_file(ngx_http_request_t *r,
+    ngx_http_lua_loc_conf_t *llcf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L,
+                                     llcf->proxy_ssl_verify_src.data,
+                                     &llcf->proxy_ssl_verify_src_ref,
+                                     llcf->proxy_ssl_verify_src_key);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_http_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_http_lua_proxy_ssl_verify_by_chunk(L, r);
+}
+
+
+ngx_int_t
+ngx_http_lua_proxy_ssl_verify_handler_inline(ngx_http_request_t *r,
+    ngx_http_lua_loc_conf_t *llcf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       llcf->proxy_ssl_verify_src.data,
+                                       llcf->proxy_ssl_verify_src.len,
+                                       &llcf->proxy_ssl_verify_src_ref,
+                                       llcf->proxy_ssl_verify_src_key,
+                           (const char *) llcf->proxy_ssl_verify_chunkname);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_http_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_http_lua_proxy_ssl_verify_by_chunk(L, r);
+}
+
+
+char *
+ngx_http_lua_proxy_ssl_verify_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    char        *rv;
+    ngx_conf_t   save;
+
+    save = *cf;
+    cf->handler = ngx_http_lua_proxy_ssl_verify_by_lua;
+    cf->handler_conf = conf;
+
+    rv = ngx_http_lua_conf_lua_block_parse(cf, cmd);
+
+    *cf = save;
+
+    return rv;
+}
+
+
+char *
+ngx_http_lua_proxy_ssl_verify_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+#if defined(LIBRESSL_VERSION_NUMBER)
+
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  "LibreSSL does not support by proxy_ssl_verify_by_lua*");
+
+    return NGX_CONF_ERROR;
+
+#elif defined(OPENSSL_IS_BORINGSSL)
+
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  "BoringSSL does not support by proxy_ssl_verify_by_lua*");
+
+    return NGX_CONF_ERROR;
+
+#else
+
+#if (!defined SSL_ERROR_WANT_RETRY_VERIFY                                    \
+     || OPENSSL_VERSION_NUMBER < 0x30000020L)
+
+    /* SSL_set_retry_verify() was added in OpenSSL 3.0.2 */
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  "at least OpenSSL 3.0.2 required but found "
+                  OPENSSL_VERSION_TEXT);
+
+    return NGX_CONF_ERROR;
+
+#else
+
+    size_t                       chunkname_len;
+    u_char                      *chunkname;
+    u_char                      *cache_key = NULL;
+    u_char                      *name;
+    ngx_str_t                   *value;
+    ngx_http_lua_loc_conf_t     *llcf = conf;
+
+    /*  must specify a concrete handler */
+    if (cmd->post == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (llcf->proxy_ssl_verify_handler) {
+        return "is duplicate";
+    }
+
+    if (ngx_http_lua_ssl_init(cf->log) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    value = cf->args->elts;
+
+    llcf->proxy_ssl_verify_handler =
+        (ngx_http_lua_loc_conf_handler_pt) cmd->post;
+
+    if (cmd->post == ngx_http_lua_proxy_ssl_verify_handler_file) {
+        /* Lua code in an external file */
+
+        name = ngx_http_lua_rebase_path(cf->pool, value[1].data,
+                                        value[1].len);
+        if (name == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        cache_key = ngx_http_lua_gen_file_cache_key(cf, value[1].data,
+                                                    value[1].len);
+        if (cache_key == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        llcf->proxy_ssl_verify_src.data = name;
+        llcf->proxy_ssl_verify_src.len = ngx_strlen(name);
+
+    } else {
+        cache_key = ngx_http_lua_gen_chunk_cache_key(cf,
+                                                     "proxy_ssl_verify_by_lua",
+                                                     value[1].data,
+                                                     value[1].len);
+        if (cache_key == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        chunkname = ngx_http_lua_gen_chunk_name(cf, "proxy_ssl_verify_by_lua",
+                                          sizeof("proxy_ssl_verify_by_lua") - 1,
+                                          &chunkname_len);
+        if (chunkname == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        /* Don't eval nginx variables for inline lua code */
+        llcf->proxy_ssl_verify_src = value[1];
+        llcf->proxy_ssl_verify_chunkname = chunkname;
+    }
+
+    llcf->proxy_ssl_verify_src_key = cache_key;
+
+    return NGX_CONF_OK;
+
+#endif  /* SSL_ERROR_WANT_RETRY_VERIFY */
+
+#endif
+}
+
+
+int
+ngx_http_lua_proxy_ssl_verify_handler(X509_STORE_CTX *x509_store, void *arg)
+{
+#if defined(LIBRESSL_VERSION_NUMBER)
+    ngx_connection_t                *c;
+
+    c = ngx_ssl_get_connection(ssl_conn);  /* upstream connection */
+    ngx_ssl_conn_t                  *ssl_conn;
+
+    ssl_conn = X509_STORE_CTX_get_ex_data(x509_store,
+                                          SSL_get_ex_data_X509_STORE_CTX_idx());
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+        "LibreSSL does not support by proxy_ssl_verify_by_lua*");
+
+    return 1;
+
+#elif defined(OPENSSL_IS_BORINGSSL)
+    ngx_connection_t                *c;
+    ngx_ssl_conn_t                  *ssl_conn;
+
+    ssl_conn = X509_STORE_CTX_get_ex_data(x509_store,
+                                          SSL_get_ex_data_X509_STORE_CTX_idx());
+    c = ngx_ssl_get_connection(ssl_conn);  /* upstream connection */
+
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+        "BoringSSL does not support by proxy_ssl_verify_by_lua*");
+
+    return 1;
+#elif defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < 0x30000020uL)
+
+    ngx_connection_t                *c;
+    ngx_ssl_conn_t                  *ssl_conn;
+
+    ssl_conn = X509_STORE_CTX_get_ex_data(x509_store,
+                                          SSL_get_ex_data_X509_STORE_CTX_idx());
+    c = ngx_ssl_get_connection(ssl_conn);  /* upstream connection */
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+        "OpenSSL(< 3.0.2) does not support by proxy_ssl_verify_by_lua*");
+
+    return 1;
+
+#else
+
+    lua_State                       *L;
+    ngx_int_t                        rc;
+    ngx_connection_t                *c;
+    ngx_http_request_t              *r = NULL;
+    ngx_pool_cleanup_t              *cln;
+    ngx_http_lua_loc_conf_t         *llcf;
+    ngx_http_lua_ssl_ctx_t          *cctx;
+    ngx_ssl_conn_t                  *ssl_conn;
+
+    ssl_conn = X509_STORE_CTX_get_ex_data(x509_store,
+                                          SSL_get_ex_data_X509_STORE_CTX_idx());
+
+    c = ngx_ssl_get_connection(ssl_conn);  /* upstream connection */
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "proxy ssl verify: connection reusable: %ud", c->reusable);
+
+    cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
+
+    dd("proxy ssl verify handler, cert-verify-ctx=%p", cctx);
+
+    if (cctx && cctx->entered_proxy_ssl_verify_handler) {
+        /* not the first time */
+
+        if (cctx->done) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "proxy_ssl_verify_by_lua: "
+                           "cert verify callback exit code: %d",
+                           cctx->exit_code);
+
+            dd("lua proxy ssl verify done, finally");
+            return cctx->exit_code;
+        }
+
+        return SSL_set_retry_verify(ssl_conn);
+    }
+
+    dd("first time");
+
+#if (nginx_version < 1017009)
+    ngx_reusable_connection(c, 0);
+#endif
+
+    r = c->data;
+
+    if (cctx == NULL) {
+        cctx = ngx_pcalloc(c->pool, sizeof(ngx_http_lua_ssl_ctx_t));
+        if (cctx == NULL) {
+            goto failed;  /* error */
+        }
+
+        cctx->ctx_ref = LUA_NOREF;
+    }
+
+    cctx->connection = c;
+    cctx->request = r;
+    cctx->x509_store = x509_store;
+    cctx->exit_code = 1;  /* successful by default */
+    cctx->original_request_count = r->main->count;
+    cctx->done = 0;
+    cctx->entered_proxy_ssl_verify_handler = 1;
+    cctx->pool = ngx_create_pool(128, c->log);
+    if (cctx->pool == NULL) {
+        goto failed;
+    }
+
+    dd("setting cctx");
+
+    if (SSL_set_ex_data(c->ssl->connection, ngx_http_lua_ssl_ctx_index,
+                        cctx) == 0)
+    {
+        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "SSL_set_ex_data() failed");
+        goto failed;
+    }
+
+    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+    if (llcf->upstream_skip_openssl_default_verify == 0) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "proxy_ssl_verify_by_lua: openssl default verify");
+
+        rc = X509_verify_cert(x509_store);
+        if (rc == 0) {
+            goto failed;
+        }
+    }
+
+    /* TODO honor lua_code_cache off */
+    L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    c->log->action = "loading proxy ssl verify by lua";
+
+    rc = llcf->proxy_ssl_verify_handler(r, llcf, L);
+
+    if (rc >= NGX_OK || rc == NGX_ERROR) {
+        cctx->done = 1;
+
+        if (cctx->cleanup) {
+            *cctx->cleanup = NULL;
+        }
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "proxy_ssl_verify_by_lua: handler return value: %i, "
+                       "cert verify callback exit code: %d", rc,
+                       cctx->exit_code);
+
+        c->log->action = "proxy pass SSL handshaking";
+        return cctx->exit_code;
+    }
+
+    /* rc == NGX_DONE */
+
+    cln = ngx_pool_cleanup_add(cctx->pool, 0);
+    if (cln == NULL) {
+        goto failed;
+    }
+
+    cln->handler = ngx_http_lua_proxy_ssl_verify_done;
+    cln->data = cctx;
+
+    if (cctx->cleanup == NULL) {
+        cln = ngx_pool_cleanup_add(c->pool, 0);
+        if (cln == NULL) {
+            goto failed;
+        }
+
+        cln->data = cctx;
+        cctx->cleanup = &cln->handler;
+    }
+
+    *cctx->cleanup = ngx_http_lua_proxy_ssl_verify_aborted;
+
+    return SSL_set_retry_verify(ssl_conn);
+
+failed:
+
+    if (cctx && cctx->pool) {
+        ngx_destroy_pool(cctx->pool);
+    }
+
+    return 0;  /* verify failure or error */
+
+#endif
+}
+
+
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x30000020uL)
+static void
+ngx_http_lua_proxy_ssl_verify_done(void *data)
+{
+    ngx_connection_t        *c;
+    ngx_http_lua_ssl_ctx_t  *cctx = data;
+
+    dd("lua proxy ssl verify done");
+
+    if (cctx->aborted) {
+        return;
+    }
+
+    ngx_http_lua_assert(cctx->done == 0);
+
+    cctx->done = 1;
+
+    if (cctx->cleanup) {
+        *cctx->cleanup = NULL;
+    }
+
+    c = cctx->connection;
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+    if (c->write->timer_set) {
+        ngx_del_timer(c->write);
+    }
+
+    c->log->action = "proxy pass SSL handshaking";
+
+    ngx_post_event(c->write, &ngx_posted_events);
+}
+
+
+static void
+ngx_http_lua_proxy_ssl_verify_aborted(void *data)
+{
+    ngx_http_lua_ssl_ctx_t  *cctx = data;
+
+    dd("lua proxy ssl verify aborted");
+
+    if (cctx->done) {
+        /* completed successfully already */
+        return;
+    }
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cctx->connection->log, 0,
+                   "proxy_ssl_verify_by_lua: cert verify callback aborted");
+
+    cctx->aborted = 1;
+    cctx->connection->ssl = NULL;
+    cctx->exit_code = 0;
+    if (cctx->pool) {
+        ngx_destroy_pool(cctx->pool);
+        cctx->pool = NULL;
+    }
+}
+#endif
+
+
+static ngx_int_t
+ngx_http_lua_proxy_ssl_verify_by_chunk(lua_State *L, ngx_http_request_t *r)
+{
+    int                      co_ref;
+    ngx_int_t                rc;
+    lua_State               *co;
+    ngx_http_lua_ctx_t      *ctx;
+    ngx_pool_cleanup_t      *cln;
+    ngx_http_upstream_t     *u;
+    ngx_connection_t        *c;
+    ngx_http_lua_ssl_ctx_t  *cctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (ctx == NULL) {
+        ctx = ngx_http_lua_create_ctx(r);
+        if (ctx == NULL) {
+            rc = NGX_ERROR;
+            ngx_http_lua_finalize_request(r, rc);
+            return rc;
+        }
+
+    } else {
+        dd("reset ctx");
+        ngx_http_lua_reset_ctx(r, L, ctx);
+    }
+
+    ctx->entered_content_phase = 1;
+
+    /*  {{{ new coroutine to handle request */
+    co = ngx_http_lua_new_thread(r, L, &co_ref);
+
+    if (co == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "lua: failed to create new coroutine to handle request");
+
+        rc = NGX_ERROR;
+        ngx_http_lua_finalize_request(r, rc);
+        return rc;
+    }
+
+    /*  move code closure to new coroutine */
+    lua_xmove(L, co, 1);
+
+#ifndef OPENRESTY_LUAJIT
+    /*  set closure's env table to new coroutine's globals table */
+    ngx_http_lua_get_globals_table(co);
+    lua_setfenv(co, -2);
+#endif
+
+    /* save nginx request in coroutine globals table */
+    ngx_http_lua_set_req(co, r);
+
+    ctx->cur_co_ctx = &ctx->entry_co_ctx;
+    ctx->cur_co_ctx->co = co;
+    ctx->cur_co_ctx->co_ref = co_ref;
+#ifdef NGX_LUA_USE_ASSERT
+    ctx->cur_co_ctx->co_top = 1;
+#endif
+
+    ngx_http_lua_attach_co_ctx_to_L(co, ctx->cur_co_ctx);
+
+    /* register request cleanup hooks */
+    if (ctx->cleanup == NULL) {
+        u = r->upstream;
+        c = u->peer.connection;
+        cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
+
+        cln = ngx_pool_cleanup_add(cctx->pool, 0);
+        if (cln == NULL) {
+            rc = NGX_ERROR;
+            ngx_http_lua_finalize_request(r, rc);
+            return rc;
+        }
+
+        cln->handler = ngx_http_lua_request_cleanup_handler;
+        cln->data = ctx;
+        ctx->cleanup = &cln->handler;
+    }
+
+    ctx->context = NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY;
+
+    rc = ngx_http_lua_run_thread(L, r, ctx, 0);
+
+    if (rc == NGX_ERROR || rc >= NGX_OK) {
+        /* do nothing */
+
+    } else if (rc == NGX_AGAIN) {
+        rc = ngx_http_lua_content_run_posted_threads(L, r, ctx, 0);
+
+    } else if (rc == NGX_DONE) {
+        rc = ngx_http_lua_content_run_posted_threads(L, r, ctx, 1);
+
+    } else {
+        rc = NGX_OK;
+    }
+
+    ngx_http_lua_finalize_request(r, rc);
+    return rc;
+}
+
+
+/*
+ * openssl's doc of SSL_CTX_set_cert_verify_callback:
+ * In any case a viable verification result value must
+ * be reflected in the error member of x509_store_ctx,
+ * which can be done using X509_STORE_CTX_set_error.
+ */
+int
+ngx_http_lua_ffi_proxy_ssl_set_verify_result(ngx_http_request_t *r,
+    int verify_result, char **err)
+{
+#if defined(LIBRESSL_VERSION_NUMBER)
+
+    *err = "LibreSSL does not support this function";
+
+    return NGX_ERROR;
+
+#elif defined(OPENSSL_IS_BORINGSSL)
+
+    *err = "BoringSSL does not support this function";
+
+    return NGX_ERROR;
+
+#else
+
+#ifdef SSL_ERROR_WANT_RETRY_VERIFY
+    ngx_http_upstream_t             *u;
+    ngx_ssl_conn_t                  *ssl_conn;
+    ngx_connection_t                *c;
+    ngx_http_lua_ssl_ctx_t          *cctx;
+    X509_STORE_CTX                  *x509_store;
+
+    u = r->upstream;
+    if (u == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    c = u->peer.connection;
+    if (c == NULL || c->ssl == NULL) {
+        *err = "bad upstream connection";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = c->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    dd("get cctx session");
+
+    c = ngx_ssl_get_connection(ssl_conn);
+
+    cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
+    if (cctx == NULL) {
+        *err = "bad lua context";
+        return NGX_ERROR;
+    }
+
+    x509_store = cctx->x509_store;
+
+    X509_STORE_CTX_set_error(x509_store, verify_result);
+
+    return NGX_OK;
+#else
+    *err = "OpenSSL too old to support this function";
+
+    return NGX_ERROR;
+#endif
+
+#endif
+}
+
+
+int
+ngx_http_lua_ffi_proxy_ssl_get_verify_result(ngx_http_request_t *r, char **err)
+{
+#if defined(LIBRESSL_VERSION_NUMBER)
+
+    *err = "LibreSSL does not support this function";
+
+    return NGX_ERROR;
+
+#elif defined(OPENSSL_IS_BORINGSSL)
+
+    *err = "BoringSSL does not support this function";
+
+    return NGX_ERROR;
+
+#else
+
+#ifdef SSL_ERROR_WANT_RETRY_VERIFY
+    ngx_http_upstream_t             *u;
+    ngx_ssl_conn_t                  *ssl_conn;
+    ngx_connection_t                *c;
+    ngx_http_lua_ssl_ctx_t          *cctx;
+    X509_STORE_CTX                  *x509_store;
+
+    u = r->upstream;
+    if (u == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    c = u->peer.connection;
+    if (c == NULL || c->ssl == NULL) {
+        *err = "bad upstream connection";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = c->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    dd("get cctx session");
+
+    c = ngx_ssl_get_connection(ssl_conn);
+
+    cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
+    if (cctx == NULL) {
+        *err = "bad lua context";
+        return NGX_ERROR;
+    }
+
+    x509_store = cctx->x509_store;
+
+    return X509_STORE_CTX_get_error(x509_store);
+#else
+    *err = "OpenSSL too old to support this function";
+
+    return NGX_ERROR;
+#endif
+
+#endif
+}
+
+
+void
+ngx_http_lua_ffi_proxy_ssl_free_verify_cert(void *cdata)
+{
+    X509  *cert = cdata;
+
+    X509_free(cert);
+}
+
+
+void *
+ngx_http_lua_ffi_proxy_ssl_get_verify_cert(ngx_http_request_t *r, char **err)
+{
+#if defined(LIBRESSL_VERSION_NUMBER)
+
+    *err = "LibreSSL does not support this function";
+
+    return NGX_ERROR;
+
+#elif defined(OPENSSL_IS_BORINGSSL)
+
+    *err = "BoringSSL does not support this function";
+
+    return NGX_ERROR;
+
+#else
+
+#ifdef SSL_ERROR_WANT_RETRY_VERIFY
+    ngx_http_upstream_t             *u;
+    ngx_ssl_conn_t                  *ssl_conn;
+    ngx_connection_t                *c;
+    ngx_http_lua_ssl_ctx_t          *cctx;
+    X509_STORE_CTX                  *x509_store;
+    X509                            *x509;
+
+    u = r->upstream;
+    if (u == NULL) {
+        *err = "bad request";
+        return NULL;
+    }
+
+    c = u->peer.connection;
+    if (c == NULL || c->ssl == NULL) {
+        *err = "bad upstream connection";
+        return NULL;
+    }
+
+    ssl_conn = c->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NULL;
+    }
+
+    dd("get cctx session");
+
+    c = ngx_ssl_get_connection(ssl_conn);
+
+    cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
+    if (cctx == NULL) {
+        *err = "bad lua context";
+        return NULL;
+    }
+
+    x509_store = cctx->x509_store;
+
+    x509 = X509_STORE_CTX_get0_cert(x509_store);
+
+    if (!X509_up_ref(x509)) {
+        *err = "get verify result failed";
+        return NULL;
+    }
+
+    return x509;
+#else
+    *err = "OpenSSL too old to support this function";
+
+    return NULL;
+#endif
+
+#endif
+}
+
+
+#else  /* HAVE_PROXY_SSL_PATCH */
+
+
+int
+ngx_http_lua_ffi_proxy_ssl_set_verify_result(ngx_http_request_t *r,
+    int verify_result, char **err)
+{
+    *err = "Does not have HAVE_PROXY_SSL_PATCH to support this function";
+
+    return NGX_ERROR;
+}
+
+
+int
+ngx_http_lua_ffi_proxy_ssl_get_verify_result(ngx_http_request_t *r, char **err)
+{
+    *err = "Does not have HAVE_PROXY_SSL_PATCH to support this function";
+
+    return NGX_ERROR;
+}
+
+
+void
+ngx_http_lua_ffi_proxy_ssl_free_verify_cert(void *cdata)
+{
+}
+
+
+void *
+ngx_http_lua_ffi_proxy_ssl_get_verify_cert(ngx_http_request_t *r, char **err)
+{
+    *err = "Does not have HAVE_PROXY_SSL_PATCH to support this function";
+
+    return NULL;
+}
+
+#endif /* HAVE_PROXY_SSL_PATCH */
+#endif /* NGX_HTTP_SSL */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_proxy_ssl_verifyby.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_proxy_ssl_verifyby.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+#ifndef _NGX_HTTP_LUA_PROXY_SSL_VERIFYBY_H_INCLUDED_
+#define _NGX_HTTP_LUA_PROXY_SSL_VERIFYBY_H_INCLUDED_
+
+
+#include "ngx_http_lua_common.h"
+
+
+#if (NGX_HTTP_SSL)
+#ifdef HAVE_PROXY_SSL_PATCH
+
+/* do not introduce ngx_http_proxy_module to pollute ngx_http_lua_module.c */
+extern ngx_module_t  ngx_http_proxy_module;
+
+ngx_int_t ngx_http_lua_proxy_ssl_verify_handler_inline(ngx_http_request_t *r,
+    ngx_http_lua_loc_conf_t *llcf, lua_State *L);
+
+ngx_int_t ngx_http_lua_proxy_ssl_verify_handler_file(ngx_http_request_t *r,
+    ngx_http_lua_loc_conf_t *llcf, lua_State *L);
+
+char *ngx_http_lua_proxy_ssl_verify_by_lua_block(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+
+char *ngx_http_lua_proxy_ssl_verify_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+int ngx_http_lua_proxy_ssl_verify_handler(X509_STORE_CTX *x509_store,
+    void *arg);
+
+ngx_int_t ngx_http_lua_proxy_ssl_verify_set_callback(ngx_conf_t *cf);
+
+#endif  /* HAVE_PROXY_SSL_PATCH */
+#endif  /* NGX_HTTP_SSL */
+
+
+#endif /* _NGX_HTTP_LUA_PROXY_SSL_VERIFYBY_H_INCLUDED_ */
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_regex.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_regex.c
@@ -9,7 +9,6 @@
 #endif
 #include "ddebug.h"
 
-
 #if (NGX_PCRE)
 
 #include "ngx_http_lua_pcrefix.h"
@@ -17,10 +16,21 @@
 #include "ngx_http_lua_util.h"
 
 
-#if (PCRE_MAJOR >= 6)
+#if (PCRE_MAJOR >= 6 || NGX_PCRE2)
 #   define LUA_HAVE_PCRE_DFA 1
 #else
 #   define LUA_HAVE_PCRE_DFA 0
+#endif
+
+
+#if (NGX_PCRE2)
+static pcre2_compile_context  *ngx_regex_compile_context;
+static pcre2_match_context    *ngx_regex_match_context;
+static pcre2_match_data       *ngx_regex_match_data;
+static ngx_uint_t              ngx_regex_match_data_size = 0;
+
+#define PCRE2_VERSION_SIZE     64
+static char                    ngx_pcre2_version[PCRE2_VERSION_SIZE];
 #endif
 
 
@@ -42,8 +52,17 @@ typedef struct {
     int                           ncaptures;
     int                          *captures;
 
+#if (NGX_PCRE2)
+    pcre2_code                   *regex;
+    /*
+     * pcre2 doesn't use pcre_extra any more,
+     * just for keeping same memory layout in the lua ffi cdef
+     */
+    void                         *regex_sd;
+#else
     pcre                         *regex;
     pcre_extra                   *regex_sd;
+#endif
 
     ngx_http_lua_complex_value_t *replace;
 
@@ -57,7 +76,11 @@ typedef struct {
     ngx_pool_t   *pool;
     ngx_int_t     options;
 
+#if (NGX_PCRE2)
+    pcre2_code   *regex;
+#else
     pcre         *regex;
+#endif
     int           captures;
     ngx_str_t     err;
 } ngx_http_lua_regex_compile_t;
@@ -65,8 +88,12 @@ typedef struct {
 
 typedef struct {
     ngx_http_request_t      *request;
+#if (NGX_PCRE2)
+    pcre2_code              *regex;
+#else
     pcre                    *regex;
     pcre_extra              *regex_sd;
+#endif
     int                      ncaptures;
     int                     *captures;
     int                      captures_len;
@@ -74,8 +101,6 @@ typedef struct {
 } ngx_http_lua_regex_ctx_t;
 
 
-static void ngx_http_lua_regex_free_study_data(ngx_pool_t *pool,
-    pcre_extra *sd);
 static ngx_int_t ngx_http_lua_regex_compile(ngx_http_lua_regex_compile_t *rc);
 
 
@@ -91,21 +116,155 @@ static ngx_int_t ngx_http_lua_regex_compile(ngx_http_lua_regex_compile_t *rc);
 
 
 static void
-ngx_http_lua_regex_free_study_data(ngx_pool_t *pool, pcre_extra *sd)
+ngx_http_lua_regex_free_study_data(ngx_pool_t *pool, ngx_http_lua_regex_t *re)
 {
-    ngx_pool_t              *old_pool;
+    ngx_pool_t  *old_pool;
 
-    old_pool = ngx_http_lua_pcre_malloc_init(pool);
+#if (NGX_PCRE2)
+    if (re && re->regex) {
+        old_pool = ngx_http_lua_pcre_malloc_init(pool);
 
-#if LUA_HAVE_PCRE_JIT
-    pcre_free_study(sd);
+        pcre2_code_free(re->regex);
+
+        ngx_http_lua_pcre_malloc_done(old_pool);
+
+        re->regex = NULL;
+    }
 #else
-    pcre_free(sd);
+    if (re && re->regex_sd) {
+        old_pool = ngx_http_lua_pcre_malloc_init(pool);
+#if LUA_HAVE_PCRE_JIT
+        pcre_free_study(re->regex_sd);
+#else
+        pcre_free(re->regex_sd);
 #endif
+        ngx_http_lua_pcre_malloc_done(old_pool);
 
-    ngx_http_lua_pcre_malloc_done(old_pool);
+        re->regex_sd = NULL;
+    }
+#endif
 }
 
+
+#if (NGX_PCRE2)
+static ngx_int_t
+ngx_http_lua_regex_compile(ngx_http_lua_regex_compile_t *rc)
+{
+    int                     n, errcode;
+    char                   *p;
+    size_t                  erroff;
+    u_char                  errstr[128];
+    pcre2_code             *re;
+    ngx_pool_t             *old_pool;
+    pcre2_general_context  *gctx;
+    pcre2_compile_context  *cctx;
+
+    ngx_http_lua_main_conf_t    *lmcf;
+
+    if (ngx_regex_compile_context == NULL) {
+        /*
+         * Allocate a compile context if not yet allocated.  This uses
+         * direct allocations from heap, so the result can be cached
+         * even at runtime.
+         */
+
+        old_pool = ngx_http_lua_pcre_malloc_init(NULL);
+
+        gctx = pcre2_general_context_create(ngx_http_lua_pcre_malloc,
+                                            ngx_http_lua_pcre_free,
+                                            NULL);
+        if (gctx == NULL) {
+            ngx_http_lua_pcre_malloc_done(old_pool);
+            goto nomem;
+        }
+
+        cctx = pcre2_compile_context_create(gctx);
+        if (cctx == NULL) {
+            pcre2_general_context_free(gctx);
+            ngx_http_lua_pcre_malloc_done(old_pool);
+            goto nomem;
+        }
+
+        ngx_regex_compile_context = cctx;
+
+        ngx_regex_match_context = pcre2_match_context_create(gctx);
+        if (ngx_regex_match_context == NULL) {
+            pcre2_general_context_free(gctx);
+            ngx_http_lua_pcre_malloc_done(old_pool);
+            goto nomem;
+        }
+
+        lmcf = ngx_http_cycle_get_module_main_conf(ngx_cycle,
+                                                   ngx_http_lua_module);
+        if (lmcf && lmcf->regex_match_limit > 0) {
+            pcre2_set_match_limit(ngx_regex_match_context,
+                                  lmcf->regex_match_limit);
+        }
+
+        pcre2_general_context_free(gctx);
+        ngx_http_lua_pcre_malloc_done(old_pool);
+    }
+
+    old_pool = ngx_http_lua_pcre_malloc_init(rc->pool);
+
+    re = pcre2_compile(rc->pattern.data,
+                       rc->pattern.len, rc->options,
+                       &errcode, &erroff, ngx_regex_compile_context);
+
+    ngx_http_lua_pcre_malloc_done(old_pool);
+
+    if (re == NULL) {
+        pcre2_get_error_message(errcode, errstr, 128);
+
+        if ((size_t) erroff == rc->pattern.len) {
+            rc->err.len = ngx_snprintf(rc->err.data, rc->err.len,
+                                       "pcre2_compile() failed: %s in \"%V\"",
+                                       errstr, &rc->pattern)
+                          - rc->err.data;
+
+        } else {
+            rc->err.len = ngx_snprintf(rc->err.data, rc->err.len,
+                                       "pcre2_compile() failed: %s in "
+                                       "\"%V\" at \"%s\"", errstr, &rc->pattern,
+                                       rc->pattern.data + erroff)
+                          - rc->err.data;
+        }
+
+        return NGX_ERROR;
+    }
+
+    rc->regex = re;
+
+    n = pcre2_pattern_info(re, PCRE2_INFO_CAPTURECOUNT, &rc->captures);
+    if (n < 0) {
+        p = "pcre2_pattern_info(\"%V\", PCRE_INFO_CAPTURECOUNT) failed: %d";
+        goto failed;
+    }
+
+#if (NGX_DEBUG)
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                   "pcre2_compile: pattern[%V], options 0x%08Xd, ncaptures %d",
+                   &rc->pattern, rc->options, rc->captures);
+#endif
+
+    return NGX_OK;
+
+failed:
+
+    rc->err.len = ngx_snprintf(rc->err.data, rc->err.len, p, &rc->pattern, n)
+                  - rc->err.data;
+    return NGX_ERROR;
+
+nomem:
+
+    rc->err.len = ngx_snprintf(rc->err.data, rc->err.len,
+                               "regex \"%V\" compilation failed: no memory",
+                               &rc->pattern)
+                  - rc->err.data;
+    return NGX_ERROR;
+}
+
+#else
 
 static ngx_int_t
 ngx_http_lua_regex_compile(ngx_http_lua_regex_compile_t *rc)
@@ -159,13 +318,14 @@ failed:
                   - rc->err.data;
     return NGX_OK;
 }
+#endif
 
 
 ngx_int_t
 ngx_http_lua_ffi_set_jit_stack_size(int size, u_char *errstr,
     size_t *errstr_size)
 {
-#if LUA_HAVE_PCRE_JIT
+#if (LUA_HAVE_PCRE_JIT)
 
     ngx_http_lua_main_conf_t    *lmcf;
     ngx_pool_t                  *pool, *old_pool;
@@ -186,15 +346,24 @@ ngx_http_lua_ffi_set_jit_stack_size(int size, u_char *errstr,
     if (lmcf->jit_stack) {
         old_pool = ngx_http_lua_pcre_malloc_init(pool);
 
+#if (NGX_PCRE2)
+        pcre2_jit_stack_free(lmcf->jit_stack);
+#else
         pcre_jit_stack_free(lmcf->jit_stack);
+#endif
 
         ngx_http_lua_pcre_malloc_done(old_pool);
     }
 
     old_pool = ngx_http_lua_pcre_malloc_init(pool);
 
+#if (NGX_PCRE2)
+    lmcf->jit_stack = pcre2_jit_stack_create(NGX_LUA_RE_MIN_JIT_STACK_SIZE,
+                                             size, NULL);
+#else
     lmcf->jit_stack = pcre_jit_stack_alloc(NGX_LUA_RE_MIN_JIT_STACK_SIZE,
                                            size);
+#endif
 
     ngx_http_lua_pcre_malloc_done(old_pool);
 
@@ -214,8 +383,153 @@ ngx_http_lua_ffi_set_jit_stack_size(int size, u_char *errstr,
                    - errstr;
     return NGX_ERROR;
 
-#endif /* LUA_HAVE_PCRE_JIT */
+#endif
 }
+
+
+#if (NGX_PCRE2)
+static void
+ngx_http_lua_regex_jit_compile(ngx_http_lua_regex_t *re, int flags,
+    ngx_pool_t *pool, ngx_http_lua_main_conf_t *lmcf,
+    ngx_http_lua_regex_compile_t *re_comp)
+{
+    ngx_int_t    ret;
+    ngx_pool_t  *old_pool;
+
+    if (flags & NGX_LUA_RE_MODE_JIT) {
+        old_pool = ngx_http_lua_pcre_malloc_init(pool);
+        ret = pcre2_jit_compile(re_comp->regex, PCRE2_JIT_COMPLETE);
+
+        if (ret != 0) {
+            ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
+                          "pcre2_jit_compile() failed: %d in \"%V\", "
+                          "ignored",
+                          ret, &re_comp->pattern);
+
+#if (NGX_DEBUG)
+
+        } else {
+            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                           "pcre2 JIT compiled successfully");
+#   endif /* !(NGX_DEBUG) */
+        }
+
+        ngx_http_lua_pcre_malloc_done(old_pool);
+
+    }
+
+    if (lmcf && lmcf->jit_stack) {
+        pcre2_jit_stack_assign(ngx_regex_match_context, NULL,
+                               lmcf->jit_stack);
+    }
+
+    return;
+}
+
+#else
+
+static void
+ngx_http_lua_regex_jit_compile(ngx_http_lua_regex_t *re, int flags,
+    ngx_pool_t *pool, ngx_http_lua_main_conf_t *lmcf,
+    ngx_http_lua_regex_compile_t *re_comp)
+{
+    const char  *msg;
+    pcre_extra  *sd = NULL;
+    ngx_pool_t  *old_pool;
+
+
+#if (LUA_HAVE_PCRE_JIT)
+    if (flags & NGX_LUA_RE_MODE_JIT) {
+        old_pool = ngx_http_lua_pcre_malloc_init(pool);
+        sd = pcre_study(re_comp->regex, PCRE_STUDY_JIT_COMPILE, &msg);
+        ngx_http_lua_pcre_malloc_done(old_pool);
+
+#   if (NGX_DEBUG)
+        if (msg != NULL) {
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                           "pcre study failed with PCRE_STUDY_JIT_COMPILE: "
+                           "%s (%p)", msg, sd);
+        }
+
+        if (sd != NULL) {
+            int         jitted;
+
+            old_pool = ngx_http_lua_pcre_malloc_init(pool);
+
+            pcre_fullinfo(re_comp->regex, sd, PCRE_INFO_JIT, &jitted);
+
+            ngx_http_lua_pcre_malloc_done(old_pool);
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                           "pcre JIT compiling result: %d", jitted);
+        }
+#   endif /* !(NGX_DEBUG) */
+
+    } else {
+        old_pool = ngx_http_lua_pcre_malloc_init(pool);
+        sd = pcre_study(re_comp->regex, 0, &msg);
+        ngx_http_lua_pcre_malloc_done(old_pool);
+    }
+
+    if (sd && lmcf && lmcf->jit_stack) {
+        pcre_assign_jit_stack(sd, NULL, lmcf->jit_stack);
+    }
+
+    if (sd
+        && lmcf && lmcf->regex_match_limit > 0
+        && !(flags & NGX_LUA_RE_MODE_DFA))
+    {
+        sd->flags |= PCRE_EXTRA_MATCH_LIMIT;
+        sd->match_limit = lmcf->regex_match_limit;
+    }
+
+#endif /* LUA_HAVE_PCRE_JIT */
+
+    re->regex_sd = sd;
+}
+#endif
+
+
+#if (NGX_PCRE2)
+void
+ngx_http_lua_regex_cleanup(void *data)
+{
+    ngx_pool_t                *old_pool;
+    ngx_http_lua_main_conf_t  *lmcf;
+
+    lmcf = data;
+
+    if (ngx_regex_compile_context) {
+        old_pool = ngx_http_lua_pcre_malloc_init(NULL);
+        if (ngx_regex_match_context != NULL) {
+            pcre2_match_context_free(ngx_regex_match_context);
+            ngx_regex_match_context = NULL;
+        }
+
+        pcre2_compile_context_free(ngx_regex_compile_context);
+        ngx_regex_compile_context = NULL;
+        ngx_http_lua_pcre_malloc_done(old_pool);
+    }
+
+    if (lmcf && lmcf->jit_stack) {
+        old_pool = ngx_http_lua_pcre_malloc_init(NULL);
+
+        pcre2_jit_stack_free(lmcf->jit_stack);
+        lmcf->jit_stack = NULL;
+
+        ngx_http_lua_pcre_malloc_done(old_pool);
+    }
+
+    if (ngx_regex_match_data) {
+        old_pool = ngx_http_lua_pcre_malloc_init(NULL);
+        pcre2_match_data_free(ngx_regex_match_data);
+        ngx_regex_match_data = NULL;
+        ngx_regex_match_data_size = 0;
+        ngx_http_lua_pcre_malloc_done(old_pool);
+    }
+
+}
+#endif
 
 
 ngx_http_lua_regex_t *
@@ -228,8 +542,7 @@ ngx_http_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
     ngx_int_t                rc;
     const char              *msg;
     ngx_pool_t              *pool, *old_pool;
-    pcre_extra              *sd = NULL;
-    ngx_http_lua_regex_t    *re;
+    ngx_http_lua_regex_t    *re = NULL;
 
     ngx_http_lua_main_conf_t         *lmcf;
     ngx_http_lua_regex_compile_t      re_comp;
@@ -251,6 +564,8 @@ ngx_http_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
     }
 
     re->pool = pool;
+    re->regex = NULL;
+    re->regex_sd = NULL;
 
     re_comp.options      = pcre_opts;
     re_comp.pattern.data = (u_char *) pat;
@@ -274,61 +589,18 @@ ngx_http_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
 
     ngx_http_lua_assert(lmcf != NULL);
 
-#if (LUA_HAVE_PCRE_JIT)
-
-    if (flags & NGX_LUA_RE_MODE_JIT) {
-
-        old_pool = ngx_http_lua_pcre_malloc_init(pool);
-        sd = pcre_study(re_comp.regex, PCRE_STUDY_JIT_COMPILE, &msg);
-        ngx_http_lua_pcre_malloc_done(old_pool);
-
-#   if (NGX_DEBUG)
-        if (msg != NULL) {
-            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
-                           "pcre study failed with PCRE_STUDY_JIT_COMPILE: "
-                           "%s (%p)", msg, sd);
-        }
-
-        if (sd != NULL) {
-            int         jitted;
-
-            old_pool = ngx_http_lua_pcre_malloc_init(pool);
-
-            pcre_fullinfo(re_comp.regex, sd, PCRE_INFO_JIT, &jitted);
-
-            ngx_http_lua_pcre_malloc_done(old_pool);
-
-            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
-                           "pcre JIT compiling result: %d", jitted);
-        }
-#   endif /* !(NGX_DEBUG) */
-
-    } else {
-        old_pool = ngx_http_lua_pcre_malloc_init(pool);
-        sd = pcre_study(re_comp.regex, 0, &msg);
-        ngx_http_lua_pcre_malloc_done(old_pool);
-    }
-
-    if (sd && lmcf->jit_stack) {
-        pcre_assign_jit_stack(sd, NULL, lmcf->jit_stack);
-    }
-
-#endif /* LUA_HAVE_PCRE_JIT */
-
-    if (sd
-        && lmcf && lmcf->regex_match_limit > 0
-        && !(flags & NGX_LUA_RE_MODE_DFA))
-    {
-        sd->flags |= PCRE_EXTRA_MATCH_LIMIT;
-        sd->match_limit = lmcf->regex_match_limit;
-    }
+    ngx_http_lua_regex_jit_compile(re, flags, pool, lmcf, &re_comp);
 
     if (flags & NGX_LUA_RE_MODE_DFA) {
         ovecsize = 2;
         re_comp.captures = 0;
 
     } else {
+#if (NGX_PCRE2)
+        ovecsize = (re_comp.captures + 1) * 2;
+#else
         ovecsize = (re_comp.captures + 1) * 3;
+#endif
     }
 
     dd("allocating cap with size: %d", (int) ovecsize);
@@ -339,6 +611,31 @@ ngx_http_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
         goto error;
     }
 
+#if (NGX_PCRE2)
+    if (pcre2_pattern_info(re_comp.regex, PCRE2_INFO_NAMECOUNT,
+                           &re->name_count) < 0)
+    {
+        msg = "cannot acquire named subpattern count";
+        goto error;
+    }
+
+    if (re->name_count > 0) {
+        if (pcre2_pattern_info(re_comp.regex, PCRE2_INFO_NAMEENTRYSIZE,
+                               &re->name_entry_size) != 0)
+        {
+            msg = "cannot acquire named subpattern entry size";
+            goto error;
+        }
+
+        if (pcre2_pattern_info(re_comp.regex, PCRE2_INFO_NAMETABLE,
+                               &re->name_table) != 0)
+        {
+            msg = "cannot acquire named subpattern table";
+            goto error;
+        }
+    }
+
+#else
     if (pcre_fullinfo(re_comp.regex, NULL, PCRE_INFO_NAMECOUNT,
                       &re->name_count) != 0)
     {
@@ -361,9 +658,9 @@ ngx_http_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
             goto error;
         }
     }
+#endif
 
     re->regex = re_comp.regex;
-    re->regex_sd = sd;
     re->ncaptures = re_comp.captures;
     re->captures = cap;
     re->replace = NULL;
@@ -379,9 +676,7 @@ error:
     p = ngx_snprintf(errstr, errstr_size - 1, "%s", msg);
     *p = '\0';
 
-    if (sd) {
-        ngx_http_lua_regex_free_study_data(pool, sd);
-    }
+    ngx_http_lua_regex_free_study_data(pool, re);
 
     if (pool) {
         ngx_destroy_pool(pool);
@@ -390,6 +685,103 @@ error:
     return NULL;
 }
 
+
+#if (NGX_PCRE2)
+int
+ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+    const u_char *s, size_t len, int pos)
+{
+    int          rc, exec_opts = 0;
+    size_t      *ov;
+    ngx_uint_t   ovecpair, n, i;
+    ngx_pool_t  *old_pool;
+
+    if (flags & NGX_LUA_RE_MODE_DFA) {
+        ovecpair = 1;
+        re->ncaptures = 0;
+
+    } else {
+        ovecpair = re->ncaptures + 1;
+    }
+
+    old_pool = ngx_http_lua_pcre_malloc_init(NULL);
+
+    if (ngx_regex_match_data == NULL
+        || ovecpair > ngx_regex_match_data_size)
+    {
+        /*
+         * Allocate a match data if not yet allocated or smaller than
+         * needed.
+         */
+
+        if (ngx_regex_match_data) {
+            pcre2_match_data_free(ngx_regex_match_data);
+        }
+
+        ngx_regex_match_data_size = ovecpair;
+        ngx_regex_match_data = pcre2_match_data_create(ovecpair, NULL);
+
+        if (ngx_regex_match_data == NULL) {
+            rc = PCRE2_ERROR_NOMEMORY;
+            goto failed;
+        }
+    }
+
+    if (flags & NGX_LUA_RE_NO_UTF8_CHECK) {
+        exec_opts = PCRE2_NO_UTF_CHECK;
+
+    } else {
+        exec_opts = 0;
+    }
+
+    if (flags & NGX_LUA_RE_MODE_DFA) {
+        int ws[NGX_LUA_RE_DFA_MODE_WORKSPACE_COUNT];
+        rc = pcre2_dfa_match(re->regex, s, len, pos, exec_opts,
+                             ngx_regex_match_data, ngx_regex_match_context,
+                             ws, sizeof(ws) / sizeof(ws[0]));
+
+
+    } else {
+        rc = pcre2_match(re->regex, s, len, pos, exec_opts,
+                         ngx_regex_match_data, ngx_regex_match_context);
+    }
+
+    if (rc < 0) {
+#if (NGX_DEBUG)
+        ngx_log_debug4(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                       "pcre2_match failed: flags 0x%05Xd, options 0x%08Xd, "
+                       "rc %d, ovecpair %ui", flags, exec_opts, rc, ovecpair);
+#endif
+
+        goto failed;
+    }
+
+    n = pcre2_get_ovector_count(ngx_regex_match_data);
+    ov = pcre2_get_ovector_pointer(ngx_regex_match_data);
+
+#if (NGX_DEBUG)
+    ngx_log_debug5(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                   "pcre2_match: flags 0x%05Xd, options 0x%08Xd, rc %d, "
+                   "n %ui, ovecpair %ui", flags, exec_opts, rc, n, ovecpair);
+#endif
+
+    if (n > ovecpair) {
+        n = ovecpair;
+    }
+
+    for (i = 0; i < n; i++) {
+        re->captures[i * 2] = ov[i * 2];
+        re->captures[i * 2 + 1] = ov[i * 2 + 1];
+    }
+
+failed:
+
+    ngx_http_lua_pcre_malloc_done(old_pool);
+
+    return rc;
+}
+
+#else
 
 int
 ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
@@ -427,7 +819,8 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
         int ws[NGX_LUA_RE_DFA_MODE_WORKSPACE_COUNT];
         rc = ngx_http_lua_regex_dfa_exec(re->regex, sd, &subj,
                                          (int) pos, cap, ovecsize, ws,
-                                         sizeof(ws)/sizeof(ws[0]), exec_opts);
+                                         sizeof(ws) / sizeof(ws[0]),
+                                         exec_opts);
 
 #else
 
@@ -443,28 +836,19 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
     return rc;
 }
 
+#endif
+
 
 void
 ngx_http_lua_ffi_destroy_regex(ngx_http_lua_regex_t *re)
 {
-    ngx_pool_t                  *old_pool;
-
     dd("destroy regex called");
 
     if (re == NULL || re->pool == NULL) {
         return;
     }
 
-    if (re->regex_sd) {
-        old_pool = ngx_http_lua_pcre_malloc_init(re->pool);
-#if LUA_HAVE_PCRE_JIT
-        pcre_free_study(re->regex_sd);
-#else
-        pcre_free(re->regex_sd);
-#endif
-        ngx_http_lua_pcre_malloc_done(old_pool);
-        re->regex_sd = NULL;
-    }
+    ngx_http_lua_regex_free_study_data(re->pool, re);
 
     ngx_destroy_pool(re->pool);
 }
@@ -592,7 +976,13 @@ ngx_http_lua_ffi_max_regex_cache_size(void)
 const char *
 ngx_http_lua_ffi_pcre_version(void)
 {
+#if (NGX_PCRE2)
+    pcre2_config(PCRE2_CONFIG_VERSION, ngx_pcre2_version);
+
+    return ngx_pcre2_version;
+#else
     return pcre_version();
+#endif
 }
 
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_req_body.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_req_body.c
@@ -229,15 +229,21 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
 {
     ngx_http_request_t          *r;
     int                          n;
-    size_t                       len;
+    size_t                       len, max;
+    size_t                       size, rest;
     ngx_chain_t                 *cl;
     u_char                      *p;
     u_char                      *buf;
 
     n = lua_gettop(L);
 
-    if (n != 0) {
-        return luaL_error(L, "expecting 0 arguments but seen %d", n);
+    if (n != 0 && n != 1) {
+        return luaL_error(L, "expecting 0 or 1 arguments but seen %d", n);
+    }
+
+    max = 0;
+    if (n == 1) {
+        max = (size_t) luaL_checknumber(L, 1);
     }
 
     r = ngx_http_lua_get_req(L);
@@ -265,6 +271,7 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
             return 1;
         }
 
+        len = (max > 0 && len > max) ? max : len;
         lua_pushlstring(L, (char *) cl->buf->pos, len);
         return 1;
     }
@@ -275,7 +282,13 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
 
     for (; cl; cl = cl->next) {
         dd("body chunk len: %d", (int) ngx_buf_size(cl->buf));
-        len += cl->buf->last - cl->buf->pos;
+        size = cl->buf->last - cl->buf->pos;
+        if (max > 0 && (len + size > max)) {
+            len = max;
+            break;
+        }
+
+        len += size;
     }
 
     if (len == 0) {
@@ -286,8 +299,15 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
     buf = (u_char *) lua_newuserdata(L, len);
 
     p = buf;
-    for (cl = r->request_body->bufs; cl; cl = cl->next) {
-        p = ngx_copy(p, cl->buf->pos, cl->buf->last - cl->buf->pos);
+    rest = len;
+    for (cl = r->request_body->bufs; cl != NULL && rest > 0; cl = cl->next) {
+        size = ngx_buf_size(cl->buf);
+        if (size > rest) { /* reach limit*/
+            size = rest;
+        }
+
+        p = ngx_copy(p, cl->buf->pos, size);
+        rest -= size;
     }
 
     lua_pushlstring(L, (char *) buf, len);

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_rewriteby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_rewriteby.c
@@ -107,7 +107,9 @@ ngx_http_lua_rewrite_handler(ngx_http_request_t *r)
         }
 
         if (rc == NGX_DECLINED) {
-            if (r->header_sent) {
+            if (r->header_sent
+                || (r->headers_out.status != 0 && ctx->out != NULL))
+            {
                 dd("header already sent");
 
                 /* response header was already generated in rewrite_by_lua*,
@@ -175,6 +177,10 @@ ngx_http_lua_rewrite_handler_inline(ngx_http_request_t *r)
     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->rewrite_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->rewrite_src.value.data,
@@ -214,6 +220,10 @@ ngx_http_lua_rewrite_handler_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->rewrite_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
@@ -357,7 +367,9 @@ ngx_http_lua_rewrite_by_chunk(lua_State *L, ngx_http_request_t *r)
     }
 
     if (rc == NGX_OK || rc == NGX_DECLINED) {
-        if (r->header_sent) {
+        if (r->header_sent
+            || (r->headers_out.status != 0 && ctx->out != NULL))
+        {
             dd("header already sent");
 
             /* response header was already generated in rewrite_by_lua*,

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_server_rewriteby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_server_rewriteby.c
@@ -69,7 +69,9 @@ ngx_http_lua_server_rewrite_handler(ngx_http_request_t *r)
         }
 
         if (rc == NGX_DECLINED) {
-            if (r->header_sent) {
+            if (r->header_sent
+                || (r->headers_out.status != 0 && ctx->out != NULL))
+            {
                 dd("header already sent");
 
                 /* response header was already generated in rewrite_by_lua*,
@@ -307,7 +309,9 @@ ngx_http_lua_server_rewrite_by_chunk(lua_State *L, ngx_http_request_t *r)
     }
 
     if (rc == NGX_OK || rc == NGX_DECLINED) {
-        if (r->header_sent) {
+        if (r->header_sent
+            || (r->headers_out.status != 0 && ctx->out != NULL))
+        {
             dd("header already sent");
 
             /* response header was already generated in rewrite_by_lua*,

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_shdict.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_shdict.c
@@ -198,9 +198,6 @@ ngx_http_lua_shdict_lookup(ngx_shm_zone_t *shm_zone, ngx_uint_t hash,
         rc = ngx_memn2cmp(kdata, sd->data, klen, (size_t) sd->key_len);
 
         if (rc == 0) {
-            ngx_queue_remove(&sd->queue);
-            ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
-
             *sdp = sd;
 
             dd("node expires: %lld", (long long) sd->expires);
@@ -213,11 +210,14 @@ ngx_http_lua_shdict_lookup(ngx_shm_zone_t *shm_zone, ngx_uint_t hash,
 
                 dd("time to live: %lld", (long long) ms);
 
-                if (ms < 0) {
+                if (ms <= 0) {
                     dd("node already expired");
                     return NGX_DONE;
                 }
             }
+
+            ngx_queue_remove(&sd->queue);
+            ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
 
             return NGX_OK;
         }
@@ -654,7 +654,7 @@ ngx_http_lua_shared_dict_get(ngx_shm_zone_t *zone, u_char *key_data,
             return NGX_ERROR;
         }
 
-        ngx_memcpy(&value->value.b, data, len);
+        ngx_memcpy(&value->value.n, data, len);
         break;
 
     case SHDICT_TBOOLEAN:

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_socket_tcp.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_socket_tcp.c
@@ -75,6 +75,8 @@ static void ngx_http_lua_socket_dummy_handler(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u);
 static int ngx_http_lua_socket_tcp_receive_helper(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
+static void ngx_http_lua_socket_tcp_read_prepare(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, void *data, lua_State *L);
 static ngx_int_t ngx_http_lua_socket_tcp_read(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u);
 static int ngx_http_lua_socket_tcp_receive_retval_handler(ngx_http_request_t *r,
@@ -126,7 +128,7 @@ static int ngx_http_lua_socket_tcp_conn_op_resume_retval_handler(
     ngx_http_request_t *r, ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
 static int ngx_http_lua_socket_tcp_upstream_destroy(lua_State *L);
 static int ngx_http_lua_socket_downstream_destroy(lua_State *L);
-static ngx_int_t ngx_http_lua_socket_push_input_data(ngx_http_request_t *r,
+static void ngx_http_lua_socket_push_input_data(ngx_http_request_t *r,
     ngx_http_lua_ctx_t *ctx, ngx_http_lua_socket_tcp_upstream_t *u,
     lua_State *L);
 static ngx_int_t ngx_http_lua_socket_add_pending_data(ngx_http_request_t *r,
@@ -225,6 +227,10 @@ static char ngx_http_lua_pattern_udata_metatable_key;
 
 
 #define ngx_http_lua_tcp_socket_metatable_literal_key  "__tcp_cosocket_mt"
+#define ngx_http_lua_tcp_req_socket_metatable_literal_key                    \
+    "__tcp_req_cosocket_mt"
+#define ngx_http_lua_tcp_raw_req_socket_metatable_literal_key                \
+    "__tcp_raw_req_cosocket_mt"
 
 
 void
@@ -282,6 +288,12 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
     lua_setfield(L, -2, "__index");
 
     lua_rawset(L, LUA_REGISTRYINDEX);
+
+    lua_pushliteral(L, ngx_http_lua_tcp_req_socket_metatable_literal_key);
+    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
+                          req_socket_metatable_key));
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    lua_rawset(L, LUA_REGISTRYINDEX);
     /* }}} */
 
     /* {{{raw req socket object metatable */
@@ -310,6 +322,12 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
     lua_pushvalue(L, -1);
     lua_setfield(L, -2, "__index");
 
+    lua_rawset(L, LUA_REGISTRYINDEX);
+
+    lua_pushliteral(L, ngx_http_lua_tcp_raw_req_socket_metatable_literal_key);
+    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
+                          raw_req_socket_metatable_key));
+    lua_rawget(L, LUA_REGISTRYINDEX);
     lua_rawset(L, LUA_REGISTRYINDEX);
     /* }}} */
 
@@ -835,6 +853,7 @@ no_memory_and_not_resuming:
 static int
 ngx_http_lua_socket_tcp_bind(lua_State *L)
 {
+    int                   port;
     ngx_http_request_t   *r;
     ngx_http_lua_ctx_t   *ctx;
     int                   n;
@@ -844,8 +863,9 @@ ngx_http_lua_socket_tcp_bind(lua_State *L)
 
     n = lua_gettop(L);
 
-    if (n != 2) {
-        return luaL_error(L, "expecting 2 arguments, but got %d",
+    /* Correct the parameter check and allow 2 or 3 parameters */
+    if (n != 2 && n != 3) {
+        return luaL_error(L, "expecting 2 or 3 arguments, but got %d",
                           lua_gettop(L));
     }
 
@@ -859,13 +879,29 @@ ngx_http_lua_socket_tcp_bind(lua_State *L)
         return luaL_error(L, "no ctx found");
     }
 
-    ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_REWRITE
-                               | NGX_HTTP_LUA_CONTEXT_ACCESS
-                               | NGX_HTTP_LUA_CONTEXT_CONTENT
-                               | NGX_HTTP_LUA_CONTEXT_TIMER
-                               | NGX_HTTP_LUA_CONTEXT_SSL_CERT);
+    ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_YIELDABLE);
 
     luaL_checktype(L, 1, LUA_TTABLE);
+
+    port = 0;
+    /* handle case: host:port */
+    /* Hit the following parameter combination:
+     * sock:bind("127.0.0.1", port)     */
+    if (n == 3) {
+        if (!lua_isnumber(L, 3)) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "expecting port to be a"
+                            "number but got type: %s", luaL_typename(L, 3));
+            return 2;
+        }
+
+        port = (int) lua_tointeger(L, 3);
+        if (port < 0 || port > 65535) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "bad port number: %d", port);
+            return 2;
+        }
+    }
 
     text = (u_char *) luaL_checklstring(L, 2, &len);
 
@@ -876,9 +912,11 @@ ngx_http_lua_socket_tcp_bind(lua_State *L)
         return 2;
     }
 
+    if (port > 0) {
+        ngx_inet_set_port(local->sockaddr, (in_port_t) port);
+    }
     /* TODO: we may reuse the userdata here */
     lua_rawseti(L, 1, SOCKET_BIND_INDEX);
-
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua tcp socket bind ip: %V", &local->name);
 
@@ -1131,6 +1169,12 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
 
     lua_rawgeti(L, 1, SOCKET_BIND_INDEX);
     local = lua_touserdata(L, -1);
+
+    if (local != NULL) {
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "lua tcp socket sock:connect ip: %V", &local->name);
+    }
+
     lua_pop(L, 1);
 
     if (local) {
@@ -2163,8 +2207,6 @@ ngx_http_lua_socket_tcp_receive_helper(ngx_http_request_t *r,
     ngx_http_lua_ctx_t                  *ctx;
     ngx_http_lua_co_ctx_t               *coctx;
 
-    u->input_filter_ctx = u;
-
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 
     if (u->bufs_in == NULL) {
@@ -2192,6 +2234,8 @@ ngx_http_lua_socket_tcp_receive_helper(ngx_http_request_t *r,
 
     u->read_waiting = 0;
     u->read_co_ctx = NULL;
+
+    ngx_http_lua_socket_tcp_read_prepare(r, u, u, L);
 
     rc = ngx_http_lua_socket_tcp_read(r, u);
 
@@ -2409,7 +2453,7 @@ ngx_http_lua_socket_tcp_receive(lua_State *L)
         case LUA_TNUMBER:
             bytes = lua_tointeger(L, 2);
             if (bytes < 0) {
-                return luaL_argerror(L, 2, "bad pattern argument");
+                return luaL_argerror(L, 2, "bad number argument");
             }
 
 #if 1
@@ -2426,7 +2470,7 @@ ngx_http_lua_socket_tcp_receive(lua_State *L)
             break;
 
         default:
-            return luaL_argerror(L, 2, "bad pattern argument");
+            return luaL_argerror(L, 2, "bad argument");
             break;
         }
 
@@ -2511,6 +2555,87 @@ ngx_http_lua_socket_read_any(void *data, ssize_t bytes)
     }
 
     return rc;
+}
+
+
+static void
+ngx_http_lua_socket_tcp_read_prepare(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, void *data, lua_State *L)
+{
+    ngx_http_lua_ctx_t                  *ctx;
+    ngx_chain_t                         *new_cl;
+    ngx_buf_t                           *b;
+    off_t                                size;
+
+    ngx_http_lua_socket_compiled_pattern_t     *cp;
+
+    /* input_filter_ctx doesn't change, no need recovering */
+    if (u->input_filter_ctx == data) {
+        return;
+    }
+
+    /* last input_filter_ctx is null or upstream, no data pending */
+    if (u->input_filter_ctx == NULL || u->input_filter_ctx == u) {
+        u->input_filter_ctx = data;
+        return;
+    }
+
+    /* compiled pattern may be with data pending */
+
+    cp = u->input_filter_ctx;
+    u->input_filter_ctx = data;
+
+    cp->upstream = NULL;
+
+    /* no data pending */
+    if (cp->state <= 0) {
+        return;
+    }
+
+    b = &u->buffer;
+
+    if (b->pos - b->start >= cp->state) {
+        dd("pending data in one buffer");
+
+        b->pos -= cp->state;
+
+        u->buf_in->buf->pos = b->pos;
+        u->buf_in->buf->last = b->pos;
+
+        /* reset dfa state for future matching */
+        cp->state = 0;
+        return;
+    }
+
+    dd("pending data in multiple buffers");
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    size = ngx_buf_size(b);
+
+    new_cl =
+        ngx_http_lua_chain_get_free_buf(r->connection->log, r->pool,
+                                        &ctx->free_recv_bufs,
+                                        cp->state + size);
+
+    if (new_cl == NULL) {
+        luaL_error(L, "no memory");
+        return;
+    }
+
+    ngx_memcpy(b, new_cl->buf, sizeof(ngx_buf_t));
+
+    b->last = ngx_copy(b->last, cp->pattern.data, cp->state);
+    b->last = ngx_copy(b->last, u->buf_in->buf->pos, size);
+
+    u->buf_in->next = ctx->free_recv_bufs;
+    ctx->free_recv_bufs = u->buf_in;
+
+    u->bufs_in = new_cl;
+    u->buf_in = new_cl;
+
+    /* reset dfa state for future matching */
+    cp->state = 0;
 }
 
 
@@ -3074,7 +3199,6 @@ ngx_http_lua_socket_tcp_receive_retval_handler(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L)
 {
     int                          n;
-    ngx_int_t                    rc;
     ngx_http_lua_ctx_t          *ctx;
     ngx_event_t                 *ev;
 
@@ -3121,12 +3245,7 @@ ngx_http_lua_socket_tcp_receive_retval_handler(ngx_http_request_t *r,
         dd("u->bufs_in: %p", u->bufs_in);
 
         if (u->bufs_in) {
-            rc = ngx_http_lua_socket_push_input_data(r, ctx, u, L);
-            if (rc == NGX_ERROR) {
-                lua_pushnil(L);
-                lua_pushliteral(L, "no memory");
-                return 2;
-            }
+            ngx_http_lua_socket_push_input_data(r, ctx, u, L);
 
             (void) ngx_http_lua_socket_read_error_retval_handler(r, u, L);
 
@@ -3140,12 +3259,7 @@ ngx_http_lua_socket_tcp_receive_retval_handler(ngx_http_request_t *r,
         return n + 1;
     }
 
-    rc = ngx_http_lua_socket_push_input_data(r, ctx, u, L);
-    if (rc == NGX_ERROR) {
-        lua_pushnil(L);
-        lua_pushliteral(L, "no memory");
-        return 2;
-    }
+    ngx_http_lua_socket_push_input_data(r, ctx, u, L);
 
     return 1;
 }
@@ -3261,7 +3375,7 @@ ngx_http_lua_socket_tcp_settimeouts(lua_State *L)
     n = lua_gettop(L);
 
     if (n != 4) {
-        return luaL_error(L, "ngx.socket settimeout: expecting 4 arguments "
+        return luaL_error(L, "ngx.socket settimeouts: expecting 4 arguments "
                           "(including the object) but seen %d", lua_gettop(L));
     }
 
@@ -3351,7 +3465,7 @@ ngx_http_lua_socket_tcp_handler(ngx_event_t *ev)
 static ngx_int_t
 ngx_http_lua_socket_tcp_get_peer(ngx_peer_connection_t *pc, void *data)
 {
-    /* empty */
+    pc->type = SOCK_STREAM;
     return NGX_OK;
 }
 
@@ -4243,6 +4357,11 @@ ngx_http_lua_socket_tcp_finalize(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_finalize_read_part(r, u);
     ngx_http_lua_socket_tcp_finalize_write_part(r, u);
 
+    if (u->input_filter_ctx != NULL && u->input_filter_ctx != u) {
+        ((ngx_http_lua_socket_compiled_pattern_t *)
+         u->input_filter_ctx)->upstream = NULL;
+    }
+
     if (u->raw_downstream || u->body_downstream) {
         u->peer.connection = NULL;
         return;
@@ -4496,7 +4615,7 @@ ngx_http_lua_socket_receiveuntil_iterator(lua_State *L)
 
     n = lua_gettop(L);
     if (n > 1) {
-        return luaL_error(L, "expecting 0 or 1 arguments, "
+        return luaL_error(L, "expecting 0 or 1 argument, "
                           "but seen %d", n);
     }
 
@@ -4559,8 +4678,6 @@ ngx_http_lua_socket_receiveuntil_iterator(lua_State *L)
         (u_char *) lua_tolstring(L, lua_upvalueindex(2),
                                  &cp->pattern.len);
 
-    u->input_filter_ctx = cp;
-
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 
     if (u->bufs_in == NULL) {
@@ -4586,6 +4703,8 @@ ngx_http_lua_socket_receiveuntil_iterator(lua_State *L)
 
     u->read_waiting = 0;
     u->read_co_ctx = NULL;
+
+    ngx_http_lua_socket_tcp_read_prepare(r, u, cp, L);
 
     rc = ngx_http_lua_socket_tcp_read(r, u);
 
@@ -4915,13 +5034,24 @@ ngx_http_lua_socket_cleanup_compiled_pattern(lua_State *L)
 {
     ngx_http_lua_socket_compiled_pattern_t      *cp;
 
-    ngx_http_lua_dfa_edge_t         *edge, *p;
-    unsigned                         i;
+    ngx_http_lua_socket_tcp_upstream_t      *u;
+    ngx_http_lua_dfa_edge_t                 *edge, *p;
+    unsigned                                 i;
 
     dd("cleanup compiled pattern");
 
     cp = lua_touserdata(L, 1);
-    if (cp == NULL || cp->recovering == NULL) {
+    if (cp == NULL) {
+        return 0;
+    }
+
+    u = cp->upstream;
+    if (u != NULL) {
+        ngx_http_lua_socket_tcp_read_prepare(u->request, u, NULL, L);
+        u->input_filter_ctx = NULL;
+    }
+
+    if (cp->recovering == NULL) {
         return 0;
     }
 
@@ -4975,7 +5105,7 @@ ngx_http_lua_req_socket(lua_State *L)
         lua_pop(L, 1);
 
     } else {
-        return luaL_error(L, "expecting zero arguments, but got %d",
+        return luaL_error(L, "expecting 0 or 1 argument, but got %d",
                           lua_gettop(L));
     }
 
@@ -4995,6 +5125,12 @@ ngx_http_lua_req_socket(lua_State *L)
 #if (NGX_HTTP_V2)
     if (r->stream) {
         return luaL_error(L, "http v2 not supported yet");
+    }
+#endif
+
+#if (NGX_HTTP_V3)
+    if (r->http_version == NGX_HTTP_VERSION_30) {
+        return luaL_error(L, "http v3 not supported yet");
     }
 #endif
 
@@ -5284,6 +5420,34 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
 
     luaL_checktype(L, 1, LUA_TTABLE);
 
+    r = ngx_http_lua_get_req(L);
+    if (r == NULL) {
+        return luaL_error(L, "no request found");
+    }
+
+    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+
+    /* luaL_checkinteger will throw error if the argument is not a number.
+     * e.g.: bad argument \#2 to '?' (number expected, got string)
+     *
+     * We should check the argument in advance; otherwise,
+     * throwing an exception in the middle can compromise data integrity.
+     * e.g.: set pc->connection to NULL without following cleanup.
+     */
+    if (n >= 2 && !lua_isnil(L, 2)) {
+        timeout = (ngx_msec_t) luaL_checkinteger(L, 2);
+
+    } else {
+        timeout = llcf->keepalive_timeout;
+    }
+
+    if (n >= 3 && !lua_isnil(L, 3)) {
+        pool_size = luaL_checkinteger(L, 3);
+
+    } else {
+        pool_size = llcf->pool_size;
+    }
+
     lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
     u = lua_touserdata(L, -1);
     lua_pop(L, 1);
@@ -5308,11 +5472,6 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
         lua_pushnil(L);
         lua_pushliteral(L, "closed");
         return 2;
-    }
-
-    r = ngx_http_lua_get_req(L);
-    if (r == NULL) {
-        return luaL_error(L, "no request found");
     }
 
     if (u->request != r) {
@@ -5385,18 +5544,8 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
 
     /* stack: obj timeout? size? pools cache_key */
 
-    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
-
     if (spool == NULL) {
         /* create a new socket pool for the current peer key */
-
-        if (n >= 3 && !lua_isnil(L, 3)) {
-            pool_size = luaL_checkinteger(L, 3);
-
-        } else {
-            pool_size = llcf->pool_size;
-        }
-
         if (pool_size <= 0) {
             msg = lua_pushfstring(L, "bad \"pool_size\" option value: %d",
                                   pool_size);
@@ -5460,13 +5609,6 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
         ngx_del_timer(c->write);
     }
 
-    if (n >= 2 && !lua_isnil(L, 2)) {
-        timeout = (ngx_msec_t) luaL_checkinteger(L, 2);
-
-    } else {
-        timeout = llcf->keepalive_timeout;
-    }
-
 #if (NGX_DEBUG)
     if (timeout == 0) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
@@ -5500,6 +5642,7 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     if (c->read->ready) {
         rc = ngx_http_lua_socket_keepalive_close_handler(c->read);
         if (rc != NGX_OK) {
+            ngx_http_lua_socket_tcp_finalize(r, u);
             lua_pushnil(L);
             lua_pushliteral(L, "connection in dubious state");
             return 2;
@@ -5623,7 +5766,7 @@ ngx_http_lua_socket_keepalive_close_handler(ngx_event_t *ev)
     ngx_http_lua_socket_pool_t          *spool;
 
     int                n;
-    char               buf[1];
+    unsigned char      buf[1];
     ngx_connection_t  *c;
 
     c = ev->data;
@@ -5644,9 +5787,10 @@ ngx_http_lua_socket_keepalive_close_handler(ngx_event_t *ev)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0,
                    "lua tcp socket keepalive close handler check stale events");
 
-    n = recv(c->fd, buf, 1, MSG_PEEK);
+    /* consume the possible ssl-layer data implicitly */
+    n = c->recv(c, buf, 1);
 
-    if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
+    if (n == NGX_AGAIN) {
         /* stale event */
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
@@ -5805,7 +5949,7 @@ ngx_http_lua_socket_downstream_destroy(lua_State *L)
 }
 
 
-static ngx_int_t
+static void
 ngx_http_lua_socket_push_input_data(ngx_http_request_t *r,
     ngx_http_lua_ctx_t *ctx, ngx_http_lua_socket_tcp_upstream_t *u,
     lua_State *L)
@@ -5877,8 +6021,6 @@ ngx_http_lua_socket_push_input_data(ngx_http_request_t *r,
         u->buf_in->buf->last = u->buffer.pos;
         u->buf_in->buf->pos = u->buffer.pos;
     }
-
-    return NGX_OK;
 }
 
 
@@ -6591,6 +6733,28 @@ ngx_http_lua_ffi_socket_tcp_setoption(ngx_http_lua_socket_tcp_upstream_t *u,
     }
 
     return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_socket_tcp_getfd(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, const char **errmsg)
+{
+    int fd;
+
+    *errmsg = NULL;
+
+    if (u == NULL  || u->peer.connection == NULL) {
+        *errmsg = "closed";
+        return -1;
+    }
+
+    fd = u->peer.connection->fd;
+    if (fd == -1) {
+        *errmsg = "faked connection";
+    }
+
+    return fd;
 }
 
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_socket_udp.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_socket_udp.c
@@ -54,16 +54,19 @@ static void ngx_http_lua_socket_udp_read_handler(ngx_http_request_t *r,
     ngx_http_lua_socket_udp_upstream_t *u);
 static void ngx_http_lua_socket_udp_handle_success(ngx_http_request_t *r,
     ngx_http_lua_socket_udp_upstream_t *u);
-static ngx_int_t ngx_http_lua_udp_connect(ngx_http_lua_udp_connection_t *uc);
+static ngx_int_t ngx_http_lua_udp_connect(ngx_http_lua_udp_connection_t *uc,
+    ngx_addr_t *local);
 static int ngx_http_lua_socket_udp_close(lua_State *L);
 static ngx_int_t ngx_http_lua_socket_udp_resume(ngx_http_request_t *r);
 static void ngx_http_lua_udp_resolve_cleanup(void *data);
 static void ngx_http_lua_udp_socket_cleanup(void *data);
+static int ngx_http_lua_socket_udp_bind(lua_State *L);
 
 
 enum {
     SOCKET_CTX_INDEX = 1,
     SOCKET_TIMEOUT_INDEX = 2,
+    SOCKET_BIND_INDEX = 3,
 };
 
 
@@ -99,6 +102,9 @@ ngx_http_lua_inject_socket_udp_api(ngx_log_t *log, lua_State *L)
 
     lua_pushcfunction(L, ngx_http_lua_socket_udp_close);
     lua_setfield(L, -2, "close"); /* ngx socket mt */
+
+    lua_pushcfunction(L, ngx_http_lua_socket_udp_bind);
+    lua_setfield(L, -2, "bind");
 
     lua_pushvalue(L, -1);
     lua_setfield(L, -2, "__index");
@@ -159,6 +165,7 @@ ngx_http_lua_socket_udp_setpeername(lua_State *L)
     ngx_http_request_t          *r;
     ngx_http_lua_ctx_t          *ctx;
     ngx_str_t                    host;
+    ngx_addr_t                  *local;
     int                          port;
     ngx_resolver_ctx_t          *rctx, temp;
     ngx_http_core_loc_conf_t    *clcf;
@@ -289,6 +296,13 @@ ngx_http_lua_socket_udp_setpeername(lua_State *L)
 
     } else {
         u->read_timeout = u->conf->read_timeout;
+    }
+
+    lua_rawgeti(L, 1, SOCKET_BIND_INDEX);
+    local = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    if (local != NULL) {
+        u->local = local;
     }
 
     ngx_memzero(&url, sizeof(ngx_url_t));
@@ -618,7 +632,7 @@ ngx_http_lua_socket_resolve_retval_handler(ngx_http_request_t *r,
         return 2;
     }
 
-    rc = ngx_http_lua_udp_connect(uc);
+    rc = ngx_http_lua_udp_connect(uc, u->local);
 
     if (rc != NGX_OK) {
         u->socket_errno = ngx_socket_errno;
@@ -718,6 +732,56 @@ ngx_http_lua_socket_error_retval_handler(ngx_http_request_t *r,
     }
 
     return 2;
+}
+
+
+static int
+ngx_http_lua_socket_udp_bind(lua_State *L)
+{
+    ngx_http_request_t   *r;
+    ngx_http_lua_ctx_t   *ctx;
+    int                   n;
+    u_char               *text;
+    size_t                len;
+    ngx_addr_t           *local;
+
+    n = lua_gettop(L);
+
+    if (n != 2) {
+        return luaL_error(L, "expecting 2 arguments, but got %d",
+                          lua_gettop(L));
+    }
+
+    r = ngx_http_lua_get_req(L);
+    if (r == NULL) {
+        return luaL_error(L, "no request found");
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        return luaL_error(L, "no ctx found");
+    }
+
+    ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_YIELDABLE);
+
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    text = (u_char *) luaL_checklstring(L, 2, &len);
+
+    local = ngx_http_lua_parse_addr(L, text, len);
+    if (local == NULL) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "bad address");
+        return 2;
+    }
+
+    lua_rawseti(L, 1, SOCKET_BIND_INDEX);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua udp socket bind ip: %V", &local->name);
+
+    lua_pushinteger(L, 1);
+    return 1;
 }
 
 
@@ -1143,7 +1207,7 @@ ngx_http_lua_socket_udp_read(ngx_http_request_t *r,
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "lua udp socket read data: waiting: %d", (int) u->waiting);
 
-    n = ngx_udp_recv(u->udp_connection.connection,
+    n = ngx_udp_recv(c,
                      ngx_http_lua_socket_udp_buffer, u->recv_buf_size);
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
@@ -1340,7 +1404,7 @@ ngx_http_lua_socket_udp_handle_success(ngx_http_request_t *r,
 
 
 static ngx_int_t
-ngx_http_lua_udp_connect(ngx_http_lua_udp_connection_t *uc)
+ngx_http_lua_udp_connect(ngx_http_lua_udp_connection_t *uc, ngx_addr_t *local)
 {
     int                rc;
     ngx_int_t          event;
@@ -1413,7 +1477,17 @@ ngx_http_lua_udp_connect(ngx_http_lua_udp_connection_t *uc)
             return NGX_ERROR;
         }
     }
+
 #endif
+
+    if (local != NULL) {
+        if (bind(s, local->sockaddr, local->socklen) == -1) {
+            ngx_log_error(NGX_LOG_CRIT, &uc->log, ngx_socket_errno,
+                          "bind(%V) failed", &local->name);
+
+            return NGX_ERROR;
+        }
+    }
 
     ngx_log_debug3(NGX_LOG_DEBUG_EVENT, &uc->log, 0,
                    "connect to %V, fd:%d #%d", &uc->server, s, c->number);

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_socket_udp.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_socket_udp.h
@@ -42,6 +42,8 @@ struct ngx_http_lua_socket_udp_upstream_s {
     ngx_http_request_t              *request;
     ngx_http_lua_udp_connection_t    udp_connection;
 
+    ngx_addr_t                      *local;
+
     ngx_msec_t                       read_timeout;
 
     ngx_http_upstream_resolved_t    *resolved;
@@ -53,7 +55,7 @@ struct ngx_http_lua_socket_udp_upstream_s {
 
     ngx_http_lua_co_ctx_t           *co_ctx;
 
-    unsigned                         waiting; /* :1 */
+    unsigned                         waiting:1; /* :1 */
 };
 
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl.c
@@ -14,6 +14,7 @@
 
 
 int ngx_http_lua_ssl_ctx_index = -1;
+int ngx_http_lua_ssl_key_log_index = -1;
 
 
 ngx_int_t
@@ -26,6 +27,17 @@ ngx_http_lua_ssl_init(ngx_log_t *log)
         if (ngx_http_lua_ssl_ctx_index == -1) {
             ngx_ssl_error(NGX_LOG_ALERT, log, 0,
                           "lua: SSL_get_ex_new_index() for ctx failed");
+            return NGX_ERROR;
+        }
+    }
+
+    if (ngx_http_lua_ssl_key_log_index == -1) {
+        ngx_http_lua_ssl_key_log_index = SSL_get_ex_new_index(0, NULL, NULL,
+                                                              NULL, NULL);
+
+        if (ngx_http_lua_ssl_key_log_index == -1) {
+            ngx_ssl_error(NGX_LOG_ALERT, log, 0,
+                          "lua: SSL_get_ex_new_index() for key log failed");
             return NGX_ERROR;
         }
     }

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl.h
@@ -16,7 +16,7 @@
 
 typedef struct {
     ngx_connection_t        *connection; /* original true connection */
-    ngx_http_request_t      *request;    /* fake request */
+    ngx_http_request_t      *request;
     ngx_pool_cleanup_pt     *cleanup;
 
     ngx_ssl_session_t       *session;    /* return value for openssl's
@@ -24,27 +24,48 @@ typedef struct {
 
     ngx_str_t                session_id;
 
+#ifdef HAVE_PROXY_SSL_PATCH
+    X509_STORE_CTX          *x509_store;
+    ngx_pool_t              *pool;
+#endif
+
     int                      exit_code;  /* exit code for openssl's
                                             set_client_hello_cb or
-                                            set_cert_cb callback */
+                                            set_cert_cb callback or
+                                            SSL_CTX_set_cert_verify_callback */
 
     int                      ctx_ref;  /*  reference to anchor
                                            request ctx data in lua
                                            registry */
 
+#ifdef HAVE_PROXY_SSL_PATCH
+    /* same size as count field of ngx_http_request_t */
+    unsigned                 original_request_count:16;
+#endif
     unsigned                 done:1;
     unsigned                 aborted:1;
 
     unsigned                 entered_client_hello_handler:1;
     unsigned                 entered_cert_handler:1;
     unsigned                 entered_sess_fetch_handler:1;
+#ifdef HAVE_PROXY_SSL_PATCH
+    unsigned                 entered_proxy_ssl_verify_handler:1;
+#endif
 } ngx_http_lua_ssl_ctx_t;
+
+
+typedef struct {
+    ngx_ssl_t     *ssl;
+    ngx_fd_t       fd;
+    ngx_str_t      name;
+} ngx_http_lua_ssl_key_log_t;
 
 
 ngx_int_t ngx_http_lua_ssl_init(ngx_log_t *log);
 
 
 extern int ngx_http_lua_ssl_ctx_index;
+extern int ngx_http_lua_ssl_key_log_index;
 
 
 #endif

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_certby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_certby.c
@@ -37,6 +37,10 @@ static u_char *ngx_http_lua_log_ssl_cert_error(ngx_log_t *log, u_char *buf,
 static ngx_int_t ngx_http_lua_ssl_cert_by_chunk(lua_State *L,
     ngx_http_request_t *r);
 
+#ifndef OPENSSL_IS_BORINGSSL
+static int ngx_http_lua_is_grease_cipher(uint16_t cipher_id);
+#endif
+
 
 ngx_int_t
 ngx_http_lua_ssl_cert_handler_file(ngx_http_request_t *r,
@@ -213,7 +217,7 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
         if (cctx->done) {
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                           "lua_certificate_by_lua: cert cb exit code: %d",
+                           "ssl_certificate_by_lua: cert cb exit code: %d",
                            cctx->exit_code);
 
             dd("lua ssl cert done, finally");
@@ -326,7 +330,7 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
         }
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                       "lua_certificate_by_lua: handler return value: %i, "
+                       "ssl_certificate_by_lua: handler return value: %i, "
                        "cert cb exit code: %d", rc, cctx->exit_code);
 
         c->log->action = "SSL handshaking";
@@ -357,7 +361,6 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
     return -1;
 
-#if 1
 failed:
 
     if (r && r->pool) {
@@ -369,15 +372,14 @@ failed:
     }
 
     return 0;
-#endif
 }
 
 
 static void
 ngx_http_lua_ssl_cert_done(void *data)
 {
-    ngx_connection_t                *c;
-    ngx_http_lua_ssl_ctx_t          *cctx = data;
+    ngx_connection_t        *c;
+    ngx_http_lua_ssl_ctx_t  *cctx = data;
 
     dd("lua ssl cert done");
 
@@ -398,6 +400,14 @@ ngx_http_lua_ssl_cert_done(void *data)
     c->log->action = "SSL handshaking";
 
     ngx_post_event(c->write, &ngx_posted_events);
+
+#if (HAVE_QUIC_SSL_LUA_YIELD_PATCH && NGX_HTTP_V3)
+#   if OPENSSL_VERSION_NUMBER >= 0x1000205fL
+#       if (NGX_QUIC_OPENSSL_COMPAT || NGX_QUIC_OPENSSL_API)
+    ngx_http_lua_resume_quic_ssl_handshake(c);
+#       endif
+#   endif
+#endif
 }
 
 
@@ -406,7 +416,7 @@ ngx_http_lua_ssl_cert_aborted(void *data)
 {
     ngx_http_lua_ssl_ctx_t      *cctx = data;
 
-    dd("lua ssl cert done");
+    dd("lua ssl cert aborted");
 
     if (cctx->done) {
         /* completed successfully already */
@@ -414,7 +424,7 @@ ngx_http_lua_ssl_cert_aborted(void *data)
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cctx->connection->log, 0,
-                   "lua_certificate_by_lua: cert cb aborted");
+                   "ssl_certificate_by_lua: cert cb aborted");
 
     cctx->aborted = 1;
     cctx->request->connection->ssl = NULL;
@@ -455,6 +465,18 @@ ngx_http_lua_log_ssl_cert_error(ngx_log_t *log, u_char *buf, size_t len)
 
     return buf;
 }
+
+
+#ifndef OPENSSL_IS_BORINGSSL
+static int
+ngx_http_lua_is_grease_cipher(uint16_t cipher_id)
+{
+    /* GREASE values follow pattern: 0x?A?A where ? can be any hex digit */
+    /* and both ? must be the same */
+    /* Check if both bytes follow ?A pattern and high nibbles match */
+    return (cipher_id & 0x0F0F) == 0x0A0A;
+}
+#endif
 
 
 static ngx_int_t
@@ -845,6 +867,70 @@ ngx_http_lua_ffi_ssl_raw_server_addr(ngx_http_request_t *r, char **addr,
 
 
 int
+ngx_http_lua_ffi_req_shared_ssl_ciphers(ngx_http_request_t *r,
+    uint16_t *ciphers, uint16_t *nciphers, int filter_grease, char **err)
+{
+#ifdef OPENSSL_IS_BORINGSSL
+
+    *err = "BoringSSL is not supported for SSL cipher operations";
+    return NGX_ERROR;
+
+#else
+    ngx_ssl_conn_t         *ssl_conn;
+    STACK_OF(SSL_CIPHER)   *sk, *ck;
+    int                     sn, cn, i, n;
+    uint16_t                cipher;
+
+    if (r == NULL || r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    sk = SSL_get1_supported_ciphers(ssl_conn);
+    ck = SSL_get_client_ciphers(ssl_conn);
+    sn = sk_SSL_CIPHER_num(sk);
+    cn = sk_SSL_CIPHER_num(ck);
+
+    if (sn > *nciphers) {
+        *err = "buffer too small";
+        *nciphers = 0;
+        sk_SSL_CIPHER_free(sk);
+        return NGX_ERROR;
+    }
+
+    for (*nciphers = 0, i = 0; i < sn; i++) {
+        cipher = SSL_CIPHER_get_protocol_id(sk_SSL_CIPHER_value(sk, i));
+
+        /* Skip GREASE ciphers if filtering is enabled */
+        if (filter_grease && ngx_http_lua_is_grease_cipher(cipher)) {
+            continue;
+        }
+
+        for (n = 0; n < cn; n++) {
+            if (SSL_CIPHER_get_protocol_id(sk_SSL_CIPHER_value(ck, n))
+                == cipher)
+            {
+                ciphers[(*nciphers)++] = cipher;
+                break;
+            }
+        }
+    }
+
+    sk_SSL_CIPHER_free(sk);
+
+    return NGX_OK;
+#endif
+
+}
+
+
+int
 ngx_http_lua_ffi_ssl_server_name(ngx_http_request_t *r, char **name,
     size_t *namelen, char **err)
 {
@@ -1183,6 +1269,81 @@ ngx_http_lua_ffi_parse_pem_cert(const u_char *pem, size_t pem_len,
 }
 
 
+void *
+ngx_http_lua_ffi_parse_der_cert(const char *data, size_t len,
+    char **err)
+{
+    BIO             *bio;
+    X509            *x509;
+    STACK_OF(X509)  *chain;
+
+    if (data == NULL || len == 0) {
+        *err = "invalid argument";
+        ERR_clear_error();
+        return NULL;
+    }
+
+    bio = BIO_new_mem_buf((char *) data, len);
+    if (bio == NULL) {
+        *err = "BIO_new_mem_buf() failed";
+        ERR_clear_error();
+        return NULL;
+    }
+
+    x509 = d2i_X509_bio(bio, NULL);
+    if (x509 == NULL) {
+        *err = "d2i_X509_bio() failed";
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    chain = sk_X509_new_null();
+    if (chain == NULL) {
+        *err = "sk_X509_new_null() failed";
+        X509_free(x509);
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    if (sk_X509_push(chain, x509) == 0) {
+        *err = "sk_X509_push() failed";
+        sk_X509_free(chain);
+        X509_free(x509);
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    /* read rest of the chain */
+
+    while (!BIO_eof(bio)) {
+        x509 = d2i_X509_bio(bio, NULL);
+        if (x509 == NULL) {
+            *err = "d2i_X509_bio() failed in rest of chain";
+            sk_X509_pop_free(chain, X509_free);
+            BIO_free(bio);
+            ERR_clear_error();
+            return NULL;
+        }
+
+        if (sk_X509_push(chain, x509) == 0) {
+            *err = "sk_X509_push() failed in rest of chain";
+            sk_X509_pop_free(chain, X509_free);
+            X509_free(x509);
+            BIO_free(bio);
+            ERR_clear_error();
+            return NULL;
+        }
+    }
+
+    BIO_free(bio);
+
+    return chain;
+}
+
+
 void
 ngx_http_lua_ffi_free_cert(void *cdata)
 {
@@ -1215,6 +1376,40 @@ ngx_http_lua_ffi_parse_pem_priv_key(const u_char *pem, size_t pem_len,
     }
 
     BIO_free(in);
+
+    return pkey;
+}
+
+
+void *
+ngx_http_lua_ffi_parse_der_priv_key(const char *data, size_t len,
+    char **err)
+{
+    BIO               *bio = NULL;
+    EVP_PKEY          *pkey = NULL;
+
+    if (data == NULL || len == 0) {
+        *err = "invalid argument";
+        ERR_clear_error();
+        return NULL;
+    }
+
+    bio = BIO_new_mem_buf((char *) data, len);
+    if (bio == NULL) {
+        *err = "BIO_new_mem_buf() failed";
+        ERR_clear_error();
+        return NULL;
+    }
+
+    pkey = d2i_PrivateKey_bio(bio, NULL);
+    if (pkey == NULL) {
+        *err = "d2i_PrivateKey_bio() failed";
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    BIO_free(bio);
 
     return pkey;
 }
@@ -1335,7 +1530,7 @@ ngx_http_lua_ffi_set_priv_key(ngx_http_request_t *r,
 
     pkey = cdata;
     if (pkey == NULL) {
-        *err = "invalid private key failed";
+        *err = "invalid private key";
         goto failed;
     }
 
@@ -1370,8 +1565,8 @@ ngx_http_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 
 
 int
-ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
-    int depth, char **err)
+ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *client_certs,
+    void *trusted_certs, int depth, char **err)
 {
 #ifdef LIBRESSL_VERSION_NUMBER
 
@@ -1383,7 +1578,8 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
     ngx_http_lua_ctx_t          *ctx;
     ngx_ssl_conn_t              *ssl_conn;
     ngx_http_ssl_srv_conf_t     *sscf;
-    STACK_OF(X509)              *chain = ca_certs;
+    STACK_OF(X509)              *client_chain = client_certs;
+    STACK_OF(X509)              *trusted_chain = trusted_certs;
     STACK_OF(X509_NAME)         *name_chain = NULL;
     X509                        *x509 = NULL;
     X509_NAME                   *subject = NULL;
@@ -1437,54 +1633,75 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
 
     /* set CA chain */
 
-    if (chain != NULL) {
+    if (client_chain != NULL || trusted_chain != NULL) {
+
         ca_store = X509_STORE_new();
         if (ca_store == NULL) {
             *err = "X509_STORE_new() failed";
             return NGX_ERROR;
         }
 
-        /* construct name chain */
+        if (client_chain != NULL) {
 
-        name_chain = sk_X509_NAME_new_null();
-        if (name_chain == NULL) {
-            *err = "sk_X509_NAME_new_null() failed";
-            goto failed;
+            /* construct name chain */
+            name_chain = sk_X509_NAME_new_null();
+            if (name_chain == NULL) {
+                *err = "sk_X509_NAME_new_null() failed";
+                goto failed;
+            }
+
+            for (i = 0; i < sk_X509_num(client_chain); i++) {
+                x509 = sk_X509_value(client_chain, i);
+                if (x509 == NULL) {
+                    *err = "sk_X509_value() failed";
+                    goto failed;
+                }
+
+                /* add subject to name chain, which will be sent to client */
+                subject = X509_NAME_dup(X509_get_subject_name(x509));
+                if (subject == NULL) {
+                    *err = "X509_get_subject_name() failed";
+                    goto failed;
+                }
+
+                if (!sk_X509_NAME_push(name_chain, subject)) {
+                    *err = "sk_X509_NAME_push() failed";
+                    X509_NAME_free(subject);
+                    goto failed;
+                }
+
+                /* add to trusted CA store */
+                if (X509_STORE_add_cert(ca_store, x509) == 0) {
+                    *err = "X509_STORE_add_cert() failed";
+                    goto failed;
+                }
+            }
+
+            /* clean subject name list, and set it for send to client */
+            SSL_set_client_CA_list(ssl_conn, name_chain);
         }
 
-        for (i = 0; i < sk_X509_num(chain); i++) {
-            x509 = sk_X509_value(chain, i);
-            if (x509 == NULL) {
-                *err = "sk_X509_value() failed";
-                goto failed;
-            }
+        if (trusted_chain != NULL) {
+            for (i = 0; i < sk_X509_num(trusted_chain); i++) {
+                x509 = sk_X509_value(trusted_chain, i);
+                if (x509 == NULL) {
+                    *err = "sk_X509_value() failed";
+                    goto failed;
+                }
 
-            /* add subject to name chain, which will be sent to client */
-            subject = X509_NAME_dup(X509_get_subject_name(x509));
-            if (subject == NULL) {
-                *err = "X509_get_subject_name() failed";
-                goto failed;
-            }
-
-            if (!sk_X509_NAME_push(name_chain, subject)) {
-                *err = "sk_X509_NAME_push() failed";
-                X509_NAME_free(subject);
-                goto failed;
-            }
-
-            /* add to trusted CA store */
-            if (X509_STORE_add_cert(ca_store, x509) == 0) {
-                *err = "X509_STORE_add_cert() failed";
-                goto failed;
+                /* add to trusted CA store */
+                if (X509_STORE_add_cert(ca_store, x509) == 0) {
+                    *err = "X509_STORE_add_cert() failed";
+                    goto failed;
+                }
             }
         }
 
+        /* clean ca_store, and store new ca_store */
         if (SSL_set0_verify_cert_store(ssl_conn, ca_store) == 0) {
             *err = "SSL_set0_verify_cert_store() failed";
             goto failed;
         }
-
-        SSL_set_client_CA_list(ssl_conn, name_chain);
     }
 
     return NGX_OK;
@@ -1501,13 +1718,42 @@ failed:
 
 
 ngx_ssl_conn_t *
-ngx_http_lua_ffi_get_req_ssl_pointer(ngx_http_request_t *r)
+ngx_http_lua_ffi_get_req_ssl_pointer(ngx_http_request_t *r, const char **err)
 {
     if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NULL;
+    }
+
+    if (r->connection->ssl->connection == NULL) {
+        *err = "bad ssl connection";
         return NULL;
     }
 
     return r->connection->ssl->connection;
+}
+
+
+int
+ngx_http_lua_ffi_ssl_client_random(ngx_http_request_t *r,
+    unsigned char *out, size_t *outlen, char **err)
+{
+    ngx_ssl_conn_t          *ssl_conn;
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    *outlen = SSL_get_client_random(ssl_conn, out, *outlen);
+
+    return NGX_OK;
 }
 
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_client_helloby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_client_helloby.c
@@ -159,7 +159,7 @@ ngx_http_lua_ssl_client_hello_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
         }
 
         chunkname = ngx_http_lua_gen_chunk_name(cf, "ssl_client_hello_by_lua",
-                                          sizeof("ssl_client_hello_by_lua")- 1,
+                                          sizeof("ssl_client_hello_by_lua") - 1,
                                           &chunkname_len);
         if (chunkname == NULL) {
             return NGX_CONF_ERROR;
@@ -207,7 +207,7 @@ ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
 
         if (cctx->done) {
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                           "lua_client_hello_by_lua: "
+                           "ssl_client_hello_by_lua: "
                            "client hello cb exit code: %d",
                            cctx->exit_code);
 
@@ -219,6 +219,15 @@ ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
     }
 
     dd("first time");
+
+#if (nginx_version > 1029001)
+    /* see commit 0373fe5d98c1515640 for more details */
+    rc = ngx_ssl_client_hello_callback(ssl_conn, al, arg);
+
+    if (rc == 0) {
+        return rc;
+    }
+#endif
 
 #if (nginx_version < 1017009)
     ngx_reusable_connection(c, 0);
@@ -310,7 +319,7 @@ ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
         }
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                       "lua_client_hello_by_lua: handler return value: %i, "
+                       "ssl_client_hello_by_lua: handler return value: %i, "
                        "client hello cb exit code: %d", rc, cctx->exit_code);
 
         c->log->action = "SSL handshaking";
@@ -341,7 +350,6 @@ ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
 
     return -1;
 
-#if 1
 failed:
 
     if (r && r->pool) {
@@ -353,15 +361,14 @@ failed:
     }
 
     return 0;
-#endif
 }
 
 
 static void
 ngx_http_lua_ssl_client_hello_done(void *data)
 {
-    ngx_connection_t                *c;
-    ngx_http_lua_ssl_ctx_t          *cctx = data;
+    ngx_connection_t        *c;
+    ngx_http_lua_ssl_ctx_t  *cctx = data;
 
     dd("lua ssl client hello done");
 
@@ -382,6 +389,14 @@ ngx_http_lua_ssl_client_hello_done(void *data)
     c->log->action = "SSL handshaking";
 
     ngx_post_event(c->write, &ngx_posted_events);
+
+#if (HAVE_QUIC_SSL_LUA_YIELD_PATCH && NGX_HTTP_V3)
+#   if defined(SSL_ERROR_WANT_CLIENT_HELLO_CB)
+#       if (NGX_QUIC_OPENSSL_COMPAT || NGX_QUIC_OPENSSL_API)
+    ngx_http_lua_resume_quic_ssl_handshake(c);
+#       endif
+#   endif
+#endif
 }
 
 
@@ -390,7 +405,7 @@ ngx_http_lua_ssl_client_hello_aborted(void *data)
 {
     ngx_http_lua_ssl_ctx_t      *cctx = data;
 
-    dd("lua ssl client hello done");
+    dd("lua ssl client hello aborted");
 
     if (cctx->done) {
         /* completed successfully already */
@@ -398,7 +413,7 @@ ngx_http_lua_ssl_client_hello_aborted(void *data)
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cctx->connection->log, 0,
-                   "lua_client_hello_by_lua: client hello cb aborted");
+                   "ssl_client_hello_by_lua: client hello cb aborted");
 
     cctx->aborted = 1;
     cctx->request->connection->ssl = NULL;
@@ -541,6 +556,10 @@ int
 ngx_http_lua_ffi_ssl_get_client_hello_server_name(ngx_http_request_t *r,
     const char **name, size_t *namelen, char **err)
 {
+#ifdef LIBRESSL_VERSION_NUMBER
+    *err = "LibreSSL does not support by ssl_client_hello_by_lua*";
+    return NGX_ERROR;
+#else
     ngx_ssl_conn_t          *ssl_conn;
 #ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
     const unsigned char     *p;
@@ -619,6 +638,7 @@ ngx_http_lua_ffi_ssl_get_client_hello_server_name(ngx_http_request_t *r,
     *err = "no TLS extension support";
     return NGX_ERROR;
 #endif
+#endif  /* LIBRESSL_VERSION_NUMBER */
 }
 
 
@@ -626,6 +646,10 @@ int
 ngx_http_lua_ffi_ssl_get_client_hello_ext(ngx_http_request_t *r,
     unsigned int type, const unsigned char **out, size_t *outlen, char **err)
 {
+#ifdef LIBRESSL_VERSION_NUMBER
+    *err = "LibreSSL does not support by ssl_client_hello_by_lua*";
+    return NGX_ERROR;
+#else
     ngx_ssl_conn_t          *ssl_conn;
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
@@ -649,7 +673,100 @@ ngx_http_lua_ffi_ssl_get_client_hello_ext(ngx_http_request_t *r,
     *err = "OpenSSL too old to support this function";
     return NGX_ERROR;
 #endif
+#endif  /* LIBRESSL_VERSION_NUMBER */
+}
 
+
+int
+ngx_http_lua_ffi_ssl_get_client_hello_ext_present(ngx_http_request_t *r,
+    int **extensions, size_t *extensions_len, char **err)
+{
+#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
+    ngx_ssl_conn_t          *ssl_conn;
+    int                      got_extensions;
+    size_t                   ext_len;
+    int                     *ext_out;
+    /* OPENSSL will allocate memory for us and make the ext_out point to it */
+
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    got_extensions = SSL_client_hello_get1_extensions_present(ssl_conn,
+                                                           &ext_out, &ext_len);
+    if (!got_extensions || !ext_out || !ext_len) {
+        *err = "failed SSL_client_hello_get1_extensions_present()";
+        return NGX_DECLINED;
+    }
+
+    *extensions = ngx_palloc(r->connection->pool, sizeof(int) * ext_len);
+    if (*extensions != NULL) {
+        ngx_memcpy(*extensions, ext_out, sizeof(int) * ext_len);
+        *extensions_len = ext_len;
+    }
+
+    OPENSSL_free(ext_out);
+    return NGX_OK;
+#else
+    *err = "OpenSSL too old to support this function";
+    return NGX_ERROR;
+#endif
+}
+
+
+int ngx_http_lua_ffi_ssl_get_client_hello_ciphers(ngx_http_request_t *r,
+    unsigned short *ciphers,  size_t ciphers_size, char **err)
+{
+#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
+    int                      i;
+    size_t                   ciphers_cnt;
+    size_t                   ciphersuites_bytes;
+    ngx_ssl_conn_t          *ssl_conn;
+    const unsigned char     *ciphers_raw;
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    ciphersuites_bytes = SSL_client_hello_get0_ciphers(ssl_conn, &ciphers_raw);
+
+    if (ciphersuites_bytes == 0) {
+        *err = "failed SSL_client_hello_get0_ciphers()";
+        return NGX_DECLINED;
+    }
+
+    if (ciphersuites_bytes % 2 != 0) {
+        *err = "SSL_client_hello_get0_ciphers() odd ciphersuites_bytes";
+        return NGX_DECLINED;
+    }
+
+    ciphers_cnt = ciphersuites_bytes / 2;
+    ciphers_cnt = ciphers_cnt > ciphers_size ? ciphers_size : ciphers_cnt;
+
+    for (i = 0 ; i < (int) ciphers_cnt ; i++) {
+        ciphers[i] = (ciphers_raw[i * 2] << 8) | ciphers_raw[i * 2 + 1];
+    }
+
+    return ciphers_cnt;
+#else
+    *err = "OpenSSL too old to support this function";
+    return NGX_ERROR;
+#endif
 }
 
 
@@ -703,7 +820,7 @@ ngx_http_lua_ffi_ssl_set_protocols(ngx_http_request_t *r,
     }
 #endif
 
-#ifdef SSL_OP_NO_TLSv1_3
+#if defined(NGX_SSL_TLSv1_3) && defined( SSL_OP_NO_TLSv1_3)
     SSL_clear_options(ssl_conn, SSL_OP_NO_TLSv1_3);
     if (!(protocols & NGX_SSL_TLSv1_3)) {
         SSL_set_options(ssl_conn, SSL_OP_NO_TLSv1_3);

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_export_keying_material.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_export_keying_material.c
@@ -1,0 +1,125 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+
+
+#include "ddebug.h"
+
+#if (NGX_HTTP_SSL)
+
+#include <openssl/ssl.h>
+
+#include "ngx_http_lua_cache.h"
+#include "ngx_http_lua_initworkerby.h"
+#include "ngx_http_lua_util.h"
+#include "ngx_http_ssl_module.h"
+#include "ngx_http_lua_contentby.h"
+#include "ngx_http_lua_ssl_session_fetchby.h"
+#include "ngx_http_lua_ssl.h"
+#include "ngx_http_lua_directive.h"
+#include "ngx_http_lua_ssl_export_keying_material.h"
+
+
+ngx_int_t
+ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
+    u_char *out, size_t out_size, const char *label, size_t llen,
+    const u_char *context, size_t ctxlen, int use_ctx, char **err)
+{
+#if defined(OPENSSL_IS_BORINGSSL) || OPENSSL_VERSION_NUMBER < 0x10101000L
+    *err = "BoringSSL does not support SSL_export_keying_material";
+    return NGX_ERROR;
+#elif defined(LIBRESSL_VERSION_NUMBER)
+    *err = "LibreSSL does not support SSL_export_keying_material";
+    return NGX_ERROR;
+#elif OPENSSL_VERSION_NUMBER < 0x10101000L
+    *err = "OpenSSL too old";
+    return NGX_ERROR;
+#else
+    ngx_connection_t   *c;
+    ngx_ssl_conn_t     *ssl_conn;
+    int                 rc;
+
+    c = r->connection;
+    if (c == NULL || c->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = c->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl connection";
+        return NGX_ERROR;
+    }
+
+    rc = SSL_export_keying_material(ssl_conn, out, out_size, label, llen,
+                                    context, ctxlen, use_ctx);
+    if (rc == 1) {
+        return NGX_OK;
+    }
+
+    ngx_ssl_error(NGX_LOG_INFO, c->log, 0,
+                  "SSL_export_keying_material rc: %d, error: %s",
+                  rc, ERR_error_string(ERR_get_error(), NULL));
+
+    *err = "SSL_export_keying_material() failed";
+
+    return NGX_ERROR;
+#endif
+}
+
+
+ngx_int_t
+ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
+    u_char *out, size_t out_size, const char *label, size_t llen,
+    const u_char *context, size_t ctxlen, char **err)
+{
+#if defined(OPENSSL_IS_BORINGSSL) || OPENSSL_VERSION_NUMBER < 0x10101000L
+    *err = "BoringSSL does not support SSL_export_keying_material";
+    return NGX_ERROR;
+#elif defined(LIBRESSL_VERSION_NUMBER)
+    *err = "LibreSSL does not support SSL_export_keying_material";
+    return NGX_ERROR;
+#elif OPENSSL_VERSION_NUMBER < 0x10101000L
+    *err = "OpenSSL too old";
+    return NGX_ERROR;
+#else
+    int                  rc;
+    ngx_ssl_conn_t      *ssl_conn;
+    ngx_connection_t    *c;
+
+    c = r->connection;
+    if (c == NULL || c->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = c->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl connection";
+        return NGX_ERROR;
+    }
+
+    rc = SSL_export_keying_material_early(ssl_conn, out, out_size,
+                                          label, llen, context, ctxlen);
+
+    if (rc == 1) {
+        return NGX_OK;
+    }
+
+    ngx_ssl_error(NGX_LOG_INFO, c->log, 0,
+                  "SSL_export_keying_material_early rc: %d, error: %s",
+                  rc, ERR_error_string(ERR_get_error(), NULL));
+
+    *err = "SSL_export_keying_material_early() failed";
+
+    return NGX_ERROR;
+#endif
+}
+
+#endif /* NGX_HTTP_SSL */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_export_keying_material.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_export_keying_material.h
@@ -1,0 +1,24 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef _NGX_HTTP_LUA_SSL_EXPORT_KEYING_MATERIAL_H_INCLUDED_
+#define _NGX_HTTP_LUA_SSL_EXPORT_KEYING_MATERIAL_H_INCLUDED_
+
+#include "ngx_http_lua_common.h"
+
+#if (NGX_HTTP_SSL)
+ngx_int_t ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
+    u_char *out, size_t out_size, const char *label, size_t llen,
+    const u_char *ctx, size_t ctxlen, int use_ctx, char **err);
+
+ngx_int_t ngx_http_lua_ffi_ssl_export_keying_material_early(
+    ngx_http_request_t *r, u_char *out, size_t out_size, const char *label,
+    size_t llen, const u_char *ctx, size_t ctxlen, char **err);
+#endif
+
+#endif /* _NGX_HTTP_LUA_SSL_EXPORT_KEYING_MATERIAL_H_INCLUDED_ */
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_ocsp.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_ocsp.c
@@ -19,8 +19,9 @@
 #ifdef NGX_HTTP_LUA_USE_OCSP
 static int ngx_http_lua_ssl_empty_status_callback(ngx_ssl_conn_t *ssl_conn,
     void *data);
-#endif
 
+static long ngx_http_lua_ssl_stapling_time(ASN1_GENERALIZEDTIME *asn1time);
+#endif
 
 int
 ngx_http_lua_ffi_ssl_get_ocsp_responder_from_der_chain(
@@ -262,7 +263,7 @@ failed:
 int
 ngx_http_lua_ffi_ssl_validate_ocsp_response(const u_char *resp,
     size_t resp_len, const char *chain_data, size_t chain_len,
-    u_char *errbuf, size_t *errbuf_size)
+    u_char *errbuf, size_t *errbuf_size, long *valid)
 {
 #ifndef NGX_HTTP_LUA_USE_OCSP
 
@@ -279,7 +280,7 @@ ngx_http_lua_ffi_ssl_validate_ocsp_response(const u_char *resp,
     OCSP_RESPONSE         *ocsp = NULL;
     OCSP_BASICRESP        *basic = NULL;
     STACK_OF(X509)        *chain = NULL;
-    ASN1_GENERALIZEDTIME  *thisupdate, *nextupdate;
+    ASN1_GENERALIZEDTIME  *thisupdate = NULL, *nextupdate = NULL;
 
     ocsp = d2i_OCSP_RESPONSE(NULL, &resp, resp_len);
     if (ocsp == NULL) {
@@ -383,6 +384,16 @@ ngx_http_lua_ffi_ssl_validate_ocsp_response(const u_char *resp,
         goto error;
     }
 
+    if (nextupdate) {
+        *valid = ngx_http_lua_ssl_stapling_time(nextupdate);
+        if (*valid == NGX_ERROR) {
+            *errbuf_size = ngx_snprintf(errbuf, *errbuf_size,
+                                        "invalid nextUpdate time "
+                                        "in certificate status") - errbuf;
+            goto error;
+        }
+    }
+
     sk_X509_free(chain);
     X509_free(cert);
     X509_free(issuer);
@@ -436,6 +447,40 @@ static int
 ngx_http_lua_ssl_empty_status_callback(ngx_ssl_conn_t *ssl_conn, void *data)
 {
     return SSL_TLSEXT_ERR_OK;
+}
+
+
+static long
+ngx_http_lua_ssl_stapling_time(ASN1_GENERALIZEDTIME *asn1time)
+{
+    BIO     *bio;
+    char    *value;
+    size_t   len;
+    time_t   time;
+
+    /*
+     * OpenSSL doesn't provide a way to convert ASN1_GENERALIZEDTIME
+     * into long.  To do this, we use ASN1_GENERALIZEDTIME_print(),
+     * which uses the "MMM DD HH:MM:SS YYYY [GMT]" format (e.g.,
+     * "Feb  3 00:55:52 2015 GMT"), and parse the result.
+     */
+
+    bio = BIO_new(BIO_s_mem());
+    if (bio == NULL) {
+        return NGX_ERROR;
+    }
+
+    /* fake weekday prepended to match C asctime() format */
+
+    BIO_write(bio, "Tue ", sizeof("Tue ") - 1);
+    ASN1_GENERALIZEDTIME_print(bio, asn1time);
+    len = BIO_get_mem_data(bio, &value);
+
+    time = ngx_parse_http_time((u_char *) value, len);
+
+    BIO_free(bio);
+
+    return time;
 }
 #endif
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_ssl_session_fetchby.c
@@ -416,7 +416,7 @@ ngx_http_lua_ssl_sess_fetch_aborted(void *data)
 {
     ngx_http_lua_ssl_ctx_t          *cctx = data;
 
-    dd("lua ssl sess_fetch done");
+    dd("lua ssl sess_fetch aborted");
 
     if (cctx->done) {
         /* completed successfully already */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_string.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_string.c
@@ -424,6 +424,26 @@ ngx_http_lua_ffi_decode_base64(const u_char *src, size_t slen, u_char *dst,
 }
 
 
+int
+ngx_http_lua_ffi_decode_base64mime(const u_char *src, size_t slen, u_char *dst,
+    size_t *dlen)
+{
+    ngx_int_t      rc;
+    ngx_str_t      in, out;
+
+    in.data = (u_char *) src;
+    in.len = slen;
+
+    out.data = dst;
+
+    rc = ngx_http_lua_decode_base64mime(&out, &in);
+
+    *dlen = out.len;
+
+    return rc == NGX_OK;
+}
+
+
 size_t
 ngx_http_lua_ffi_unescape_uri(const u_char *src, size_t len, u_char *dst)
 {

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_subrequest.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_subrequest.c
@@ -52,6 +52,8 @@ ngx_str_t  ngx_http_lua_patch_method =
 ngx_str_t  ngx_http_lua_trace_method =
         ngx_http_lua_method_name("TRACE");
 
+ngx_str_t host_header = ngx_string("host");
+
 
 static ngx_str_t  ngx_http_lua_content_length_header_key =
     ngx_string("Content-Length");
@@ -60,10 +62,10 @@ static ngx_str_t  ngx_http_lua_content_length_header_key =
 static ngx_int_t ngx_http_lua_adjust_subrequest(ngx_http_request_t *sr,
     ngx_uint_t method, int forward_body,
     ngx_http_request_body_t *body, unsigned vars_action,
-    ngx_array_t *extra_vars);
+    ngx_array_t *extra_vars, ngx_array_t *extra_headers);
 static int ngx_http_lua_ngx_location_capture(lua_State *L);
 static int ngx_http_lua_ngx_location_capture_multi(lua_State *L);
-static void ngx_http_lua_process_vars_option(ngx_http_request_t *r,
+static void ngx_http_lua_process_keyval_option(ngx_http_request_t *r,
     lua_State *L, int table, ngx_array_t **varsp);
 static ngx_int_t ngx_http_lua_subrequest_add_extra_vars(ngx_http_request_t *r,
     ngx_array_t *extra_vars);
@@ -77,7 +79,7 @@ static void ngx_http_lua_cancel_subreq(ngx_http_request_t *r);
 static ngx_int_t ngx_http_post_request_to_head(ngx_http_request_t *r);
 static ngx_int_t ngx_http_lua_copy_in_file_request_body(ngx_http_request_t *r);
 static ngx_int_t ngx_http_lua_copy_request_headers(ngx_http_request_t *sr,
-    ngx_http_request_t *pr, int pr_not_chunked);
+    ngx_http_request_t *pr, int pr_not_chunked, ngx_array_t *extra_headers);
 
 
 enum {
@@ -125,6 +127,7 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
     ngx_http_lua_ctx_t              *sr_ctx;
     ngx_http_lua_ctx_t              *ctx;
     ngx_array_t                     *extra_vars;
+    ngx_array_t                     *extra_headers;
     ngx_str_t                        uri;
     ngx_str_t                        args;
     ngx_str_t                        extra_args;
@@ -170,12 +173,11 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
         return luaL_error(L, "no request object found");
     }
 
-#if (NGX_HTTP_V2)
-    if (r->main->stream) {
-        return luaL_error(L, "http2 requests not supported yet");
-    }
-#endif
-
+/*
+ * Upstream dropped its HTTP/2 guard here once subrequests worked over v2.
+ * The xquic HTTP/3 path is a separate implementation that never got that
+ * work, so it keeps rejecting instead of silently misbehaving.
+ */
 #if (T_NGX_XQUIC)
     if (r->main->xqstream) {
         return luaL_error(L, "http3 requests not supported yet");
@@ -228,6 +230,7 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
     coctx->pending_subreqs = 0;
 
     extra_vars = NULL;
+    extra_headers = NULL;
 
     for (index = 0; index < nsubreqs; index++) {
         coctx->pending_subreqs++;
@@ -265,6 +268,11 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
         if (extra_vars != NULL) {
             /* flush out existing elements in the array */
             extra_vars->nelts = 0;
+        }
+
+        if (extra_headers != NULL) {
+            /* flush out existing elements in the array */
+            extra_headers->nelts = 0;
         }
 
         vars_action = 0;
@@ -322,7 +330,7 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
 
             switch (lua_type(L, -1)) {
             case LUA_TTABLE:
-                ngx_http_lua_process_vars_option(r, L, -1, &extra_vars);
+                ngx_http_lua_process_keyval_option(r, L, -1, &extra_vars);
 
                 dd("post process vars top: %d", lua_gettop(L));
                 break;
@@ -336,6 +344,29 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
             }
 
             lua_pop(L, 1);
+
+            dd("queries query uri opts: %d", lua_gettop(L));
+
+            /* check the headers option */
+
+            lua_getfield(L, 4, "headers");
+
+            switch (lua_type(L, -1)) {
+            case LUA_TTABLE:
+                ngx_http_lua_process_keyval_option(r, L, -1, &extra_headers);
+
+                dd("post process vars top: %d", lua_gettop(L));
+                break;
+
+            case LUA_TNIL:
+                /* do nothing */
+                break;
+
+            default:
+                return luaL_error(L, "Bad headers option value");
+            }
+
+            lua_pop(L, 1); /* pop the headers */
 
             dd("queries query uri opts: %d", lua_gettop(L));
 
@@ -599,7 +630,8 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
         ngx_http_set_ctx(sr, sr_ctx, ngx_http_lua_module);
 
         rc = ngx_http_lua_adjust_subrequest(sr, method, always_forward_body,
-                                            body, vars_action, extra_vars);
+                                            body, vars_action, extra_vars,
+                                            extra_headers);
 
         if (rc != NGX_OK) {
             ngx_http_lua_cancel_subreq(sr);
@@ -635,7 +667,7 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
 static ngx_int_t
 ngx_http_lua_adjust_subrequest(ngx_http_request_t *sr, ngx_uint_t method,
     int always_forward_body, ngx_http_request_body_t *body,
-    unsigned vars_action, ngx_array_t *extra_vars)
+    unsigned vars_action, ngx_array_t *extra_vars, ngx_array_t *extra_headers)
 {
     ngx_http_request_t          *r;
     ngx_http_core_main_conf_t   *cmcf;
@@ -671,7 +703,9 @@ ngx_http_lua_adjust_subrequest(ngx_http_request_t *sr, ngx_uint_t method,
         }
     }
 
-    if (ngx_http_lua_copy_request_headers(sr, r, pr_not_chunked) != NGX_OK) {
+    if (ngx_http_lua_copy_request_headers(sr, r, pr_not_chunked, extra_headers)
+        != NGX_OK)
+    {
         return NGX_ERROR;
     }
 
@@ -886,7 +920,7 @@ ngx_http_lua_subrequest_add_extra_vars(ngx_http_request_t *sr,
 
 
 static void
-ngx_http_lua_process_vars_option(ngx_http_request_t *r, lua_State *L,
+ngx_http_lua_process_keyval_option(ngx_http_request_t *r, lua_State *L,
     int table, ngx_array_t **varsp)
 {
     ngx_array_t         *vars;
@@ -1653,10 +1687,11 @@ ngx_http_lua_copy_in_file_request_body(ngx_http_request_t *r)
 
 static ngx_int_t
 ngx_http_lua_copy_request_headers(ngx_http_request_t *sr,
-    ngx_http_request_t *pr, int pr_not_chunked)
+    ngx_http_request_t *pr, int pr_not_chunked, ngx_array_t *extra_headers)
 {
     ngx_table_elt_t                 *clh, *header;
     ngx_list_part_t                 *part;
+    ngx_keyval_t                    *header_keyval;
     ngx_chain_t                     *in;
     ngx_uint_t                       i;
     u_char                          *p;
@@ -1687,6 +1722,9 @@ ngx_http_lua_copy_request_headers(ngx_http_request_t *sr,
 
         clh->hash = ngx_http_lua_content_length_hash;
         clh->key = ngx_http_lua_content_length_header_key;
+#if defined(nginx_version) && nginx_version >= 1023000
+        clh->next = NULL;
+#endif
         clh->lowcase_key = ngx_pnalloc(sr->pool, clh->key.len);
         if (clh->lowcase_key == NULL) {
             return NGX_ERROR;
@@ -1716,6 +1754,17 @@ ngx_http_lua_copy_request_headers(ngx_http_request_t *sr,
     part = &pr->headers_in.headers.part;
     header = part->elts;
 
+#if (NGX_HTTP_V3)
+    if (pr->headers_in.server.data != NULL) {
+        if (ngx_http_lua_set_input_header(sr, host_header,
+                                          pr->headers_in.server, 0)
+            == NGX_ERROR)
+        {
+            return NGX_ERROR;
+        }
+    }
+#endif
+
     for (i = 0; /* void */; i++) {
 
         if (i >= part->nelts) {
@@ -1743,6 +1792,20 @@ ngx_http_lua_copy_request_headers(ngx_http_request_t *sr,
                                           header[i].value, 0) == NGX_ERROR)
         {
             return NGX_ERROR;
+        }
+    }
+
+    if (extra_headers && extra_headers->nelts > 0) {
+
+        header_keyval = extra_headers->elts;
+
+        for (i = 0; i < extra_headers->nelts; i++, header_keyval++) {
+
+            if (ngx_http_lua_set_input_header(sr, header_keyval->key,
+                                        header_keyval->value, 1) == NGX_ERROR)
+            {
+                return NGX_ERROR;
+            }
         }
     }
 

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_util.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_util.c
@@ -49,6 +49,10 @@
 #if (NGX_THREADS)
 #include "ngx_http_lua_worker_thread.h"
 #endif
+#if (NGX_HTTP_V3)
+#include <ngx_event_quic.h>
+#include <ngx_event_quic_connection.h>
+#endif
 
 
 #if 1
@@ -549,6 +553,10 @@ ngx_http_lua_send_header_if_needed(ngx_http_request_t *r,
         if (!ctx->buffering) {
             dd("sending headers");
             rc = ngx_http_send_header(r);
+            if (r->filter_finalize) {
+                ngx_http_set_ctx(r, ctx, ngx_http_lua_module);
+            }
+
             ctx->header_sent = 1;
             return rc;
         }
@@ -598,6 +606,12 @@ ngx_http_lua_send_chain_link(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx,
 
     if (r->header_only) {
         ctx->eof = 1;
+
+        if (!r->request_body && r == r->main) {
+            if (ngx_http_discard_request_body(r) != NGX_OK) {
+                return NGX_ERROR;
+            }
+        }
 
         if (ctx->buffering) {
             return ngx_http_lua_send_http10_headers(r, ctx);
@@ -754,10 +768,6 @@ ngx_http_lua_send_http10_headers(ngx_http_request_t *r,
         }
 
         r->headers_out.content_length_n = size;
-
-        if (r->headers_out.content_length) {
-            r->headers_out.content_length->hash = 0;
-        }
     }
 
 send:
@@ -1673,6 +1683,12 @@ no_parent:
 
 done:
 
+#ifdef HAVE_PROXY_SSL_PATCH
+    if (ctx->context == NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY) {
+        return NGX_OK;
+    }
+#endif
+
     if (ctx->entered_content_phase
         && r->connection->fd != (ngx_socket_t) -1)
     {
@@ -2427,6 +2443,12 @@ ngx_http_lua_handle_exit(lua_State *L, ngx_http_request_t *r,
     if (r->connection->fd == (ngx_socket_t) -1) {  /* fake request */
         return ctx->exit_code;
     }
+
+#ifdef HAVE_PROXY_SSL_PATCH
+    if (ctx->context == NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY) {
+        return ctx->exit_code;
+    }
+#endif
 
 #if 1
     if (!r->header_sent
@@ -3669,11 +3691,45 @@ void
 ngx_http_lua_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
 {
     ngx_http_lua_ctx_t              *ctx;
+#if (NGX_HTTP_SSL)
+#ifdef HAVE_PROXY_SSL_PATCH
+    ngx_http_upstream_t             *u;
+    ngx_connection_t                *c;
+    ngx_http_lua_ssl_ctx_t          *cctx;
+#endif
+#endif
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
     if (ctx && ctx->cur_co_ctx) {
         ngx_http_lua_cleanup_pending_operation(ctx->cur_co_ctx);
     }
+
+#if (NGX_HTTP_SSL)
+#ifdef HAVE_PROXY_SSL_PATCH
+    u = r->upstream;
+    if (u) {
+        c = u->peer.connection;
+        if (c && c->ssl) {
+            cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
+            if (cctx && cctx->pool) {
+                if (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+                    cctx->exit_code = 0;
+                }
+
+                if (r->main->count > cctx->original_request_count) {
+                    r->main->count--;
+                    return;
+                }
+
+                ngx_destroy_pool(cctx->pool);
+                cctx->pool = NULL;
+
+                return;
+            }
+        }
+    }
+#endif
+#endif
 
     if (r->connection->fd != (ngx_socket_t) -1) {
         ngx_http_finalize_request(r, rc);
@@ -3826,6 +3882,18 @@ ngx_http_lua_close_fake_connection(ngx_connection_t *c)
     c->read->closed = 1;
     c->write->closed = 1;
 
+    /* When destroying the pool, the registered clean callbacks will be
+     * executed. If the ngx_connection_t is freed before these callbacks are
+     * run, and a new ngx_connection_t is created within a clean callback,
+     * it is possible for the freed ngx_connection_t to be reused again.
+     * If this reused ngx_connection_t is destroyed again within the clean
+     * callback logic, it may result in other clean callbacks holding a
+     * ngx_connection_t that has already been destroyed.
+     */
+    if (pool) {
+        ngx_destroy_pool(pool);
+    }
+
     /* we temporarily use a valid fd (0) to make ngx_free_connection happy */
 
     c->fd = 0;
@@ -3840,10 +3908,6 @@ ngx_http_lua_close_fake_connection(ngx_connection_t *c)
 
     if (ngx_cycle->files) {
         ngx_cycle->files[0] = saved_c;
-    }
-
-    if (pool) {
-        ngx_destroy_pool(pool);
     }
 }
 
@@ -4403,6 +4467,86 @@ ngx_http_lua_copy_escaped_header(ngx_http_request_t *r,
 }
 
 
+ngx_int_t
+ngx_http_lua_decode_base64mime(ngx_str_t *dst, ngx_str_t *src)
+{
+    size_t          i;
+    u_char         *d, *s, ch;
+    size_t          data_len = 0;
+    u_char          buf[4];
+    size_t          buf_len = 0;
+    static u_char   basis[] = {
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 62, 77, 77, 77, 63,
+        52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 77, 77, 77, 77, 77, 77,
+        77,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 77, 77, 77, 77, 77,
+        77, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+        41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 77, 77, 77, 77, 77,
+
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+        77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77
+    };
+
+    for (i = 0; i < src->len; i++) {
+        ch = src->data[i];
+        if (ch == '=') {
+            break;
+        }
+
+        if (basis[ch] == 77) {
+            continue;
+        }
+
+        data_len++;
+    }
+
+    if (data_len % 4 == 1) {
+        return NGX_ERROR;
+    }
+
+    s = src->data;
+    d = dst->data;
+
+    for (i = 0; i < src->len; i++) {
+        if (s[i] == '=') {
+            break;
+        }
+
+        if (basis[s[i]] == 77) {
+            continue;
+        }
+
+        buf[buf_len++] = s[i];
+        if (buf_len == 4) {
+            *d++ = (u_char) (basis[buf[0]] << 2 | basis[buf[1]] >> 4);
+            *d++ = (u_char) (basis[buf[1]] << 4 | basis[buf[2]] >> 2);
+            *d++ = (u_char) (basis[buf[2]] << 6 | basis[buf[3]]);
+            buf_len = 0;
+        }
+    }
+
+    if (buf_len > 1) {
+        *d++ = (u_char) (basis[buf[0]] << 2 | basis[buf[1]] >> 4);
+    }
+
+    if (buf_len > 2) {
+        *d++ = (u_char) (basis[buf[1]] << 4 | basis[buf[2]] >> 2);
+    }
+
+    dst->len = d - dst->data;
+
+    return NGX_OK;
+}
+
+
 ngx_addr_t *
 ngx_http_lua_parse_addr(lua_State *L, u_char *text, size_t len)
 {
@@ -4474,5 +4618,70 @@ ngx_http_lua_parse_addr(lua_State *L, u_char *text, size_t len)
     return addr;
 }
 
+
+void
+ngx_http_lua_ffi_bypass_if_checks(ngx_http_request_t *r)
+{
+    r->disable_not_modified = 1;
+}
+
+
+#if (HAVE_QUIC_SSL_LUA_YIELD_PATCH && NGX_HTTP_V3)
+void
+ngx_http_lua_resume_quic_ssl_handshake(ngx_connection_t *c)
+{
+    ngx_int_t        rc, sslerr;
+    ngx_ssl_conn_t  *ssl_conn;
+
+    if (c == NULL || c->ssl == NULL || c->ssl->connection == NULL) {
+        return;
+    }
+
+    if (!c->udp || c->read == NULL
+        || c->read->handler != ngx_quic_input_handler)
+    {
+        return;
+    }
+
+    ssl_conn = c->ssl->connection;
+
+    /* Openresty ssl lua scripts are triggered by registering callbacks into
+     * openssl. If a lua script calls a yield api during execution, openssl's
+     * SSL_do_handshake will return a specific error code. The application
+     * should not treat these codes as fatal. The lua script will resume on
+     * yield-related events until it finishes. After completion,
+     * SSL_do_handshake should be called again to advance openssl's state
+     * machine.
+     *
+     * Note that nginx quic and openresty ssl lua scripts are independent. When
+     * openresty ssl lua runs, the client is waiting for a server response, so
+     * nginx quic does not affect the execution of the lua script. After the lua
+     * script finishes, SSL_do_handshake is called again, and nginx quic's
+     * registered callback continues the handshake.
+     */
+    rc = SSL_do_handshake(ssl_conn);
+    sslerr = SSL_get_error(ssl_conn, rc);
+
+    if (rc <= 0 && sslerr != SSL_ERROR_WANT_READ
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+        && sslerr != SSL_ERROR_WANT_X509_LOOKUP
+#endif
+#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
+        && sslerr != SSL_ERROR_WANT_CLIENT_HELLO_CB
+#endif
+    ) {
+        /* If a fatal error occurs or lua script exits with error during quic
+         * handshake, the quic connection will be closed immediately.
+         */
+        ngx_quic_close_connection(c, NGX_ERROR);
+
+    } else {
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "lua resuming quic ssl handshake: rc %d, err %d, will "
+                       "continue driving handshake or next lua script phase",
+                       rc, sslerr);
+    }
+}
+#endif
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_util.h
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_util.h
@@ -32,6 +32,20 @@
 
 #define NGX_HTTP_LUA_ESCAPE_HEADER_VALUE  8
 
+#ifdef HAVE_PROXY_SSL_PATCH
+
+#define NGX_HTTP_LUA_CONTEXT_YIELDABLE (NGX_HTTP_LUA_CONTEXT_REWRITE         \
+                                | NGX_HTTP_LUA_CONTEXT_SERVER_REWRITE        \
+                                | NGX_HTTP_LUA_CONTEXT_ACCESS                \
+                                | NGX_HTTP_LUA_CONTEXT_CONTENT               \
+                                | NGX_HTTP_LUA_CONTEXT_TIMER                 \
+                                | NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY      \
+                                | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO      \
+                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT              \
+                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH)
+
+#else
+
 #define NGX_HTTP_LUA_CONTEXT_YIELDABLE (NGX_HTTP_LUA_CONTEXT_REWRITE         \
                                 | NGX_HTTP_LUA_CONTEXT_SERVER_REWRITE        \
                                 | NGX_HTTP_LUA_CONTEXT_ACCESS                \
@@ -41,10 +55,40 @@
                                 | NGX_HTTP_LUA_CONTEXT_SSL_CERT              \
                                 | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH)
 
+#endif  /* HAVE_PROXY_SSL_PATCH */
+
 
 /* key in Lua vm registry for all the "ngx.ctx" tables */
 #define ngx_http_lua_ctx_tables_key  "ngx_lua_ctx_tables"
 
+
+#ifdef HAVE_PROXY_SSL_PATCH
+
+#define ngx_http_lua_context_name(c)                                         \
+    ((c) == NGX_HTTP_LUA_CONTEXT_SET ? "set_by_lua*"                         \
+     : (c) == NGX_HTTP_LUA_CONTEXT_REWRITE ? "rewrite_by_lua*"               \
+     : (c) == NGX_HTTP_LUA_CONTEXT_SERVER_REWRITE ? "server_rewrite_by_lua*" \
+     : (c) == NGX_HTTP_LUA_CONTEXT_ACCESS ? "access_by_lua*"                 \
+     : (c) == NGX_HTTP_LUA_CONTEXT_CONTENT ? "content_by_lua*"               \
+     : (c) == NGX_HTTP_LUA_CONTEXT_LOG ? "log_by_lua*"                       \
+     : (c) == NGX_HTTP_LUA_CONTEXT_HEADER_FILTER ? "header_filter_by_lua*"   \
+     : (c) == NGX_HTTP_LUA_CONTEXT_BODY_FILTER ? "body_filter_by_lua*"       \
+     : (c) == NGX_HTTP_LUA_CONTEXT_TIMER ? "ngx.timer"                       \
+     : (c) == NGX_HTTP_LUA_CONTEXT_INIT_WORKER ? "init_worker_by_lua*"       \
+     : (c) == NGX_HTTP_LUA_CONTEXT_EXIT_WORKER ? "exit_worker_by_lua*"       \
+     : (c) == NGX_HTTP_LUA_CONTEXT_BALANCER ? "balancer_by_lua*"             \
+     : (c) == NGX_HTTP_LUA_CONTEXT_PROXY_SSL_VERIFY ?                        \
+                                                 "proxy_ssl_verify_by_lua*"  \
+     : (c) == NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO ?                        \
+                                                 "ssl_client_hello_by_lua*"  \
+     : (c) == NGX_HTTP_LUA_CONTEXT_SSL_CERT ? "ssl_certificate_by_lua*"      \
+     : (c) == NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE ?                          \
+                                                 "ssl_session_store_by_lua*" \
+     : (c) == NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH ?                          \
+                                                 "ssl_session_fetch_by_lua*" \
+     : "(unknown)")
+
+#else
 
 #define ngx_http_lua_context_name(c)                                         \
     ((c) == NGX_HTTP_LUA_CONTEXT_SET ? "set_by_lua*"                         \
@@ -67,6 +111,8 @@
      : (c) == NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH ?                          \
                                                  "ssl_session_fetch_by_lua*" \
      : "(unknown)")
+
+#endif  /* HAVE_PROXY_SSL_PATCH */
 
 
 #define ngx_http_lua_check_context(L, ctx, flags)                            \
@@ -261,10 +307,15 @@ void ngx_http_lua_cleanup_free(ngx_http_request_t *r,
 #if (NGX_HTTP_LUA_HAVE_SA_RESTART)
 void ngx_http_lua_set_sa_restart(ngx_log_t *log);
 #endif
+ngx_int_t ngx_http_lua_decode_base64mime(ngx_str_t *dst, ngx_str_t *src);
 
 ngx_addr_t *ngx_http_lua_parse_addr(lua_State *L, u_char *text, size_t len);
 
 size_t ngx_http_lua_escape_log(u_char *dst, u_char *src, size_t size);
+
+#if (HAVE_QUIC_SSL_LUA_YIELD_PATCH && NGX_HTTP_V3)
+void ngx_http_lua_resume_quic_ssl_handshake(ngx_connection_t *c);
+#endif
 
 
 static ngx_inline void

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_variable.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_variable.c
@@ -70,6 +70,18 @@ ngx_http_lua_ffi_var_get(ngx_http_request_t *r, u_char *name_data,
     }
 #endif
 
+#if (NGX_HTTP_V3)
+    if (name_len == 9
+        && r->http_version == NGX_HTTP_VERSION_30
+        && ngx_strncasecmp(name_data, (u_char *) "http_host", 9) == 0
+        && r->headers_in.server.data != NULL)
+    {
+        *value = r->headers_in.server.data;
+        *value_len = r->headers_in.server.len;
+        return NGX_OK;
+    }
+#endif
+
     hash = ngx_hash_strlow(lowcase_buf, name_data, name_len);
 
     name.data = lowcase_buf;

--- a/modules/ngx_http_lua_module/src/ngx_http_lua_worker_thread.c
+++ b/modules/ngx_http_lua_module/src/ngx_http_lua_worker_thread.c
@@ -42,7 +42,7 @@ typedef struct {
     ngx_http_lua_co_ctx_t   *wait_co_ctx;
     int                      n_args;
     int                      rc;
-    int                      is_abort:1;
+    ngx_uint_t               is_abort:1;
 } ngx_http_lua_worker_thread_ctx_t;
 
 
@@ -157,15 +157,6 @@ ngx_http_lua_get_task_ctx(lua_State *L, ngx_http_request_t *r)
         ngx_http_lua_inject_shdict_api(lmcf, vm);
         lua_setglobal(vm, "ngx");
 
-        /* inject API via ffi */
-        lua_getglobal(vm, "require");
-        lua_pushstring(vm, "resty.core.regex");
-        if (lua_pcall(vm, 1, 0, 0) != 0) {
-            lua_close(vm);
-            ngx_free(ctx);
-            return NULL;
-        }
-
         lua_getglobal(vm, "require");
         lua_pushstring(vm, "resty.core.hash");
         if (lua_pcall(vm, 1, 0, 0) != 0) {
@@ -203,11 +194,21 @@ ngx_http_lua_get_task_ctx(lua_State *L, ngx_http_request_t *r)
 static void
 ngx_http_lua_free_task_ctx(ngx_http_lua_task_ctx_t *ctx)
 {
+    lua_State   *vm;
+
     ctx->next = ctxpool->next;
     ctxpool->next = ctx;
 
     /* clean Lua stack */
-    lua_settop(ctx->vm, 0);
+    vm = ctx->vm;
+
+    /* call collectgarbage("collect") */
+    lua_settop(vm, 0);
+    lua_getglobal(vm, "collectgarbage");
+    lua_pushstring(vm, "collect");
+    lua_pcall(vm, 1, 1, 0);
+
+    lua_settop(vm, 0);
 }
 
 

--- a/packages/build/fetch-deps.sh
+++ b/packages/build/fetch-deps.sh
@@ -29,6 +29,7 @@ PRINT_CHECKSUMS=no
 
 die() { printf '%s: error: %s\n' "${0##*/}" "$*" >&2; exit 1; }
 info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m==>\033[0m %s\n' "$*" >&2; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -53,13 +54,39 @@ else
     die "no sha256 tool found (need sha256sum, shasum or openssl)"
 fi
 
+DOWNLOAD_TRIES=3
+DOWNLOAD_DELAY=3
+
 if command -v curl >/dev/null 2>&1; then
-    download() { curl -fsSL -o "$2" "$1"; }
+    fetch_to() { curl -fsSL --connect-timeout 20 --retry 2 --retry-delay 2 -o "$2" "$1"; }
 elif command -v wget >/dev/null 2>&1; then
-    download() { wget -qO "$2" "$1"; }
+    fetch_to() { wget -q --timeout=20 --tries=2 --waitretry=2 -O "$2" "$1"; }
 else
     die "neither curl nor wget found"
 fi
+
+# Retrying in the shell rather than leaving it to curl: a truncated HTTP/2
+# stream exits 18, which --retry does not consider transient, and covering it
+# with --retry-all-errors would need curl 7.71 (newer than el7 ships).  Without
+# an outer retry a single network hiccup fails a whole packaging run.
+#
+# A failed attempt can leave a partial file behind, which the caller would then
+# hash as if it were complete, so drop it before retrying.
+download() {
+    _try=1
+    while :; do
+        if fetch_to "$1" "$2"; then
+            return 0
+        fi
+        rm -f "$2"
+        if [ "$_try" -ge "$DOWNLOAD_TRIES" ]; then
+            return 1
+        fi
+        warn "download failed, retrying in ${DOWNLOAD_DELAY}s ($_try/$DOWNLOAD_TRIES)"
+        _try=$((_try + 1))
+        sleep "$DOWNLOAD_DELAY"
+    done
+}
 
 mkdir -p "$OUTDIR"
 


### PR DESCRIPTION
## 问题

ngx_http_lua_module 0.10.25 不支持 PCRE2，无条件 include PCRE1 专有的
`<pcre.h>`。发行版软件包与容器镜像装的都是 PCRE2 开发包，rpm、deb、apk
与镜像构建因此全部失败。CI 未暴露该问题，因为它装的是 libpcre3-dev。

## 改动

- **Lua: update ngx_http_lua_module to 0.10.29** — PCRE2 支持自 0.10.26
  起提供，但 lua-resty-core 以严格相等校验 ngx_lua 版本，deps.env pin 的
  v0.1.32 只接受 10029，故版本必须是 0.10.29。
- **CI: align lua-resty-core with ngx_http_lua_module 0.10.29** — 三个测试
  workflow 原先 pin v0.1.27（只接受 10025），升级后会启动即退出。
- **CI: pin the luajit2 and lua-resty-lrucache checkouts** — 原先 checkout
  默认分支，构建内容随上游漂移。
- **Build: retry dependency downloads in fetch-deps.sh** — 裸的 curl 调用
  没有重试，一次网络抖动即导致整个打包流程失败。
