### PR TITLE
Fix the distro package builds and align the release tag convention

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,9 @@ on:
         default: false
   push:
     tags:
+      # Keep in sync with package.yml: 3.x tags are bare version numbers,
+      # 2.x used a "tengine-" prefix.
+      - '[0-9]+.[0-9]+.[0-9]+*'
       - 'tengine-*'
 
 permissions:
@@ -48,7 +51,8 @@ jobs:
           echo "image=ghcr.io/$owner/tengine" >> "$GITHUB_OUTPUT"
 
           if [ "${{ github.ref_type }}" = tag ]; then
-              # refs/tags/tengine-3.2.0 -> 3.2.0, tengine-3.2.0-rc1 -> 3.2.0-rc1
+              # 3.x tags are bare (3.2.0-rc1 -> 3.2.0-rc1); 2.x carried a prefix
+              # (tengine-2.2.2 -> 2.2.2), which is stripped when present.
               version=${GITHUB_REF_NAME#tengine-}
               push=true
               # A pre-release must never become what "docker pull tengine" gets.

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -205,6 +205,8 @@ jobs:
               *)                                       prerelease=false ;;
           esac
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          # Past releases are titled "Tengine-3.1.0"; the tag itself is bare.
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
           owner=$(printf '%s' "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
@@ -267,6 +269,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          name: Tengine-${{ steps.notes.outputs.version }}
           files: release/*
           body_path: notes.md
           prerelease: ${{ steps.notes.outputs.prerelease }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,11 @@ on:
         default: ''
   push:
     tags:
+      # 3.x tags are bare version numbers (3.1.0, 3.2.0-rc1); 2.x used a
+      # "tengine-" prefix. Both are accepted -- the version is derived by
+      # stripping that prefix when present, so either shape yields the same
+      # package and image versions.
+      - '[0-9]+.[0-9]+.[0-9]+*'
       - 'tengine-*'
 
 jobs:

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -351,7 +351,12 @@ build_apk() {
         "$work/APKBUILD" > "$work/APKBUILD.new"
     mv "$work/APKBUILD.new" "$work/APKBUILD"
 
-    [ -f "$HOME/.abuild/abuild.conf" ] || abuild-keygen -a -i -n
+    # -i would install the public key through doas, which the alpine build image
+    # does not carry; the build runs as root, so place it directly instead.
+    if [ ! -f "$HOME/.abuild/abuild.conf" ]; then
+        abuild-keygen -a -n
+        cp "$HOME"/.abuild/*.rsa.pub /etc/apk/keys/
+    fi
     REPODEST="$work/repo"
     export REPODEST
 

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -398,12 +398,17 @@ bootstrap_cmd() {
             cat <<'EOS'
 if command -v dnf >/dev/null 2>&1; then
     if dnf -q list pcre2-devel >/dev/null 2>&1; then _pcre=pcre2-devel; else _pcre=pcre-devel; fi
+    # el9 images carry curl-minimal, which conflicts with the full curl package.
+    # It provides /usr/bin/curl all the same, so only ask for curl when the image
+    # has none -- replacing it would drag the whole dependency chain along.
+    _curl=curl
+    command -v curl >/dev/null 2>&1 && _curl=
     # Tongsuo's Configure pulls in a handful of Perl modules that every distro
     # splits up differently -- and on el8 "perl-FindBin" is hidden behind a
     # module stream, so asking for the package name gets filtered out entirely.
     # Requesting the perl(...) virtual provides instead lets rpm resolve each
     # module to whatever package happens to carry it.
-    dnf -y install rpm-build gcc gcc-c++ make cmake tar findutils diffutils curl \
+    dnf -y install rpm-build gcc gcc-c++ make cmake tar findutils diffutils $_curl \
         perl "perl(FindBin)" "perl(IPC::Cmd)" "perl(lib)" \
         openssl-devel zlib-devel systemd "$_pcre"
 else

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -398,15 +398,21 @@ bootstrap_cmd() {
             cat <<'EOS'
 if command -v dnf >/dev/null 2>&1; then
     if dnf -q list pcre2-devel >/dev/null 2>&1; then _pcre=pcre2-devel; else _pcre=pcre-devel; fi
+    # Tongsuo's Configure pulls in a handful of Perl modules that every distro
+    # splits up differently -- and on el8 "perl-FindBin" is hidden behind a
+    # module stream, so asking for the package name gets filtered out entirely.
+    # Requesting the perl(...) virtual provides instead lets rpm resolve each
+    # module to whatever package happens to carry it.
     dnf -y install rpm-build gcc gcc-c++ make cmake tar findutils diffutils curl \
-        perl-interpreter perl-FindBin openssl-devel zlib-devel systemd "$_pcre"
+        perl "perl(FindBin)" "perl(IPC::Cmd)" "perl(lib)" \
+        openssl-devel zlib-devel systemd "$_pcre"
 else
     # CentOS 7 is EOL; its mirrors moved to vault.centos.org
     sed -i -e 's/^mirrorlist=/#mirrorlist=/' \
            -e 's|^#*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|' \
            /etc/yum.repos.d/CentOS-*.repo
     yum -y install rpm-build gcc gcc-c++ make tar findutils diffutils curl \
-        perl openssl-devel zlib-devel pcre-devel systemd
+        perl "perl(IPC::Cmd)" openssl-devel zlib-devel pcre-devel systemd
     # el7 packages CMake 2.8 and xquic needs >= 3.5. The usual answer, cmake3,
     # lives only in EPEL 7 -- itself EOL, with a dead metalink and nothing but
     # an archive mirror left, so pulling it in means rewriting a second set of

--- a/packages/build/deb/debian/rules
+++ b/packages/build/deb/debian/rules
@@ -5,7 +5,13 @@
 # feature-identical to the RPM and APK builds.
 #
 
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+# optimize=-lto: dpkg turns LTO on by default and DPKG_EXPORT_BUILDFLAGS hands
+# it to build-deps.sh as well, so Tongsuo's static archives end up carrying LTO
+# bytecode. gcc then re-runs its analysis while linking libxquic.so, where the
+# -Wno-* that build-deps.sh passes no longer apply, and hardening's -Werror
+# turns a free-nonheap-object warning inside BN_RECP_CTX_free fatal. Nothing
+# in this package benefits from LTO.
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all optimize=-lto
 
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk

--- a/packages/build/rpm/tengine.spec
+++ b/packages/build/rpm/tengine.spec
@@ -109,17 +109,22 @@ BuildRequires:  cmake >= 3.5
 BuildRequires:  gcc-c++
 %endif
 %if %{with tongsuo}
-# Tongsuo's Configure is Perl and needs FindBin; Text::Template comes from the
-# tarball's own external/perl fallback. SUSE and el7 ship one monolithic perl,
-# everything newer splits the interpreter and FindBin into separate packages.
+# Tongsuo's Configure is Perl; Text::Template comes from the tarball's own
+# external/perl fallback. SUSE and el7 ship one monolithic perl, everything
+# newer splits it up -- and on el8 the perl-FindBin package name is hidden
+# behind a module stream, so depend on the perl(...) virtual provides and let
+# rpm map each module to whichever package carries it.
 %if 0%{?suse_version}
 BuildRequires:  perl
 %else
 %if 0%{?rhel} == 7
 BuildRequires:  perl
+BuildRequires:  perl(IPC::Cmd)
 %else
-BuildRequires:  perl-interpreter
-BuildRequires:  perl-FindBin
+BuildRequires:  perl
+BuildRequires:  perl(FindBin)
+BuildRequires:  perl(IPC::Cmd)
+BuildRequires:  perl(lib)
 %endif
 %endif
 %endif


### PR DESCRIPTION
## 改动

**Perl 依赖**（el7 / el8 / el10 / anolis8，8 个 job）— Tongsuo 的 Configure 需要若干
Perl 模块，各发行版拆包方式不同：el7 缺 `IPC::Cmd`，el10 缺 `lib.pm`，el8 与 anolis8
的 `perl-FindBin` 包名被模块流过滤（`Unable to find a match`）。改为依赖 `perl(...)`
虚拟 provides，由 rpm 解析到实际承载模块的包；`build.sh` 的 bootstrap 与 spec 的
`BuildRequires` 一并调整。

**LTO**（ubuntu2204 / ubuntu2404，4 个 job）— dpkg 默认开启 LTO，且
`DPKG_EXPORT_BUILDFLAGS` 会把 flags 一并交给 `build-deps.sh`，于是 Tongsuo 的静态库
带上了 LTO 字节码。链接 libxquic.so 时 gcc 在链接期重跑分析，此时 `build-deps.sh`
传入的 `-Wno-*` 已不起作用，hardening 的 `-Werror` 便把 `BN_RECP_CTX_free` 中的
`free-nonheap-object` 告警变成致命错误。本包无需 LTO，在 `DEB_BUILD_MAINT_OPTIONS`
中关闭。

**curl**（el9，2 个 job）— el9 镜像自带 curl-minimal，与完整的 curl 包互斥。
curl-minimal 同样提供 `/usr/bin/curl`，因此仅在镜像完全没有 curl 时才安装，避免替换
系统包并牵连其依赖链。

**abuild 密钥**（alpine，2 个 job）— `abuild-keygen -i` 通过 doas 把公钥装到
`/etc/apk/keys`，而 Alpine 构建镜像没有 doas。构建以 root 运行，直接复制即可。

**tag 规范** — 两个 workflow 改为同时接受 `[0-9]+.[0-9]+.[0-9]+*` 与 `tengine-*`。
版本号提取本就是"存在前缀才剥离"，两种形式产出相同的包与镜像版本；预发布判定与下载
URL 均无需改动。release 标题改用剥离前缀后的版本拼成 `Tengine-<ver>`，沿用
`Tengine-3.1.0` 的格式。