### PR TITLE
Build: track the base systems nginx publishes for

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -83,6 +83,7 @@ jobs:
           - sles15
           - debian11
           - debian12
+          - debian13
           - ubuntu2204
           - ubuntu2404
           - alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@
 # Dockerfile.alpine for the musl variant).
 #
 
-ARG BASE_IMAGE=debian:12
-ARG RUNTIME_IMAGE=debian:12-slim
+ARG BASE_IMAGE=debian:13
+ARG RUNTIME_IMAGE=debian:13-slim
 
 FROM ${BASE_IMAGE} AS builder
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,8 +8,8 @@
 #     docker build -f Dockerfile.alpine -t tengine:alpine .
 #
 
-ARG BASE_IMAGE=alpine:3.20
-ARG RUNTIME_IMAGE=alpine:3.20
+ARG BASE_IMAGE=alpine:3.22
+ARG RUNTIME_IMAGE=alpine:3.22
 
 FROM ${BASE_IMAGE} AS builder
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,8 +2,7 @@
     <br>Tengine
 </h1>
 
-<p align="center">Visit <a href="https://tengine.taobao.org" target="_blank">tengine.taobao.org</a> for the full documentation,
-examples and guides.</p>
+<p align="center">Visit <a href="https://tengine.taobao.org" target="_blank">tengine.taobao.org</a> for the full documentation, examples and guides.</p>
 
 <div align="center">
 
@@ -63,8 +62,7 @@ Tengine has been an open source project since December 2011. It is being activel
 
 ### Container image
 
-Multi-arch (amd64 + arm64) images with the full feature set -- Tongsuo (NTLS),
-xquic (QUIC/HTTP-3) and Lua -- are published on every release:
+Multi-arch (amd64 + arm64) images with the full feature set -- Tongsuo (NTLS), xquic (QUIC/HTTP-3) and Lua -- are published on every release:
 
 ```bash
 docker pull ghcr.io/alibaba/tengine:latest         # Debian based
@@ -73,23 +71,17 @@ docker pull ghcr.io/alibaba/tengine:latest-alpine  # Alpine based, smaller
 docker run --rm -p 8080:80 ghcr.io/alibaba/tengine:latest
 ```
 
-The server runs as `/usr/sbin/tengine` with `/etc/tengine/tengine.conf`; drop
-your own server blocks into `/etc/tengine/conf.d/`.
+The server runs as `/usr/sbin/tengine` with `/etc/tengine/tengine.conf`; drop your own server blocks into `/etc/tengine/conf.d/`.
 
 ### Distribution packages
 
-Every release ships `.rpm`, `.deb` and `.apk` packages for the mainstream
-distributions (RHEL/Rocky/Alma/Anolis/openEuler/SLES, Debian/Ubuntu, Alpine) on
-both x86_64 and aarch64, attached to the
-[release page](https://github.com/alibaba/tengine/releases):
+Every release ships `.rpm`, `.deb` and `.apk` packages for the mainstream distributions (RHEL/Rocky/Alma/Anolis/openEuler/SLES, Debian/Ubuntu, Alpine) on both x86_64 and aarch64, attached to the [release page](https://github.com/alibaba/tengine/releases):
 
 ```bash
 dnf install https://github.com/alibaba/tengine/releases/download/tengine-3.2.0/tengine-3.2.0-<ts>.el9.x86_64.rpm
 ```
 
-These packages install alongside a distribution nginx without conflicting.
-See [packages/build/README.md](packages/build/README.md) for the exact feature
-set, how to build them yourself, and how the container images are produced.
+These packages install alongside a distribution nginx without conflicting. See [packages/build/README.md](packages/build/README.md) for the exact feature set, how to build them yourself, and how the container images are produced.
 
 ### From source
 Tengine can be downloaded at [http://tengine.taobao.org/download/tengine.tar.gz](http://tengine.taobao.org/download/tengine.tar.gz). You can also checkout the latest source code from GitHub at [https://github.com/alibaba/tengine](https://github.com/alibaba/tengine)
@@ -104,9 +96,7 @@ sudo make install
 By default, it will be installed to _/usr/local/nginx_. You can use the __'--prefix'__ option to specify the root directory.
 If you want to know all the _'configure'_ options, you should run __'./configure --help'__ for help.
 
-A plain `./configure` builds without Tongsuo, xquic and Lua -- those need their
-own libraries. To reproduce the full feature set of the released packages and
-images, use the packaging helpers:
+A plain `./configure` builds without Tongsuo, xquic and Lua -- those need their own libraries. To reproduce the full feature set of the released packages and images, use the packaging helpers:
 
 ```bash
 packages/build/fetch-deps.sh                       # download pinned sources

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -64,7 +64,7 @@ usage() {
     exit "${1:-0}"
 }
 
-ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 debian11 debian12 ubuntu2204 ubuntu2404 alpine"
+ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 debian11 debian12 debian13 ubuntu2204 ubuntu2404 alpine"
 
 # Container targets: alias -> "image|family".  family drives both the
 # bootstrap commands and which native builder runs inside.
@@ -82,6 +82,7 @@ docker_image() {
         sles15)     echo "registry.suse.com/bci/bci-base:15.6|sles" ;;
         debian11)   echo "debian:11|deb" ;;
         debian12)   echo "debian:12|deb" ;;
+        debian13)   echo "debian:13|deb" ;;
         ubuntu2204) echo "ubuntu:22.04|deb" ;;
         ubuntu2404) echo "ubuntu:24.04|deb" ;;
         alpine)     echo "alpine:3.22|apk" ;;

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -84,7 +84,7 @@ docker_image() {
         debian12)   echo "debian:12|deb" ;;
         ubuntu2204) echo "ubuntu:22.04|deb" ;;
         ubuntu2404) echo "ubuntu:24.04|deb" ;;
-        alpine)     echo "alpine:3.20|apk" ;;
+        alpine)     echo "alpine:3.22|apk" ;;
         *)          return 1 ;;
     esac
 }


### PR DESCRIPTION
## 问题

容器镜像与发行版包的基础系统落后于 nginx 官方支持列表：Debian flavour 仍是
bookworm，而 nginx 的 mainline 与 stable 均已改用 `debian:trixie-slim`；Alpine 是
3.20，既低于 nginx 支持的 3.21–3.24，社区支持也已于 2026 年 5 月到期。deb 包同样
缺 Debian 13。

## 改动

- Debian 镜像基础改为 `debian:13` / `debian:13-slim`。
- Alpine 镜像与 apk 目标同步升到 `alpine:3.22`（支持至 2027-05）。
- 新增 `debian13` 打包目标，避免出现"镜像基于 13、包只到 12"的错位；打包矩阵由
  24 个 job 增至 26 个。
- 顺带整理 README 引言部分的排版。

trixie 移除了 libpcre3，因此升级的前提是 ngx_http_lua_module 已升至 0.10.29 支持
PCRE2；deb 构建本就依赖 libpcre2-dev。

Ubuntu 26.04 与 SLES 16 的原生包暂未纳入，留待正式版。架构方面仍只覆盖 amd64 与
arm64：nginx 官方镜像还提供 arm/v7、s390x、ppc64le 等，但这些没有原生 runner，而
完备功能集需要编译两次 Tongsuo 加 xquic，QEMU 模拟下不具可行性。
