### PR TITLE
Fix unix socket health checking and the GCC 14 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
            cases/ngx_http_upstream_check_module/http_check.t \
            cases/ngx_http_upstream_check_module/http_check_keepalive_body.t \
            cases/ngx_http_upstream_check_module/tcp_check.t \
+           cases/ngx_http_upstream_check_module/unix_socket_check.t \
            cases/ngx_http_upstream_check_module/websocket.t \
            cases/ngx_http_upstream_check_module/check_interface.t
      - name: upstream check HTTP parser unit tests

--- a/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
+++ b/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
@@ -503,6 +503,7 @@ static void ngx_http_upstream_check_status_prometheus_format(ngx_buf_t *b,
 
 static ngx_int_t ngx_http_upstream_check_addr_change_port(ngx_pool_t *pool,
     ngx_addr_t *dst, ngx_addr_t *src, ngx_uint_t port);
+static ngx_flag_t ngx_http_upstream_check_addr_has_port(ngx_addr_t *addr);
 
 static ngx_check_conf_t *ngx_http_get_check_type_conf(ngx_str_t *str);
 
@@ -958,7 +959,7 @@ ngx_http_upstream_check_add_dynamic_peer(ngx_pool_t *pool,
                    "peer: %V, index: %ui",
                    &us->host, &peer_addr->name, index);
 
-    if (ucscf->port) {
+    if (ucscf->port && ngx_http_upstream_check_addr_has_port(peer_addr)) {
         peer->check_peer_addr = ngx_pcalloc(pool, sizeof(ngx_addr_t));
         if (peer->check_peer_addr == NULL) {
             return NGX_ERROR;
@@ -968,10 +969,30 @@ ngx_http_upstream_check_add_dynamic_peer(ngx_pool_t *pool,
                 peer->check_peer_addr, peer_addr, ucscf->port)
             != NGX_OK) {
 
+            ngx_log_error(NGX_LOG_ERR, pool->log, 0,
+                          "http upstream check cannot apply \"port=%ui\" to "
+                          "peer \"%V\" in upstream \"%V\", it is excluded "
+                          "from health checking",
+                          ucscf->port, &peer_addr->name, &us->host);
+
             return NGX_ERROR;
         }
 
     } else {
+        /*
+         * An address without the notion of a port, such as a unix domain
+         * socket, cannot be checked on a different port: ignore "port=" and
+         * check the peer on its own address instead of silently dropping it
+         * out of health checking.
+         */
+        if (ucscf->port) {
+            ngx_log_error(NGX_LOG_WARN, pool->log, 0,
+                          "http upstream check ignores \"port=%ui\" for peer "
+                          "\"%V\" in upstream \"%V\", the peer has no port "
+                          "and is checked on its own address",
+                          ucscf->port, &peer_addr->name, &us->host);
+        }
+
         peer->check_peer_addr = peer->peer_addr;
     }
 
@@ -1042,7 +1063,7 @@ ngx_http_upstream_check_add_peer(ngx_conf_t *cf,
     peer->upstream_name = &us->host;
     peer->peer_addr = peer_addr;
 
-    if (ucscf->port) {
+    if (ucscf->port && ngx_http_upstream_check_addr_has_port(peer_addr)) {
         peer->check_peer_addr = ngx_pcalloc(cf->pool, sizeof(ngx_addr_t));
         if (peer->check_peer_addr == NULL) {
             return NGX_ERROR;
@@ -1052,10 +1073,30 @@ ngx_http_upstream_check_add_peer(ngx_conf_t *cf,
                 peer->check_peer_addr, peer_addr, ucscf->port)
             != NGX_OK) {
 
+            ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
+                               "\"check\" cannot apply \"port=%ui\" to peer "
+                               "\"%V\" in upstream \"%V\", it is excluded "
+                               "from health checking",
+                               ucscf->port, &peer_addr->name, &us->host);
+
             return NGX_ERROR;
         }
 
     } else {
+        /*
+         * An address without the notion of a port, such as a unix domain
+         * socket, cannot be checked on a different port: ignore "port=" and
+         * check the peer on its own address instead of silently dropping it
+         * out of health checking.
+         */
+        if (ucscf->port) {
+            ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                               "\"check\" ignores \"port=%ui\" for peer "
+                               "\"%V\" in upstream \"%V\", the peer has no "
+                               "port and is checked on its own address",
+                               ucscf->port, &peer_addr->name, &us->host);
+        }
+
         peer->check_peer_addr = peer->peer_addr;
     }
 
@@ -1063,6 +1104,28 @@ ngx_http_upstream_check_add_peer(ngx_conf_t *cf,
         ngx_murmur_hash2(peer_addr->name.data, peer_addr->name.len);
 
     return peer->index;
+}
+
+
+/*
+ * Whether the address family carries a port that a health check can be
+ * redirected to. Keep the families in sync with the switch in
+ * ngx_http_upstream_check_addr_change_port() below.
+ */
+static ngx_flag_t
+ngx_http_upstream_check_addr_has_port(ngx_addr_t *addr)
+{
+    switch (addr->sockaddr->sa_family) {
+
+    case AF_INET:
+#if (NGX_HAVE_INET6)
+    case AF_INET6:
+#endif
+        return 1;
+
+    default:
+        return 0;
+    }
 }
 
 

--- a/modules/ngx_http_xquic_module/ngx_xquic_intercom.c
+++ b/modules/ngx_http_xquic_module/ngx_xquic_intercom.c
@@ -745,7 +745,8 @@ ngx_xquic_intercom_send(ngx_int_t worker_num, ngx_xquic_recv_packet_t *packet,
     c = ctx->connection;
 
     n = sendto(c->fd, packet, sizeof(ngx_xquic_recv_packet_t), 0,
-               &ctx->addr[worker_num], ctx->addrlen[worker_num]);
+               (struct sockaddr *) &ctx->addr[worker_num],
+               ctx->addrlen[worker_num]);
 
     ngx_xquic_stat_send_cnt++;
 

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/unix_socket_check.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/unix_socket_check.t
@@ -1,0 +1,136 @@
+# vi:filetype=perl
+
+# Regression cases for "check ... port=N" combined with unix domain socket
+# servers.
+#
+# A unix domain socket has no port, so port= cannot be applied to it. It used to
+# make ngx_http_upstream_check_add_peer() fail, which left the peer's
+# check_index at NGX_ERROR; ngx_http_upstream_check_peer_down() fails open on an
+# invalid index, so the socket was reported alive forever and the load balancer
+# kept selecting it even while the health check itself had marked it down. The
+# expected behaviour is that port= is ignored for such a peer and the peer is
+# checked on its own address.
+#
+# Every block sets "proxy_next_upstream off". Without it the retry to the next
+# peer masks the bug: the request still ends up with a 200 after one failed
+# connection, so the case would pass both before and after the fix.
+#
+# Blocks whose expectation depends on a peer having been checked at least once
+# wait in "--- init" first: the first check only fires after a random delay of
+# up to max(interval, 1s), while the framework sends its request roughly 100ms
+# after the server starts.
+
+use lib 'lib';
+use Test::Nginx::LWP;
+
+plan tests => repeat_each(2) * 2 * blocks();
+
+no_root_location();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: a unix socket peer with port= is checked on its own address, so a dead socket fails over to the backup
+--- http_config
+    upstream test_unix_down {
+        server unix:/tmp/tengine_check_no_such_socket.sock;
+        server 127.0.0.1:1980 backup;
+
+        check interval=500 rise=1 fall=1 timeout=1000 type=http default_down=false port=1981;
+        check_http_send "GET /health_check HTTP/1.0\r\n\r\n";
+        check_http_expect_alive http_2xx;
+    }
+
+    # The backup peer is an IP peer, so port= does apply to it: keep 1981
+    # healthy or the backup would be marked down too.
+    server {
+        listen 1981;
+        location / {
+            return 200 "PROBE\n";
+        }
+    }
+
+    server {
+        listen 1980;
+        location / {
+            return 200 "BACKUP\n";
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test_unix_down;
+        proxy_next_upstream off;
+    }
+
+--- init: sleep 3;
+--- request
+GET /
+--- response_body_like: BACKUP
+
+=== TEST 2: a unix socket peer with port= is marked up while its socket is healthy
+--- http_config
+    upstream test_unix_up {
+        server unix:/tmp/tengine_check_unix_up.sock;
+
+        check interval=500 rise=1 fall=1 timeout=1000 type=http default_down=false port=1981;
+        check_http_send "GET /health_check HTTP/1.0\r\n\r\n";
+        check_http_expect_alive http_2xx;
+    }
+
+    server {
+        listen unix:/tmp/tengine_check_unix_up.sock;
+        location / {
+            return 200 "UNIX\n";
+        }
+    }
+
+    server {
+        listen 1981;
+        location / {
+            return 200 "PROBE\n";
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test_unix_up;
+        proxy_next_upstream off;
+    }
+
+--- init: sleep 3;
+--- request
+GET /
+--- response_body_like: UNIX
+
+=== TEST 3: port= still applies to IP peers, so a dead probe port marks a healthy peer down
+--- http_config
+    upstream test_ip_probe_down {
+        # 1980 serves fine, but the check is redirected to 1982 where nothing
+        # listens, so the peer must end up down.
+        server 127.0.0.1:1980;
+
+        check interval=500 rise=1 fall=1 timeout=1000 type=http default_down=false port=1982;
+        check_http_send "GET /health_check HTTP/1.0\r\n\r\n";
+        check_http_expect_alive http_2xx;
+    }
+
+    server {
+        listen 1980;
+        location / {
+            return 200 "BACKEND\n";
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://test_ip_probe_down;
+        proxy_next_upstream off;
+    }
+
+--- init: sleep 3;
+--- request
+GET /
+--- error_code: 502
+--- response_body_like: ^.*$


### PR DESCRIPTION
## unix socket peer 配置 port= 后脱离健康检查

upstream 中同时配置 unix socket server 与 `check port=N` 时，该 peer 会永久被判定
为存活，后端停止后 backup 无法接管。

断裂发生在消费侧而非探测侧：`addr_change_port()` 不处理 AF_UNIX 而返回 NGX_ERROR，
`add_peer()` 将其静默上抛，round_robin 的 check_index 遂变为 NGX_ERROR，而
`check_peer_down()` 对越界 index 采取 fail-open 返回存活。探测本身一直正常并如实
标记 down，只是无人读取该状态。

`port=` 的语义是检查同一主机的另一个端口，对没有端口概念的地址无意义。新增
`addr_has_port()` 判据，令 `port=` 只作用于带端口的地址族，其余情况忽略该参数并
告警，unix socket peer 继续按自身地址接受健康检查。静态与动态两个调用点同时生效，
正常配置下也不再走到 `addr_change_port()` 的 default 分支，静默失败路径被消除。

新增回归测试 `unix_socket_check.t` 并纳入 CI：覆盖 unix socket 死掉时切到 backup、
socket 健康时判定为 up、以及 `port=` 对 IP peer 仍然生效三种情形。

## GCC 14 下 xquic 模块编译失败

alpine 与 debian13 目标编译失败：

    ngx_xquic_intercom.c:748: error: passing argument 5 of 'sendto' from
    incompatible pointer type [-Wincompatible-pointer-types]

`ctx->addr` 的类型是 `struct sockaddr_un *`，而 `sendto` 要求
`const struct sockaddr *`。GCC 14 起该诊断由警告提升为默认错误，因此 `-Wno-error`
无法压制；Alpine 3.22 与 Debian 13 使用的正是 GCC 14。补上 `(struct sockaddr *)`
转换，与同一文件中两处 `bind()` 调用的写法保持一致。
