### PR TITLE
Fix the PCRE2 build failure of ngx_http_lua_module

### DIFF
--- a/.github/scripts/verify-image.sh
+++ b/.github/scripts/verify-image.sh
@@ -57,6 +57,9 @@ ok "tengine -t passes"
 # resty.core is required by ngx_http_lua_module at startup, and cjson is a
 # compiled C module, so this one request exercises both lua_package_path and
 # lua_package_cpath -- the two settings most likely to be wrong in a package.
+# The same request also names the regex engine: ngx_http_lua_module only gained
+# PCRE2 support in 0.10.26, and the distro packages all build against PCRE2, so
+# a downgrade of either would break the build again without this check.
 workdir=$(mktemp -d)
 cid=""
 # ${cid:-} because the trap can fire before the container is started.
@@ -70,7 +73,14 @@ server {
         content_by_lua_block {
             require "resty.core"
             local cjson = require "cjson"
-            ngx.say(cjson.encode({ lua = "ok", jit = jit and jit.version or "none" }))
+            -- An invalid pattern makes the regex engine name itself in the
+            -- error string: pcre2_compile() on PCRE2, pcre_compile() on PCRE1.
+            local _, re_err = ngx.re.match("x", "(")
+            ngx.say(cjson.encode({
+                lua = "ok",
+                jit = jit and jit.version or "none",
+                regex = re_err or "no error",
+            }))
         }
     }
 }
@@ -103,6 +113,10 @@ esac
 case "$lua_out" in
     *LuaJIT*) ok "LuaJIT is the Lua VM" ;;
     *)        fail "not running on LuaJIT: $lua_out" ;;
+esac
+case "$lua_out" in
+    *pcre2_compile*) ok "Lua regexes run on PCRE2" ;;
+    *)               fail "Lua regexes are not on PCRE2: $lua_out" ;;
 esac
 
 echo "all checks passed for $IMAGE"

--- a/packages/build/build-deps.sh
+++ b/packages/build/build-deps.sh
@@ -163,8 +163,14 @@ if [ "$WITH_TONGSUO" = yes ]; then
         info "building Tongsuo (static, NTLS enabled)"
         # -fPIC is explicit: the archives get linked into libxquic.so, and a
         # no-shared OpenSSL build does not guarantee position independent code.
+        #
+        # Only the archives are wanted here, so stop at build_libs and skip the
+        # test suite: xquic links libssl.a/libcrypto.a, and Tengine's configure
+        # rebuilds this tree from scratch anyway. Building apps/ and test/ would
+        # add a large amount of compile time -- painful with an el7-era gcc --
+        # and one more chance to fail on code the package never ships.
         ( cd "$tongsuo_src" && ./config --prefix=/usr/local/tongsuo \
-            enable-ntls no-shared -fPIC && make -j"$JOBS" )
+            enable-ntls no-shared no-tests -fPIC && make -j"$JOBS" build_libs )
     fi
 
     emit "export TENGINE_TONGSUO_SRC=$tongsuo_src"

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -178,6 +178,36 @@ deps_disable_args() {
 
 # ------------------------------------------------------------------ rpm build
 
+# Is a CMake >= 3.5 reachable on PATH? Deliberately mirrors build-deps.sh's
+# find_cmake, since that is the code which will actually run it.
+cmake_binary_ok() {
+    for c in cmake3 cmake; do
+        command -v "$c" >/dev/null 2>&1 || continue
+        v=$("$c" --version 2>/dev/null | head -n 1 | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
+        [ -n "$v" ] || continue
+        if [ "$(printf '%s\n3.5\n' "$v" | sort -V | head -n 1)" = "3.5" ]; then
+            echo yes
+            return
+        fi
+    done
+    echo no
+}
+
+# Does rpm itself own a CMake new enough for the spec's BuildRequires? `rpm -q`
+# prints "package foo is not installed" on stdout and exits non-zero, hence both
+# the `||` and the leading-digit check.
+cmake_rpm_ok() {
+    for p in cmake3 cmake; do
+        v=$(rpm -q --qf '%{VERSION}\n' "$p" 2>/dev/null | head -n 1) || continue
+        case "$v" in [0-9]*) ;; *) continue ;; esac
+        if [ "$(printf '%s\n3.5\n' "$v" | sort -V | head -n 1)" = "3.5" ]; then
+            echo yes
+            return
+        fi
+    done
+    echo no
+}
+
 build_rpm() {
     command -v rpmbuild >/dev/null || die "rpmbuild not found (install rpm-build)"
     make_tarball
@@ -216,6 +246,17 @@ build_rpm() {
            --define "tengine_version $TENGINE_VERSION" \
            --define "build_ts $BUILD_TS" \
            --define "have_rich_deps $rich_deps"
+
+    # The spec's CMake BuildRequires can only be satisfied by an rpm-managed
+    # CMake. A usable one installed some other way (pip, upstream tarball,
+    # /usr/local) is invisible to rpm, which would fail the build even though
+    # build-deps.sh can use it happily -- some el7 derivatives package only
+    # cmake 2.8 while carrying a much newer one on PATH. Detect that and drop
+    # only the CMake requirement, rather than all of them.
+    if [ "$(cmake_binary_ok)" = yes ] && [ "$(cmake_rpm_ok)" = no ]; then
+        info "usable CMake found on PATH but not owned by rpm; skipping its BuildRequires"
+        set -- "$@" --with external_cmake
+    fi
     if [ -n "$DIST_TAG" ]; then
         set -- "$@" --define "dist $DIST_TAG"
     fi

--- a/packages/build/conf/tengine.conf
+++ b/packages/build/conf/tengine.conf
@@ -21,6 +21,11 @@ http {
 
     access_log  /var/log/tengine/access.log  main;
 
+    # The full feature set registers more variables than the 1024 default can
+    # hold -- the timing variables plus the ones Lua, xquic and reqstat add --
+    # so every start would otherwise warn about a suboptimal variables_hash.
+    variables_hash_max_size 2048;
+
     # Lua runtime that ships with this package. resty.core is loaded on
     # startup, so these paths must stay in sync with the packaged lualib
     # directories -- @TENGINE_LIBDIR@ is substituted at package build time

--- a/packages/build/configure-args.sh
+++ b/packages/build/configure-args.sh
@@ -68,7 +68,15 @@ case "${1:-}" in
     --print-openssl-opt)
         # --api=1.1.1 keeps the deprecated 1.1.1 API visible (Tengine still
         # uses parts of it); enable-ntls is what ngx_tongsuo_ntls needs.
-        [ "$TENGINE_WITH_TONGSUO" = yes ] && printf '%s' '--api=1.1.1 enable-ntls'
+        #
+        # no-tests matters for build time: nginx's own OpenSSL rule
+        # (auto/lib/openssl/make) runs a full `make` before `make install_sw`,
+        # which would compile Tongsuo's entire test suite even though the
+        # package ships none of it. Costly everywhere, worst with an el7-era
+        # gcc. build-deps.sh skips them in the first Tongsuo pass for the same
+        # reason.
+        [ "$TENGINE_WITH_TONGSUO" = yes ] && \
+            printf '%s' '--api=1.1.1 enable-ntls no-tests'
         exit 0
         ;;
     --print-ld-opt)

--- a/packages/build/fetch-deps.sh
+++ b/packages/build/fetch-deps.sh
@@ -58,8 +58,12 @@ DOWNLOAD_TRIES=3
 DOWNLOAD_DELAY=3
 
 if command -v curl >/dev/null 2>&1; then
-    fetch_to() { curl -fsSL --connect-timeout 20 --retry 2 --retry-delay 2 -o "$2" "$1"; }
+    # $3 carries the per-attempt options chosen by download(); it is deliberately
+    # unquoted so that an empty value adds no argument at all.
+    # shellcheck disable=SC2086
+    fetch_to() { curl -fsSL --connect-timeout 20 --retry 2 --retry-delay 2 ${3:-} -o "$2" "$1"; }
 elif command -v wget >/dev/null 2>&1; then
+    # wget only speaks HTTP/1.1, so it ignores $3.
     fetch_to() { wget -q --timeout=20 --tries=2 --waitretry=2 -O "$2" "$1"; }
 else
     die "neither curl nor wget found"
@@ -75,7 +79,15 @@ fi
 download() {
     _try=1
     while :; do
-        if fetch_to "$1" "$2"; then
+        # Networks that truncate HTTP/2 streams are usually fine over HTTP/1.1,
+        # so retries drop to it.  The first attempt keeps HTTP/2, which is
+        # faster where it works.
+        if [ "$_try" = 1 ]; then
+            _opt=""
+        else
+            _opt="--http1.1"
+        fi
+        if fetch_to "$1" "$2" "$_opt"; then
             return 0
         fi
         rm -f "$2"

--- a/packages/build/rpm/tengine.spec
+++ b/packages/build/rpm/tengine.spec
@@ -41,6 +41,13 @@
 %bcond_with zstd
 %bcond_with geoip
 
+# A CMake installed outside the package manager (pip, upstream tarball,
+# /usr/local) is perfectly usable by build-deps.sh but invisible to rpm, so its
+# BuildRequires could never be satisfied. build.sh detects that and enables
+# this to drop just the CMake requirement -- everything else stays checked,
+# unlike a blanket --nodeps.
+%bcond_with external_cmake
+
 # Default feature set: everything Tengine is known for. Turn off with
 # --without tongsuo / --without xquic / --without lua.
 %bcond_without tongsuo
@@ -88,6 +95,7 @@ BuildRequires:  zlib-devel
 # "cmake >= 3.5" there can never be satisfied. build-deps.sh already probes
 # both binaries (find_cmake), so accept either package and let it pick.
 # Rich deps need rpm >= 4.13; see have_rich_deps above.
+%if %{without external_cmake}
 %if %{have_rich_deps}
 BuildRequires:  (cmake >= 3.5 or cmake3 >= 3.5)
 %else
@@ -95,6 +103,7 @@ BuildRequires:  (cmake >= 3.5 or cmake3 >= 3.5)
 BuildRequires:  cmake3 >= 3.5
 %else
 BuildRequires:  cmake >= 3.5
+%endif
 %endif
 %endif
 BuildRequires:  gcc-c++

--- a/packages/build/rpm/tengine.spec
+++ b/packages/build/rpm/tengine.spec
@@ -83,7 +83,20 @@ BuildRequires:  make
 BuildRequires:  zlib-devel
 %if %{with xquic}
 # xquic is built with CMake and links against libstdc++.
+#
+# el7-era distros ship CMake 2.8 as "cmake" and 3.x as "cmake3", so requiring
+# "cmake >= 3.5" there can never be satisfied. build-deps.sh already probes
+# both binaries (find_cmake), so accept either package and let it pick.
+# Rich deps need rpm >= 4.13; see have_rich_deps above.
+%if %{have_rich_deps}
+BuildRequires:  (cmake >= 3.5 or cmake3 >= 3.5)
+%else
+%if 0%{?rhel} == 7
+BuildRequires:  cmake3 >= 3.5
+%else
 BuildRequires:  cmake >= 3.5
+%endif
+%endif
 BuildRequires:  gcc-c++
 %endif
 %if %{with tongsuo}


### PR DESCRIPTION
## 问题

ngx_http_lua_module 0.10.25 不支持 PCRE2，无条件 include PCRE1 专有的
`<pcre.h>`。发行版软件包与容器镜像装的都是 PCRE2 开发包，rpm、deb、apk
与镜像构建因此全部失败。CI 未暴露该问题，因为它装的是 libpcre3-dev。

## 改动

**核心** — 升级 ngx_http_lua_module 至 0.10.29。PCRE2 支持自 0.10.26 起
提供，但 lua-resty-core 以严格相等校验 ngx_lua 版本，deps.env pin 的
v0.1.32 只接受 10029，故版本必须是 0.10.29。

**依赖版本对齐** — 三个测试 workflow 原先 pin lua-resty-core v0.1.27
（只接受 10025），升级后会启动即退出；luajit2 与 lua-resty-lrucache 原先
checkout 默认分支，构建内容随上游漂移。

**构建健壮性** — fetch-deps.sh 的下载此前没有重试，一次网络抖动即导致
整个打包流程失败；重试时降级到 HTTP/1.1，以适应会截断 HTTP/2 流的网络。

**其他** — 打包默认配置提高 variables_hash_max_size（完备功能集的变量数
已超过默认 1024，每次启动都会告警）；镜像校验新增正则引擎检查，防止今后
任一侧退回 PCRE1 而无人发现。

PCRE2 与 PCRE1 两条分支均已编译并运行验证，容器镜像的完备功能集
（Tongsuo + xquic + Lua）在 amd64 上验证通过。
