### PR TITLE
Build: name the default install layout after Tengine

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ assignees: ''
 
 ### Ⅵ. Environment:
 
-- Tengine version (use `sbin/nginx -V`):
+- Tengine version (use `sbin/tengine -V`):
 - OS (e.g. from /etc/os-release):
 - Kernel (e.g. `uname -a`):
 - Others:

--- a/.github/ISSUE_TEMPLATE/question-about-tengine.md
+++ b/.github/ISSUE_TEMPLATE/question-about-tengine.md
@@ -3,7 +3,7 @@ name: Question about Tengine
 about: Ask whatever you want to know or confusion about Tengine
 title: ''
 labels: ''
-assignees: chobits
+assignees: ''
 
 ---
 

--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -97,4 +97,4 @@ jobs:
               --without-http_upstream_keepalive_module
             make -j4
             make install
-            file /usr/local/nginx/sbin/nginx | grep aarch64
+            file /usr/local/tengine/sbin/tengine | grep aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
        run: |
          sudo make install
 
-# TODO: fix tests so they don't depend on /usr/local/nginx/logs/
+# TODO: fix tests so they don't depend on /usr/local/tengine/logs/
 #       so we can run `make`, `make test`, `make install`.
 
      - name: build
@@ -117,7 +117,7 @@ jobs:
      - name: tengine test cases using nginx-tests lib
        working-directory: tests/nginx-tests
        env:
-         TEST_NGINX_BINARY: /usr/local/nginx/sbin/nginx
+         TEST_NGINX_BINARY: /usr/local/tengine/sbin/tengine
        run: |
          sudo cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
          prove -v -Inginx-tests/lib tengine-tests/
@@ -130,12 +130,12 @@ jobs:
        run: |
          sudo cpanm --notest Shell Test::Base Test::LongString List::MoreUtils LWP::UserAgent HTTP::Response  > build.log 2>&1 || (cat build.log && exit 1)
          mkdir t
-         PATH=/usr/local/nginx/sbin:$PATH \
+         TEST_NGINX_BINARY=/usr/local/tengine/sbin/tengine \
          prove -v -Itest-nginx/lib cases/
          # the cases/ prove above is non-recursive, so the upstream_check cases
          # live in a subdir that was never exercised; invoke them explicitly.
          # ssl_hello_check.t stays out on purpose -- see the note in that file.
-         PATH=/usr/local/nginx/sbin:$PATH \
+         TEST_NGINX_BINARY=/usr/local/tengine/sbin/tengine \
          prove -v -Itest-nginx/lib \
            cases/ngx_http_upstream_check_module/http_check.t \
            cases/ngx_http_upstream_check_module/http_check_keepalive_body.t \
@@ -172,7 +172,7 @@ jobs:
      - name: run native tunnel test cases
        working-directory: tests/nginx-tests
        env:
-         TEST_NGINX_BINARY: /usr/local/nginx/sbin/nginx
+         TEST_NGINX_BINARY: /usr/local/tengine/sbin/tengine
        run: |
          sudo cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
          prove -v -Inginx-tests/lib \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,12 +130,17 @@ jobs:
        run: |
          sudo cpanm --notest Shell Test::Base Test::LongString List::MoreUtils LWP::UserAgent HTTP::Response  > build.log 2>&1 || (cat build.log && exit 1)
          mkdir t
-         TEST_NGINX_BINARY=/usr/local/tengine/sbin/tengine \
+         # test-nginx resolves the binary with its own can_run(), which only
+         # joins each PATH entry with the given name -- an absolute path in
+         # TEST_NGINX_BINARY can never match. Pass the bare name and put the
+         # install dir on PATH. (nginx-tests execs the value directly, so the
+         # steps above can and do use an absolute path.)
+         PATH=/usr/local/tengine/sbin:$PATH TEST_NGINX_BINARY=tengine \
          prove -v -Itest-nginx/lib cases/
          # the cases/ prove above is non-recursive, so the upstream_check cases
          # live in a subdir that was never exercised; invoke them explicitly.
          # ssl_hello_check.t stays out on purpose -- see the note in that file.
-         TEST_NGINX_BINARY=/usr/local/tengine/sbin/tengine \
+         PATH=/usr/local/tengine/sbin:$PATH TEST_NGINX_BINARY=tengine \
          prove -v -Itest-nginx/lib \
            cases/ngx_http_upstream_check_module/http_check.t \
            cases/ngx_http_upstream_check_module/http_check_keepalive_body.t \

--- a/.github/workflows/test-nginx-core.yml
+++ b/.github/workflows/test-nginx-core.yml
@@ -149,7 +149,7 @@ jobs:
      - name: run cases in nginx-tests
        working-directory: tests/nginx-tests
        env:
-         TEST_NGINX_BINARY: /usr/local/nginx/sbin/nginx
+         TEST_NGINX_BINARY: /usr/local/tengine/sbin/tengine
          # Do not set TEST_NGINX_UNSAFE here: it force-enables assertions that
          # upstream guards with "skip 'unsafe on VM'". Those assertions rely on
          # sub-second response timing and are unreliable on a 2-core CI runner
@@ -164,5 +164,5 @@ jobs:
          prove -I nginx-tests/lib nginx-tests/
          # It must be root for some cases.
          sudo groupadd wheel    # for proxy_bind_transparent.t
-         sudo TEST_NGINX_BINARY=/usr/local/nginx/sbin/nginx TEST_NGINX_UNSAFE=yes prove -I nginx-tests/lib nginx-tests/proxy_bind_transparent.t nginx-tests/proxy_bind_transparent_capability.t
+         sudo TEST_NGINX_BINARY=/usr/local/tengine/sbin/tengine TEST_NGINX_UNSAFE=yes prove -I nginx-tests/lib nginx-tests/proxy_bind_transparent.t nginx-tests/proxy_bind_transparent_capability.t
 

--- a/.github/workflows/test-ntls.yml
+++ b/.github/workflows/test-ntls.yml
@@ -136,7 +136,7 @@ jobs:
         working-directory: tengine
         env:
           TEST_OPENSSL_BINARY: ${{ runner.temp }}/tongsuo/bin/tongsuo
-          TEST_NGINX_BINARY: /usr/local/nginx/sbin/nginx
+          TEST_NGINX_BINARY: /usr/local/tengine/sbin/tengine
           TEST_NGINX_LEAVE: 1
         run: |
           prove -Itests/nginx-tests/nginx-tests/lib/ modules/ngx_tongsuo_ntls/t
@@ -144,7 +144,7 @@ jobs:
         working-directory: tengine
         env:
           TEST_XQUIC_CLIENT: ${{ github.workspace }}/xquic/build/test_client
-          TEST_NGINX_BINARY: /usr/local/nginx/sbin/nginx
+          TEST_NGINX_BINARY: /usr/local/tengine/sbin/tengine
           TEST_NGINX_LEAVE: 1
         run: |
           prove -Itests/nginx-tests/nginx-tests/lib/ modules/ngx_http_xquic_module/t

--- a/CHANGES.cn
+++ b/CHANGES.cn
@@ -25,6 +25,7 @@ Tengine 3.2.0 [2026-07-31]
 * Feature: 新增发行版软件包(rpm、deb和apk)与多架构容器镜像，默认构建完备功能集——Tongsuo、xquic和Lua (lianglli)
 * Feature: 新增configure选项--with-xquic-rpath，将xquic运行时查找路径与链接路径解耦 (lianglli)
 * Feature: 公开ngx_http_upstream_rbtree_lookup()，便于第三方模块按名字查找upstream (lhanjian)
+* Change: 自助编译的默认安装路径由沿用nginx的命名改为tengine：前缀/usr/local/tengine、二进制sbin/tengine、配置conf/tengine.conf、pid文件logs/tengine.pid，与rpm、deb、apk包及容器镜像保持一致。旧版本安装在原路径下，make install不会覆盖它，旧二进制会继续运行；切换后请自行删除旧安装，或通过--prefix、--sbin-path、--conf-path、--pid-path显式保留原有布局 (lianglli)
 * Change: 升级core代码到Nginx-1.31.3版本 (lianglli)
 * Change: 升级ngx_http_lua_module到0.10.29版本，支持PCRE2并与pin的lua-resty-core版本匹配，此前仅有PCRE2的环境下编译失败 (lianglli)
 * Change: 默认拥塞控制算法由CUBIC改为BBR [XQUIC] (lurker-Chen)

--- a/CHANGES.te
+++ b/CHANGES.te
@@ -82,6 +82,16 @@ Changes with Tengine 3.2.0                                         31 Jul 2026
     *) Feature: expose ngx_http_upstream_rbtree_lookup() so that third-party
        modules can look an upstream up by name (lhanjian)
 
+    *) Change: the default install layout inherited from nginx is now named
+       after Tengine: prefix /usr/local/tengine, binary sbin/tengine,
+       configuration conf/tengine.conf, and logs/tengine.pid. This matches
+       the layout the rpm, deb and apk packages and the container images
+       already used. An install made by an earlier release uses the old
+       paths, so "make install" leaves it in place instead of upgrading it
+       and the old binary keeps running; remove it once you have switched
+       over, or keep the previous layout by passing --prefix, --sbin-path,
+       --conf-path and --pid-path explicitly (lianglli)
+
     *) Change: update core to Nginx-1.31.3 (lianglli)
 
     *) Change: update ngx_http_lua_module to 0.10.29, which adds PCRE2

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN set -eux; \
     cp -a /tmp/deps-staging/. /out/
 
 # Same post-install fixups as the distro packages: ship the packaged
-# tengine.conf instead of the stock nginx.conf, resolve the libdir placeholder
+# tengine.conf instead of the in-tree one, resolve the libdir placeholder
 # in lua_package_cpath, and drop /run (a tmpfs at runtime).
 RUN set -eux; \
     rm -f /out/etc/tengine/*.default; \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -51,7 +51,7 @@ RUN set -eux; \
     cp -a /tmp/deps-staging/. /out/
 
 # Same post-install fixups as the distro packages: ship the packaged
-# tengine.conf instead of the stock nginx.conf, resolve the libdir placeholder
+# tengine.conf instead of the in-tree one, resolve the libdir placeholder
 # in lua_package_cpath, and drop /run (a tmpfs at runtime).
 RUN set -eux; \
     rm -f /out/etc/tengine/*.default; \

--- a/README.markdown
+++ b/README.markdown
@@ -93,8 +93,38 @@ make
 sudo make install
 ```
 
-By default, it will be installed to _/usr/local/nginx_. You can use the __'--prefix'__ option to specify the root directory.
+By default, it will be installed to _/usr/local/tengine_. Everything is named after Tengine, which matches the layout used by the `.rpm`/`.deb`/`.apk` packages and the container images:
+
+| | Default path |
+|---|---|
+| binary | `/usr/local/tengine/sbin/tengine` |
+| configuration | `/usr/local/tengine/conf/tengine.conf` |
+| pid file | `/usr/local/tengine/logs/tengine.pid` |
+| error log | `/usr/local/tengine/logs/error.log` |
+| access log | `/usr/local/tengine/logs/access.log` |
+| dynamic modules | `/usr/local/tengine/modules` |
+
+You can use the __'--prefix'__ option to specify the root directory, or `--sbin-path`, `--conf-path`, `--pid-path`, `--error-log-path` and `--http-log-path` to place the individual files.
 If you want to know all the _'configure'_ options, you should run __'./configure --help'__ for help.
+
+> **Upgrading from 3.1.0 or earlier.** Those releases installed to
+> _/usr/local/nginx_ as `sbin/nginx` driven by `conf/nginx.conf`. Because
+> 3.2.0 writes to different paths, `make install` does not replace that
+> install -- the old binary stays on disk and keeps serving traffic, and
+> running it still reports the old version, which easily reads as "the
+> upgrade did not take effect". After switching over, stop and remove the old
+> install, and update any systemd unit, init script or log rotation config
+> still pointing at the old paths. `configure` prints a warning when it finds
+> an install at `/usr/local/nginx/sbin/nginx`.
+>
+> To keep the previous layout instead, pass the old paths explicitly:
+>
+> ```bash
+> ./configure --prefix=/usr/local/nginx \
+>     --sbin-path=/usr/local/nginx/sbin/nginx \
+>     --conf-path=/usr/local/nginx/conf/nginx.conf \
+>     --pid-path=/usr/local/nginx/logs/nginx.pid
+> ```
 
 A plain `./configure` builds without Tongsuo, xquic and Lua -- those need their own libraries. To reproduce the full feature set of the released packages and images, use the packaging helpers:
 

--- a/auto/configure
+++ b/auto/configure
@@ -65,7 +65,7 @@ fi
 
 case ".$NGX_PREFIX" in
     .)
-        NGX_PREFIX=${NGX_PREFIX:-/usr/local/nginx}
+        NGX_PREFIX=${NGX_PREFIX:-/usr/local/tengine}
         have=NGX_PREFIX value="\"$NGX_PREFIX/\"" . auto/define
     ;;
 

--- a/auto/install
+++ b/auto/install
@@ -81,10 +81,10 @@ case ".$NGX_HTTP_LOG_PATH" in
 esac
 
 
-if test -f man/nginx.8 ; then
-    NGX_MAN=man/nginx.8
+if test -f man/tengine.8 ; then
+    NGX_MAN=man/tengine.8
 else
-    NGX_MAN=docs/man/nginx.8
+    NGX_MAN=docs/man/tengine.8
 fi
 
 if test -d html ; then
@@ -95,9 +95,9 @@ fi
 
 cat << END                                                    >> $NGX_MAKEFILE
 
-manpage:	$NGX_OBJS/nginx.8
+manpage:	$NGX_OBJS/tengine.8
 
-$NGX_OBJS/nginx.8:	$NGX_MAN $NGX_AUTO_CONFIG_H
+$NGX_OBJS/tengine.8:	$NGX_MAN $NGX_AUTO_CONFIG_H
 	sed -e "s|%%PREFIX%%|$NGX_PREFIX|" \\
 		-e "s|%%PID_PATH%%|$NGX_PID_PATH|" \\
 		-e "s|%%CONF_PATH%%|$NGX_CONF_PATH|" \\
@@ -145,8 +145,8 @@ install:	build $NGX_INSTALL_PERL_MODULES
 		'\$(DESTDIR)$NGX_CONF_PREFIX/scgi_params.default'
 
 	test -f '\$(DESTDIR)$NGX_CONF_PATH' \\
-		|| cp conf/nginx.conf '\$(DESTDIR)$NGX_CONF_PATH'
-	cp conf/nginx.conf '\$(DESTDIR)$NGX_CONF_PREFIX/nginx.conf.default'
+		|| cp conf/tengine.conf '\$(DESTDIR)$NGX_CONF_PATH'
+	cp conf/tengine.conf '\$(DESTDIR)$NGX_CONF_PREFIX/tengine.conf.default'
 
 	test -d '\$(DESTDIR)`dirname "$NGX_PID_PATH"`' \\
 		|| mkdir -p '\$(DESTDIR)`dirname "$NGX_PID_PATH"`'

--- a/auto/options
+++ b/auto/options
@@ -491,12 +491,12 @@ cat << END
   --help                             print this message
 
   --prefix=PATH                      set installation prefix
-  --sbin-path=PATH                   set nginx binary pathname
+  --sbin-path=PATH                   set tengine binary pathname
   --modules-path=PATH                set modules path
-  --conf-path=PATH                   set nginx.conf pathname
+  --conf-path=PATH                   set tengine.conf pathname
   --error-log-path=PATH              set error log pathname
-  --pid-path=PATH                    set nginx.pid pathname
-  --lock-path=PATH                   set nginx.lock pathname
+  --pid-path=PATH                    set tengine.pid pathname
+  --lock-path=PATH                   set tengine.lock pathname
 
   --user=USER                        set non-privileged user for
                                      worker processes
@@ -706,12 +706,32 @@ if [ ".$NGX_PLATFORM" = ".win32" ]; then
 fi
 
 
-NGX_SBIN_PATH=${NGX_SBIN_PATH:-sbin/nginx}
+# Tengine 3.2.0 renamed the default install layout from the inherited nginx
+# names to tengine (prefix /usr/local/tengine, binary sbin/tengine, config
+# conf/tengine.conf). An install made by an earlier release lives under
+# different paths, so "make install" no longer replaces it and the old binary
+# keeps serving traffic. Warn when both the paths are defaulted and a legacy
+# install is present, since the two would otherwise coexist silently.
+if [ -z "$NGX_PREFIX" ] && [ -z "$NGX_SBIN_PATH" ] \
+   && [ -x /usr/local/nginx/sbin/nginx ]
+then
+    NGX_POST_CONF_MSG="$NGX_POST_CONF_MSG
+$0: warning: found an existing install at \"/usr/local/nginx/sbin/nginx\". \
+Tengine 3.2.0 installs to \"/usr/local/tengine/sbin/tengine\" by default, so \
+\"make install\" will not replace that binary and the old one keeps running. \
+Remove the old install once you have switched over, or keep the previous \
+layout by passing --prefix=/usr/local/nginx \
+--sbin-path=/usr/local/nginx/sbin/nginx \
+--conf-path=/usr/local/nginx/conf/nginx.conf \
+--pid-path=/usr/local/nginx/logs/nginx.pid"
+fi
+
+NGX_SBIN_PATH=${NGX_SBIN_PATH:-sbin/tengine}
 NGX_MODULES_PATH=${NGX_MODULES_PATH:-modules}
-NGX_CONF_PATH=${NGX_CONF_PATH:-conf/nginx.conf}
+NGX_CONF_PATH=${NGX_CONF_PATH:-conf/tengine.conf}
 NGX_CONF_PREFIX=`dirname $NGX_CONF_PATH`
-NGX_PID_PATH=${NGX_PID_PATH:-logs/nginx.pid}
-NGX_LOCK_PATH=${NGX_LOCK_PATH:-logs/nginx.lock}
+NGX_PID_PATH=${NGX_PID_PATH:-logs/tengine.pid}
+NGX_LOCK_PATH=${NGX_LOCK_PATH:-logs/tengine.lock}
 
 if [ ".$NGX_ERROR_LOG_PATH" = ".stderr" ]; then
     NGX_ERROR_LOG_PATH=

--- a/auto/summary
+++ b/auto/summary
@@ -54,39 +54,39 @@ echo
 
 
 cat << END
-  nginx path prefix: "$NGX_PREFIX"
-  nginx binary file: "$NGX_SBIN_PATH"
-  nginx modules path: "$NGX_MODULES_PATH"
-  nginx configuration prefix: "$NGX_CONF_PREFIX"
-  nginx configuration file: "$NGX_CONF_PATH"
-  nginx pid file: "$NGX_PID_PATH"
+  tengine path prefix: "$NGX_PREFIX"
+  tengine binary file: "$NGX_SBIN_PATH"
+  tengine modules path: "$NGX_MODULES_PATH"
+  tengine configuration prefix: "$NGX_CONF_PREFIX"
+  tengine configuration file: "$NGX_CONF_PATH"
+  tengine pid file: "$NGX_PID_PATH"
 END
 
 if test -n "$NGX_ERROR_LOG_PATH"; then
-    echo "  nginx error log file: \"$NGX_ERROR_LOG_PATH\""
+    echo "  tengine error log file: \"$NGX_ERROR_LOG_PATH\""
 else
-    echo "  nginx logs errors to stderr"
+    echo "  tengine logs errors to stderr"
 fi
 
 cat << END
-  nginx http access log file: "$NGX_HTTP_LOG_PATH"
-  nginx http client request body temporary files: "$NGX_HTTP_CLIENT_TEMP_PATH"
+  tengine http access log file: "$NGX_HTTP_LOG_PATH"
+  tengine http client request body temporary files: "$NGX_HTTP_CLIENT_TEMP_PATH"
 END
 
 if [ $HTTP_PROXY = YES ]; then
-    echo "  nginx http proxy temporary files: \"$NGX_HTTP_PROXY_TEMP_PATH\""
+    echo "  tengine http proxy temporary files: \"$NGX_HTTP_PROXY_TEMP_PATH\""
 fi
 
 if [ $HTTP_FASTCGI = YES ]; then
-    echo "  nginx http fastcgi temporary files: \"$NGX_HTTP_FASTCGI_TEMP_PATH\""
+    echo "  tengine http fastcgi temporary files: \"$NGX_HTTP_FASTCGI_TEMP_PATH\""
 fi
 
 if [ $HTTP_UWSGI = YES ]; then
-    echo "  nginx http uwsgi temporary files: \"$NGX_HTTP_UWSGI_TEMP_PATH\""
+    echo "  tengine http uwsgi temporary files: \"$NGX_HTTP_UWSGI_TEMP_PATH\""
 fi
 
 if [ $HTTP_SCGI = YES ]; then
-    echo "  nginx http scgi temporary files: \"$NGX_HTTP_SCGI_TEMP_PATH\""
+    echo "  tengine http scgi temporary files: \"$NGX_HTTP_SCGI_TEMP_PATH\""
 fi
 
 echo "$NGX_POST_CONF_MSG"

--- a/conf/tengine.conf
+++ b/conf/tengine.conf
@@ -7,7 +7,7 @@ worker_processes  1;
 #error_log  logs/error.log  info;
 #error_log  "pipe:rollback logs/error_log interval=1d baknum=7 maxsize=2G";
 
-#pid        logs/nginx.pid;
+#pid        logs/tengine.pid;
 
 
 events {

--- a/configure
+++ b/configure
@@ -64,7 +64,7 @@ fi
 
 case ".$NGX_PREFIX" in
     .)
-        NGX_PREFIX=${NGX_PREFIX:-/usr/local/nginx}
+        NGX_PREFIX=${NGX_PREFIX:-/usr/local/tengine}
         have=NGX_PREFIX value="\"$NGX_PREFIX/\"" . auto/define
     ;;
 

--- a/contrib/vim/ftdetect/nginx.vim
+++ b/contrib/vim/ftdetect/nginx.vim
@@ -2,3 +2,6 @@ au BufRead,BufNewFile *.nginx set ft=nginx
 au BufRead,BufNewFile */etc/nginx/* set ft=nginx
 au BufRead,BufNewFile */usr/local/nginx/conf/* set ft=nginx
 au BufRead,BufNewFile nginx.conf set ft=nginx
+au BufRead,BufNewFile */etc/tengine/* set ft=nginx
+au BufRead,BufNewFile */usr/local/tengine/conf/* set ft=nginx
+au BufRead,BufNewFile tengine.conf set ft=nginx

--- a/docs/modules/ngx_http_ssl_asynchronous_mode.md
+++ b/docs/modules/ngx_http_ssl_asynchronous_mode.md
@@ -28,7 +28,7 @@ Enables SSL/TLS asynchronous mode for the given virtual server.
 Example
 ==========
 
-file: conf/nginx.conf
+file: conf/tengine.conf
 '''
     http {
         ssl_async  on;

--- a/docs/modules/ngx_http_ssl_asynchronous_mode_cn.md
+++ b/docs/modules/ngx_http_ssl_asynchronous_mode_cn.md
@@ -28,7 +28,7 @@ Description
 配置示例
 ==========
 
-配置文件: conf/nginx.conf
+配置文件: conf/tengine.conf
 '''
     http {
         ssl_async  on;

--- a/docs/modules/ngx_http_upstream_dyups_module.md
+++ b/docs/modules/ngx_http_upstream_dyups_module.md
@@ -4,7 +4,7 @@ This module can be used to update your upstream-list without reloadding Nginx.
 
 ## Example
 
-file: conf/nginx.conf
+file: conf/tengine.conf
 
 `ATTENTION`: You MUST use nginx variable to do proxy_pass
 

--- a/man/tengine.8
+++ b/man/tengine.8
@@ -26,10 +26,10 @@
 .\"
 .\"
 .Dd June 16, 2015
-.Dt NGINX 8
+.Dt TENGINE 8
 .Os
 .Sh NAME
-.Nm nginx
+.Nm tengine
 .Nd "HTTP and reverse proxy server, mail proxy server"
 .Sh SYNOPSIS
 .Nm
@@ -177,30 +177,36 @@ Error log file.
 Exit status is 0 on success, or 1 if the command fails.
 .Sh EXAMPLES
 Test configuration file
-.Pa ~/mynginx.conf
+.Pa ~/mytengine.conf
 with global directives for PID and quantity of worker processes:
 .Bd -literal -offset indent
-nginx -t -c ~/mynginx.conf \e
-	-g "pid /var/run/mynginx.pid; worker_processes 2;"
+tengine -t -c ~/mytengine.conf \e
+	-g "pid /var/run/mytengine.pid; worker_processes 2;"
 .Ed
 .Sh SEE ALSO
-.\"Xr nginx.conf 5
+.\"Xr tengine.conf 5
 .\"Pp
 Documentation at
-.Pa http://nginx.org/en/docs/ .
+.Pa https://tengine.taobao.org/ .
 .Pp
 For questions and technical support, please refer to
-.Pa http://nginx.org/en/support.html .
+.Pa https://github.com/alibaba/tengine/issues .
 .Sh HISTORY
-Development of
 .Nm
-started in 2002, with the first public release on October 4, 2004.
+is a fork of nginx, whose development started in 2002 with the first public
+release on October 4, 2004.
+.Nm
+was started at Taobao and first released publicly on December 1, 2011.
 .Sh AUTHORS
 .An -nosplit
-.An Igor Sysoev Aq igor@sysoev.ru .
+.An Igor Sysoev Aq igor@sysoev.ru
+wrote nginx, on which
+.Nm
+is based.
+.Nm
+is maintained by the Tengine team at Alibaba.
 .Pp
 This manual page was originally written by
 .An Sergey A. Osokin Aq osa@FreeBSD.org.ru
-as a result of compiling many
-.Nm
+as a result of compiling many nginx
 documents from all over the world.

--- a/modules/mod_dubbo/README.md
+++ b/modules/mod_dubbo/README.md
@@ -35,7 +35,7 @@ sudo yum install gcc-c++
 
 ### Run Tengine
 
-modify tengine config file ```/usr/local/nginx/conf/nginx.conf``` to 
+modify tengine config file ```/usr/local/tengine/conf/tengine.conf``` to 
 
 ```
 worker_processes  1;
@@ -81,15 +81,15 @@ http {
 ### Start Tengine
 
 ```
-/usr/local/nginx/sbin/nginx
+/usr/local/tengine/sbin/tengine
 ```
 
 Other Commond (no need execute usual)
 ```
 #restart
-/usr/local/nginx/sbin/nginx -s reload
+/usr/local/tengine/sbin/tengine -s reload
 #stop
-/usr/local/nginx/sbin/nginx -s stop
+/usr/local/tengine/sbin/tengine -s stop
 ```
 
 ### More document

--- a/modules/ngx_http_lua_module/LICENSE
+++ b/modules/ngx_http_lua_module/LICENSE
@@ -1,0 +1,29 @@
+BSD 2-Clause License
+
+Copyright (C) 2009-2017, by Xiaozhe Wang (chaoslawful) <chaoslawful@gmail.com>.
+
+Copyright (C) 2009-2019, by Yichun "agentzh" Zhang (章亦春) <agentzh@gmail.com>,
+OpenResty Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/modules/ngx_http_xquic_module/README.md
+++ b/modules/ngx_http_xquic_module/README.md
@@ -89,7 +89,7 @@ http {
 启动 tengine
 
 ```shell
-/usr/local/tengine/sbin/tengine -p /usr/local/tengine/ -c conf/nginx.conf
+/usr/local/tengine/sbin/tengine -p /usr/local/tengine/ -c conf/tengine.conf
 ```
 
 启动后 tengine 监听 2443 UDP 端口，此端口可以接收 HTTP3 请求，可以通过编译 xquic 自带的 `test_client` 测试（cmake 编译 xquic 时需要带 `-DXQC_ENABLE_TESTING=1` 参数）

--- a/packages/build/apk/APKBUILD
+++ b/packages/build/apk/APKBUILD
@@ -80,8 +80,8 @@ package() {
 	# their final absolute paths already in place.
 	cp -a "$srcdir"/deps-staging/. "$pkgdir"/
 
-	# make install drops the stock nginx.conf plus *.default copies; replace
-	# them with the packaged tengine.conf so the shipped names stay consistent.
+	# make install ships the in-tree conf/tengine.conf plus *.default copies;
+	# replace them with the packaged tengine.conf, which adds the conf.d layout.
 	rm -f "$pkgdir"/etc/tengine/*.default
 	install -D -m 0644 "$srcdir"/tengine.conf \
 		"$pkgdir"/etc/tengine/tengine.conf
@@ -97,7 +97,7 @@ package() {
 	    -e 's|%%PID_PATH%%|/run/tengine.pid|' \
 	    -e 's|%%CONF_PATH%%|/etc/tengine/tengine.conf|' \
 	    -e 's|%%ERROR_LOG_PATH%%|/var/log/tengine/error.log|' \
-	    man/nginx.8 > tengine.8
+	    man/tengine.8 > tengine.8
 	install -D -m 0644 tengine.8 \
 		"$pkgdir"/usr/share/man/man8/tengine.8
 

--- a/packages/build/deb/debian/rules
+++ b/packages/build/deb/debian/rules
@@ -51,8 +51,8 @@ override_dh_auto_install:
 	# The bundled libxquic.so / libluajit and the Lua modules are staged with
 	# their final absolute paths already in place.
 	cp -a $(CURDIR)/deps-staging/. $(PKGDIR)/
-	# make install drops the stock nginx.conf plus *.default copies; replace
-	# them with the packaged tengine.conf so the shipped names stay consistent.
+	# make install ships the in-tree conf/tengine.conf plus *.default copies;
+	# replace them with the packaged tengine.conf, which adds the conf.d layout.
 	rm -f $(CONFDIR)/*.default
 	install -p -m 0644 packages/build/conf/tengine.conf \
 		$(CONFDIR)/tengine.conf
@@ -65,7 +65,7 @@ override_dh_auto_install:
 	    -e 's|%%PID_PATH%%|/run/tengine.pid|' \
 	    -e 's|%%CONF_PATH%%|/etc/tengine/tengine.conf|' \
 	    -e 's|%%ERROR_LOG_PATH%%|/var/log/tengine/error.log|' \
-	    man/nginx.8 > debian/tengine.8
+	    man/tengine.8 > debian/tengine.8
 	install -D -p -m 0644 debian/tengine.8 \
 		$(PKGDIR)/usr/share/man/man8/tengine.8
 	install -d -m 0700 $(PKGDIR)/var/cache/tengine

--- a/packages/build/rpm/tengine.spec
+++ b/packages/build/rpm/tengine.spec
@@ -250,8 +250,8 @@ make install DESTDIR=%{buildroot}
 # build-deps.sh are staged with their final absolute paths already in place.
 cp -a %{_builddir}/deps-staging/. %{buildroot}/
 
-# make install drops the stock nginx.conf plus *.default copies; replace them
-# with the packaged tengine.conf so the shipped names stay consistent.
+# make install ships the in-tree conf/tengine.conf plus *.default copies;
+# replace them with the packaged tengine.conf, which adds the conf.d layout.
 rm -f %{buildroot}%{tengine_confdir}/*.default
 install -p -m 0644 packages/build/conf/tengine.conf \
     %{buildroot}%{tengine_confdir}/tengine.conf
@@ -278,7 +278,7 @@ sed -e 's|%%PREFIX%%|%{tengine_datadir}|' \
     -e 's|%%PID_PATH%%|/run/tengine.pid|' \
     -e 's|%%CONF_PATH%%|%{tengine_confdir}/tengine.conf|' \
     -e 's|%%ERROR_LOG_PATH%%|%{tengine_logdir}/error.log|' \
-    man/nginx.8 > tengine.8
+    man/tengine.8 > tengine.8
 install -D -p -m 0644 tengine.8 %{buildroot}%{_mandir}/man8/tengine.8
 
 install -d -m 0700 %{buildroot}%{tengine_home}


### PR DESCRIPTION
自助编译一直沿用 nginx 的安装命名，装出 /usr/local/nginx/sbin/nginx 与
conf/nginx.conf，而 rpm、deb、apk 包和容器镜像早已统一用 tengine 命名，两者
不一致。现将 configure 默认值改为 /usr/local/tengine，二进制、配置、pid 文件
分别为 sbin/tengine、conf/tengine.conf、logs/tengine.pid，随附的 conf 与
man page 源文件一并改名。

objs/nginx 这个构建产物名保持不变：它是测试框架的默认查找路径，改名会在每次
同步 nginx 时产生冲突，而用户看不到该中间产物。

这是破坏性变更。旧版本装在不同路径下，make install 不会覆盖它，旧二进制会继续
运行且版本号仍是旧的，容易被误判成升级未生效。为此 configure 在检测到旧安装时
给出告警，并在 README 与 changelog 中说明如何清理或显式保留旧布局。
