### PR TITLE
Build: make el7 x86_64 produce the full feature set

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,16 +49,17 @@ jobs:
     # aarch64 runs on native ARM runners: QEMU emulation would make a single
     # Tengine compile take 5-10x longer and risk the job timeout.
     runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    # el7 is best effort, both architectures. Two independent reasons:
-    # CentOS 7 is EOL and its mirrors moved to vault.centos.org, whose main tree
-    # is x86_64-only (the aarch64 archive lives under a different /altarch path
-    # that the bootstrap rewrite does not cover); and the full feature set now
-    # needs CMake >= 3.5 plus a compiler that copes with xquic's -std=gnu11 and
-    # with Tongsuo's OpenSSL 3.0 base, which is a lot to ask of gcc 4.8.
-    # If el7 keeps failing it should be dropped from the matrix outright -- a
-    # release must not ship an el7 package with a smaller feature set than the
-    # others under the same name.
-    continue-on-error: ${{ matrix.target == 'el7' }}
+    # Only el7 on aarch64 is best effort: CentOS 7 is EOL and its mirrors moved
+    # to vault.centos.org, whose main tree is x86_64-only -- the aarch64 archive
+    # lives under a different /altarch path that the bootstrap rewrite does not
+    # cover, so that combination cannot succeed at all.
+    #
+    # el7 on x86_64 is NOT exempt. The full feature set was verified to build
+    # with gcc 4.8.5 (Tongsuo's OpenSSL 3.0 base and xquic's -std=gnu11 with its
+    # own -Werror both compile fine); the only real obstacle was CMake, which
+    # bootstrap now installs from Kitware's static tarball. A failure there is
+    # therefore real news, not an expected casualty.
+    continue-on-error: ${{ matrix.target == 'el7' && matrix.arch == 'aarch64' }}
     # Tongsuo is compiled twice, plus xquic, LuaJIT and Tengine itself.
     timeout-minutes: 150
     strategy:

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -99,15 +99,20 @@ Tengine，24 个 job 全跑一遍代价很高，因此仅：
 （rolling）、`anolis23`、`openeuler2203`、`sles12` 未进矩阵，需要时用
 `build.sh docker <目标>`。
 
-**`el7` 两个架构都标记 `continue-on-error`**（尽力而为）。两个独立原因：CentOS 7
-EOL 后镜像源迁到 `vault.centos.org`，其主树只有 x86_64（aarch64 归档在 `/altarch/`
-另一路径，bootstrap 的源改写没覆盖）；且完备功能集要求 CMake ≥ 3.5、能编 xquic
-`-std=gnu11` 与 Tongsuo（OpenSSL 3.0 基线）的编译器，对 gcc 4.8 要求较高。
+**只有 `el7` + `aarch64` 标记 `continue-on-error`**：CentOS 7 EOL 后镜像源迁到
+`vault.centos.org`，其主树只有 x86_64，aarch64 归档在 `/altarch/` 另一路径下，
+bootstrap 的源改写没覆盖，该组合不可能成功。
 
-> **若 el7 持续失败，就应当直接从矩阵移除** —— 宁可不出 el7 包，也不要让同名
-> `tengine` 包在不同发行版上功能集不一致。这只是公共 CI 用 `centos:7` 镜像的限制，
-> 不是 spec 的限制；在自带完整仓库的 el7 系统（如 Alibaba Cloud Linux 2）上直接
-> `build.sh rpm --dist .el7u2` 即可。
+**`el7` + `x86_64` 不免检。** 完备功能集已实测可用 gcc 4.8.5 编出：Tongsuo 的
+OpenSSL 3.0 基线、xquic 的 `-std=gnu11` 及其自带 `-Werror` 都没有问题。唯一的真实
+障碍是 CMake —— el7 只打包 2.8，而通常的替代 `cmake3` 只存在于同样已 EOL 的
+EPEL 7（metalink 已失效，仅剩归档镜像）。因此 bootstrap 改为直接取 Kitware 的静态
+tarball（只需 glibc 2.17，el7 满足）；`build.sh` 会发现这个 CMake 不属于 rpm，
+自动为 spec 关掉对应的 `BuildRequires`（见 `external_cmake`）。
+
+> 在自带完整仓库的 el7 系统上无需这些周折，直接
+> `build.sh rpm --dist .el7u2` 即可 —— 已实测产出 4.9 MB 的完备功能集包
+> （Tongsuo 静态链入、`libxquic.so` 与 `libluajit` 随包、`resty.core` 可加载）。
 
 前置 `prepare` job 做两件事：钉住整个 run 共享的时间戳（24 个包 Release 号一致），
 以及跑一次 [fetch-deps.sh](fetch-deps.sh) 把 pin 的依赖源码下载校验后上传为

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -400,9 +400,17 @@ else
     sed -i -e 's/^mirrorlist=/#mirrorlist=/' \
            -e 's|^#*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|' \
            /etc/yum.repos.d/CentOS-*.repo
-    # el7's "cmake" is 2.8; xquic needs the separate cmake3 package.
-    yum -y install rpm-build gcc gcc-c++ make cmake3 tar findutils diffutils curl \
+    yum -y install rpm-build gcc gcc-c++ make tar findutils diffutils curl \
         perl openssl-devel zlib-devel pcre-devel systemd
+    # el7 packages CMake 2.8 and xquic needs >= 3.5. The usual answer, cmake3,
+    # lives only in EPEL 7 -- itself EOL, with a dead metalink and nothing but
+    # an archive mirror left, so pulling it in means rewriting a second set of
+    # repo files. Kitware's own build is a static tarball needing just glibc
+    # 2.17, which el7 has. build.sh detects that rpm does not own this CMake
+    # and drops the matching BuildRequires by itself.
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-linux-$(uname -m).tar.gz" \
+        | tar xz --strip-components=1 -C /usr/local
+    cmake --version
 fi
 EOS
             ;;


### PR DESCRIPTION
el7 仓库中的 CMake 只有 2.8，而 xquic 需要 3.5 以上；常用替代 cmake3 仅存在于同样 已 EOL 的 EPEL 7，其 metalink 已失效、只剩归档镜像，引入它意味着再改写一套 repo 文件。bootstrap 改为直接安装 Kitware 的静态 tarball，仅依赖 glibc 2.17，el7 满足。 build.sh 已能识别该 CMake 不由 rpm 拥有，并自动关闭 spec 中对应的 BuildRequires。

同时收窄 el7 的 continue-on-error 范围。完备功能集在 gcc 4.8.5 下可以编译，Tongsuo 的 OpenSSL 3.0 基线与 xquic 的 -std=gnu11 及其自带 -Werror 均无障碍，因此 el7 与 x86_64 的组合不再免检，失败即为真实问题。仅保留 aarch64 免检：vault.centos.org 的主树没有 aarch64，归档位于 /altarch 另一路径，该组合无法成功。