### PR TITLE
Build: fix the apk directory ownership, and sync the docs

### DIFF
--- a/CHANGES.cn
+++ b/CHANGES.cn
@@ -30,6 +30,7 @@ Tengine 3.2.0 [2026-07-31]
 * Change: ngx_http_tunnel_module改为可选编译，避免与ngx_http_proxy_connect_module冲突 (lianglli)
 * Change: 合入nginx官方测试集并补充Tengine定制测试用例 (lianglli)
 * Bugfix: 修复ngx_http_upstream_check_module在HTTP健康检查复用长连接时未排空响应体的问题 (lianglli)
+* Bugfix: 修复unix socket类型的upstream server配置check port=时被永久判定为存活，导致backup无法接管的问题 (lianglli)
 * Bugfix: 修复round-robin初始化时重复链接peer导致backup peer自环的问题 (lianglli)
 * Bugfix: 修复random负载均衡初始化时空peer组导致的除零问题 (lianglli)
 * Bugfix: 修复round-robin首次选择跳过第一个peer的问题 (lianglli)

--- a/CHANGES.te
+++ b/CHANGES.te
@@ -97,6 +97,9 @@ Changes with Tengine 3.2.0                                         31 Jul 2026
     *) Bugfix: drain the HTTP health-check response body for keepalive-safe
        connection reuse in ngx_http_upstream_check_module (lianglli)
 
+    *) Bugfix: a unix socket upstream server combined with "check port=" was
+       reported alive forever, so a backup server never took over (lianglli)
+
     *) Bugfix: fixed duplicate peer linking in round-robin init, which made
        a backup peer link to itself (lianglli)
 

--- a/README.markdown
+++ b/README.markdown
@@ -78,7 +78,7 @@ The server runs as `/usr/sbin/tengine` with `/etc/tengine/tengine.conf`; drop yo
 Every release ships `.rpm`, `.deb` and `.apk` packages for the mainstream distributions (RHEL/Rocky/Alma/Anolis/openEuler/SLES, Debian/Ubuntu, Alpine) on both x86_64 and aarch64, attached to the [release page](https://github.com/alibaba/tengine/releases):
 
 ```bash
-dnf install https://github.com/alibaba/tengine/releases/download/tengine-3.2.0/tengine-3.2.0-<ts>.el9.x86_64.rpm
+dnf install https://github.com/alibaba/tengine/releases/download/3.2.0/tengine-3.2.0-<ts>.el9.x86_64.rpm
 ```
 
 These packages install alongside a distribution nginx without conflicting. See [packages/build/README.md](packages/build/README.md) for the exact feature set, how to build them yourself, and how the container images are produced.

--- a/packages/build/apk/APKBUILD
+++ b/packages/build/apk/APKBUILD
@@ -27,7 +27,7 @@ makedepends="
 	g++
 	perl
 	"
-install="$pkgname.pre-install"
+install="$pkgname.pre-install $pkgname.post-install"
 subpackages="$pkgname-doc $pkgname-openrc"
 # tengine-deps.tar.gz holds the pinned Tongsuo / xquic / LuaJIT / resty
 # tarballs; abuild unpacks it to $srcdir/deps.
@@ -104,8 +104,11 @@ package() {
 	install -D -m 0755 "$srcdir"/tengine.openrc \
 		"$pkgdir"/etc/init.d/tengine
 
-	install -d -m 0700 -o tengine -g tengine "$pkgdir"/var/cache/tengine
-	install -d -m 0755 -o tengine -g tengine "$pkgdir"/var/log/tengine
+	# No -o/-g here: the tengine user only comes into being when the package is
+	# installed, so resolving the name at build time fails. .post-install takes
+	# ownership once the directories are on disk, the same way the deb does.
+	install -d -m 0700 "$pkgdir"/var/cache/tengine
+	install -d -m 0755 "$pkgdir"/var/log/tengine
 	install -d -m 0755 "$pkgdir"/usr/lib/tengine/modules
 
 	# /run is a tmpfs; make install creates it because of --pid-path

--- a/packages/build/apk/tengine.post-install
+++ b/packages/build/apk/tengine.post-install
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# The tengine user is created by .pre-install, which runs before the package
+# contents are unpacked -- so the directories cannot be chowned there. Do it
+# here instead, once they exist.
+#
+
+chown tengine:tengine /var/cache/tengine /var/log/tengine 2>/dev/null || true
+
+exit 0

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -339,7 +339,8 @@ build_apk() {
     rm -rf "$work"
     mkdir -p "$work"
 
-    cp "$SELF_DIR/apk/APKBUILD" "$SELF_DIR/apk/tengine.pre-install" "$work/"
+    cp "$SELF_DIR/apk/APKBUILD" "$SELF_DIR/apk/tengine.pre-install" \
+        "$SELF_DIR/apk/tengine.post-install" "$work/"
     cp "$SELF_DIR/conf/tengine.openrc" "$SELF_DIR/conf/tengine.logrotate" \
        "$SELF_DIR/conf/tengine.conf" "$work/"
     cp "$SELF_DIR/conf/conf.d/default.conf" "$work/"


### PR DESCRIPTION
**apk 属主** — APKBUILD 用 `install -d -o tengine -g tengine` 创建/var/cache/tengine 与 /var/log/tengine，而 tengine 用户由 .pre-install 在安装时创建，构建环境中并不存在，导致 `install: unknown user tengine`。改为按 deb 的做法，拆成两步：构建时只设权限，新增 .post-install 在解压后 chown（.pre-install 运行时目录尚不存在）。


