### PR TITLE
Build: align the package matrix with the platforms nginx supports

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -86,6 +86,7 @@ jobs:
           - debian13
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - alpine
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,7 +87,10 @@ jobs:
           - ubuntu2204
           - ubuntu2404
           - ubuntu2604
-          - alpine
+          - alpine321
+          - alpine322
+          - alpine323
+          - alpine324
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -81,6 +81,7 @@ jobs:
           - anolis8
           - openeuler2403
           - sles15
+          - sles16
           - debian11
           - debian12
           - debian13

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -64,7 +64,7 @@ usage() {
     exit "${1:-0}"
 }
 
-ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 debian11 debian12 debian13 ubuntu2204 ubuntu2404 alpine"
+ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 debian11 debian12 debian13 ubuntu2204 ubuntu2404 ubuntu2604 alpine"
 
 # Container targets: alias -> "image|family".  family drives both the
 # bootstrap commands and which native builder runs inside.
@@ -85,6 +85,7 @@ docker_image() {
         debian13)   echo "debian:13|deb" ;;
         ubuntu2204) echo "ubuntu:22.04|deb" ;;
         ubuntu2404) echo "ubuntu:24.04|deb" ;;
+        ubuntu2604) echo "ubuntu:26.04|deb" ;;
         alpine)     echo "alpine:3.22|apk" ;;
         *)          return 1 ;;
     esac

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -15,8 +15,9 @@
 #     packages/build/build.sh docker all     # every target listed below
 #
 # Container targets: el7 el8 el9 el10 fedora anolis8 anolis23 openeuler2203
-#                    openeuler2403 sles15 debian11 debian12 ubuntu2204
-#                    ubuntu2404 alpine
+#                    openeuler2403 sles15 sles16 debian11 debian12 debian13
+#                    ubuntu2204 ubuntu2404 ubuntu2604 alpine321 alpine322
+#                    alpine323 alpine324
 #
 # Tongsuo (NTLS), xquic (QUIC/HTTP-3) and the Lua stack are part of the default
 # feature set. Their sources are pinned in packages/build/deps.env, downloaded
@@ -64,7 +65,7 @@ usage() {
     exit "${1:-0}"
 }
 
-ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 debian11 debian12 debian13 ubuntu2204 ubuntu2404 ubuntu2604 alpine321 alpine322 alpine323 alpine324"
+ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 sles16 debian11 debian12 debian13 ubuntu2204 ubuntu2404 ubuntu2604 alpine321 alpine322 alpine323 alpine324"
 
 # Container targets: alias -> "image|family".  family drives both the
 # bootstrap commands and which native builder runs inside.
@@ -80,6 +81,7 @@ docker_image() {
         openeuler2203) echo "openeuler/openeuler:22.03-lts-sp4|rpm" ;;
         openeuler2403) echo "openeuler/openeuler:24.03-lts|rpm" ;;
         sles15)     echo "registry.suse.com/bci/bci-base:15.6|sles" ;;
+        sles16)     echo "registry.suse.com/bci/bci-base:16|sles" ;;
         debian11)   echo "debian:11|deb" ;;
         debian12)   echo "debian:12|deb" ;;
         debian13)   echo "debian:13|deb" ;;
@@ -479,6 +481,7 @@ run_docker_target() {
     if [ -z "$DIST_TAG" ]; then
         case "$target" in
             sles15)        target_dist=".sles15" ;;
+            sles16)        target_dist=".sles16" ;;
             openeuler2403) target_dist=".oe2403" ;;
         esac
     fi

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -64,7 +64,7 @@ usage() {
     exit "${1:-0}"
 }
 
-ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 debian11 debian12 debian13 ubuntu2204 ubuntu2404 ubuntu2604 alpine"
+ALL_TARGETS="el7 el8 el9 el10 anolis8 anolis23 openeuler2203 openeuler2403 sles15 debian11 debian12 debian13 ubuntu2204 ubuntu2404 ubuntu2604 alpine321 alpine322 alpine323 alpine324"
 
 # Container targets: alias -> "image|family".  family drives both the
 # bootstrap commands and which native builder runs inside.
@@ -86,7 +86,13 @@ docker_image() {
         ubuntu2204) echo "ubuntu:22.04|deb" ;;
         ubuntu2404) echo "ubuntu:24.04|deb" ;;
         ubuntu2604) echo "ubuntu:26.04|deb" ;;
-        alpine)     echo "alpine:3.22|apk" ;;
+        # An apk is tied to the musl and library sonames of the Alpine release it
+        # was built on, so unlike rpm/deb it cannot be carried to a newer one --
+        # hence one target per Alpine version that nginx also publishes for.
+        alpine321)  echo "alpine:3.21|apk" ;;
+        alpine322)  echo "alpine:3.22|apk" ;;
+        alpine323)  echo "alpine:3.23|apk" ;;
+        alpine324)  echo "alpine:3.24|apk" ;;
         *)          return 1 ;;
     esac
 }

--- a/packages/build/collect-release.sh
+++ b/packages/build/collect-release.sh
@@ -14,9 +14,10 @@
 # Two artifact naming quirks have to be handled, or files would silently
 # overwrite each other once the per-job directories are merged:
 #
-#   * apk file names carry no architecture, so the x86_64 and aarch64 builds of
-#     the same version are byte-different files with identical names. The
-#     architecture is appended here.
+#   * apk file names carry neither the architecture nor anything identifying the
+#     Alpine release they were built on, so every alpine target and architecture
+#     would produce the same name. Both are appended here, which is what lets the
+#     release ship one apk per Alpine version.
 #   * every architecture's job produces a .src.rpm of the same sources, but rpm
 #     stamps the build platform into the header, so the two are not byte-equal
 #     and a checksum comparison cannot dedupe them. One per target is what a
@@ -77,7 +78,7 @@ for jobdir in "$INDIR"/*; do
 
         srcrpm=no
         case "$base" in
-            *.apk)     base="${base%.apk}.$arch.apk" ;;
+            *.apk)     base="${base%.apk}.$target.$arch.apk" ;;
             *.src.rpm) srcrpm=yes ;;
         esac
 


### PR DESCRIPTION
## 背景

对照 nginx 的发布矩阵，Tengine 尚缺 Ubuntu 26.04、SLES 16，且 Alpine 只出 3.22 一个
版本。其中 Alpine 是唯一影响可安装性的一项：apk 与构建时的 musl、库 soname 绑定，
不像 rpm/deb 那样能向新版本平移，因此每个 Alpine 版本都需要单独出包。

## 改动

- 新增 `ubuntu2604` 目标。deb 的版本区分依赖 `VERSION_CODENAME`，`~resolute` 后缀
  自动生成，无需额外处理。
- apk 文件名加入目标标识。此前只带架构，四个 Alpine 版本会产出同名文件而在 release
  附件中互相覆盖。
- Alpine 拆分为 `alpine321` / `alpine322` / `alpine323` / `alpine324`。
- 新增 `sles16` 目标，并按 `sles15` 的方式给出 `.sles16` dist tag。

打包矩阵由 26 个 job 增至 36 个，覆盖 nginx 支持的全部平台与版本，另保留 Tengine
独有的 el7、anolis8、openeuler2403。

容器镜像不受影响：仍是 Debian 与 Alpine 各一个 flavour，与 nginx 官方镜像一致。
