### PR TITLE
Packaging: extend the distro matrix and publish -perl container images

### DIFF
--- a/.github/scripts/image-tags.sh
+++ b/.github/scripts/image-tags.sh
@@ -9,6 +9,12 @@
 #     .github/scripts/image-tags.sh debian 3.2.0 true
 #     .github/scripts/image-tags.sh alpine 3.2.0 true
 #
+# A fourth argument names an image variant, which is appended to every tag the
+# same way nginx suffixes its own variants:
+#
+#     .github/scripts/image-tags.sh debian 3.2.0 true perl
+#         -> 3.2.0-perl 3.2.0-trixie-perl ... perl trixie-perl
+#
 # Version-pinned tags (3.2.0, 3.2.0-trixie) are always printed. The rolling
 # tags -- the minor and major series, "latest" and the bare distro name -- only
 # come out when <move-rolling> is true, so a pre-release tag can never become
@@ -22,14 +28,18 @@
 
 set -eu
 
-[ $# -eq 3 ] || {
-    echo "usage: ${0##*/} <debian|alpine> <version> <move-rolling:true|false>" >&2
+[ $# -eq 3 ] || [ $# -eq 4 ] || {
+    echo "usage: ${0##*/} <debian|alpine> <version> <move-rolling:true|false> [variant]" >&2
     exit 2
 }
 
 FLAVOR=$1
 VERSION=$2
 MOVE=$3
+VARIANT=${4:-}
+
+# Appended to every tag: "" for the default image, "-perl" for the perl one.
+sfx=${VARIANT:+-$VARIANT}
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 ROOT=$(CDPATH= cd -- "$SELF_DIR/../.." && pwd)
@@ -85,16 +95,16 @@ fi
 # Each series gets both an unsuffixed (or -alpine) tag and a distro-suffixed
 # one: 3.2.0 / 3.2.0-trixie, 3.2.0-alpine / 3.2.0-alpine3.24.
 for v in $series; do
-    if [ -n "$flavor_tag" ]; then
-        echo "$v-$flavor_tag"
-    else
-        echo "$v"
-    fi
-    echo "$v-$distro"
+    echo "$v${flavor_tag:+-$flavor_tag}$sfx"
+    echo "$v-$distro$sfx"
 done
 
-# The floating aliases: "latest"/"alpine" and the bare distro name.
+# The floating aliases: "latest"/"alpine" and the bare distro name. A variant
+# replaces "latest" rather than extending it, which is how nginx spells them --
+# "perl" and "alpine-perl", never "latest-perl".
 if [ "$MOVE" = true ]; then
-    echo "${flavor_tag:-latest}"
-    echo "$distro"
+    alias_tag=$flavor_tag
+    [ -n "$VARIANT" ] && alias_tag="${alias_tag:+$alias_tag-}$VARIANT"
+    echo "${alias_tag:-latest}"
+    echo "$distro$sfx"
 fi

--- a/.github/scripts/verify-image.sh
+++ b/.github/scripts/verify-image.sh
@@ -5,6 +5,11 @@
 # Lua) are really in the build rather than just claimed in the release notes.
 #
 #     .github/scripts/verify-image.sh ghcr.io/alibaba/tengine:3.2.0
+#     .github/scripts/verify-image.sh ghcr.io/alibaba/tengine:3.2.0-perl --variant perl
+#
+# With --variant perl the perl module is additionally required to load and run
+# a handler; without it, the module is required to be ABSENT, which is what
+# keeps the default image from quietly growing the variant's payload.
 #
 # Used by .github/workflows/docker.yml for both the build-only and the
 # published-tag verification paths.
@@ -12,8 +17,20 @@
 
 set -eu
 
-[ $# -eq 1 ] || { echo "usage: ${0##*/} <image ref>" >&2; exit 2; }
-IMAGE=$1
+IMAGE=""
+VARIANT=default
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --variant) VARIANT=$2; shift 2 ;;
+        -*) echo "unknown option: $1" >&2; exit 2 ;;
+        *)  [ -z "$IMAGE" ] || { echo "unexpected argument: $1" >&2; exit 2; }
+            IMAGE=$1; shift ;;
+    esac
+done
+[ -n "$IMAGE" ] || {
+    echo "usage: ${0##*/} <image ref> [--variant perl]" >&2
+    exit 2
+}
 
 ok()   { printf '  \033[1;32mok\033[0m   %s\n' "$*"; }
 fail() { printf '  \033[1;31mFAIL\033[0m %s\n' "$*" >&2; exit 1; }
@@ -21,7 +38,9 @@ fail() { printf '  \033[1;31mFAIL\033[0m %s\n' "$*" >&2; exit 1; }
 # CMD is overridden, there is no ENTRYPOINT to work around.
 in_image() { docker run --rm "$IMAGE" "$@"; }
 
-echo "verifying $IMAGE"
+echo "verifying $IMAGE (variant: $VARIANT)"
+
+PERL_MODULE=/usr/lib/tengine/modules/ngx_http_perl_module.so
 
 # ---------------------------------------------------------------- build config
 
@@ -45,6 +64,26 @@ done
 case "$banner" in
     *enable-ntls*) ok "built against Tongsuo with NTLS enabled" ;;
     *) fail "no enable-ntls in the configure arguments: NTLS is not really in this build" ;;
+esac
+
+# ---------------------------------------------------------------- perl payload
+
+# One compile feeds both variants, so the banner always advertises the perl
+# module and cannot distinguish them -- only the presence of the .so can. The
+# negative check matters just as much as the positive one: if the builder ever
+# stops moving the module into /out-perl, the default image would silently ship
+# it (and fail to load it, having no libperl).
+if in_image test -f "$PERL_MODULE" 2>/dev/null; then
+    have_perl=yes
+else
+    have_perl=no
+fi
+
+case "$VARIANT:$have_perl" in
+    perl:yes)    ok "ngx_http_perl_module.so is present" ;;
+    perl:no)     fail "the perl variant is missing $PERL_MODULE" ;;
+    default:no)  ok "no perl module in the default image, as intended" ;;
+    default:yes) fail "$PERL_MODULE leaked into the default image" ;;
 esac
 
 # ------------------------------------------------------------------ config test
@@ -86,7 +125,37 @@ server {
 }
 EOF
 
-cid=$(docker run -d -p 18080:80 -p 18081:8081 \
+# A second server block rather than another location, so the Lua one above
+# stays byte-identical between the two variants.
+#
+# require nginx + $nginx::VERSION is the point of the handler: nginx.pm lives in
+# the private perl_modules_path compiled into the binary's @INC, so a response
+# carrying its version proves that path resolved. Returning 0 (NGX_OK) instead
+# of the OK constant keeps the handler independent of nginx.pm's exports.
+perl_ports=""
+if [ "$VARIANT" = perl ]; then
+    perl_ports="-p 18082:8082"
+    cat >> "$workdir/zz-verify.conf" <<'EOF'
+
+server {
+    listen 8082;
+
+    location = /verify-perl {
+        perl 'sub {
+            my $r = shift;
+            require nginx;
+            $r->send_http_header("text/plain");
+            $r->print("perl:ok nginx.pm=" . $nginx::VERSION . "\n");
+            return 0;
+        }';
+    }
+}
+EOF
+fi
+
+# $perl_ports is deliberately unquoted: it is either empty or two words.
+# shellcheck disable=SC2086
+cid=$(docker run -d -p 18080:80 -p 18081:8081 $perl_ports \
     -v "$workdir/zz-verify.conf:/etc/tengine/conf.d/zz-verify.conf:ro" \
     "$IMAGE")
 
@@ -119,4 +188,22 @@ case "$lua_out" in
     *)               fail "Lua regexes are not on PCRE2: $lua_out" ;;
 esac
 
-echo "all checks passed for $IMAGE"
+# ------------------------------------------------------------------------ perl
+
+if [ "$VARIANT" = perl ]; then
+    perl_out=$(curl -fsS "http://127.0.0.1:18082/verify-perl") || {
+        docker logs "$cid" || true
+        fail "the perl endpoint did not respond"
+    }
+    case "$perl_out" in
+        *'perl:ok'*) ok "perl handler runs: $perl_out" ;;
+        *)           fail "unexpected perl output: $perl_out" ;;
+    esac
+    # An unresolved nginx.pm would have made `require nginx` die before this.
+    case "$perl_out" in
+        *nginx.pm=[0-9]*) ok "nginx.pm resolved from the compiled-in @INC" ;;
+        *)                fail "nginx.pm did not report a version: $perl_out" ;;
+    esac
+fi
+
+echo "all checks passed for $IMAGE (variant: $VARIANT)"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,13 +6,19 @@ name: docker image
 # touching the registry.
 #
 # The published tag set follows the nginx official images -- version, minor and
-# major series, a floating alias and a distro-suffixed variant of each:
+# major series, a floating alias and a distro-suffixed variant of each, times
+# two image variants (default and perl):
 #
-#     3.2.0  3.2  3  latest  3.2.0-trixie      3.2-trixie  3-trixie  trixie
-#     3.2.0-alpine  ...      3.2.0-alpine3.24  ...                   alpine3.24
+#     3.2.0         3.2  3  latest  3.2.0-trixie      3.2-trixie  ...  trixie
+#     3.2.0-alpine  ...             3.2.0-alpine3.24  ...              alpine3.24
+#     3.2.0-perl    ...  perl       3.2.0-trixie-perl ...              trixie-perl
+#     3.2.0-alpine-perl ...         3.2.0-alpine3.24-perl ...          alpine3.24-perl
 #
 # .github/scripts/image-tags.sh owns that list; the rolling tags are withheld
 # from pre-releases.
+#
+# The perl variant is NOT a second compile -- see the Dockerfile header. It is a
+# --target on the same build, so it costs one extra runtime layer.
 #
 # NOTE: a GHCR package is private on first push. It has to be flipped to public
 # once, by hand, under https://github.com/<owner>?tab=packages -> tengine ->
@@ -113,24 +119,50 @@ jobs:
       # Publishing path: push by digest only. The per-architecture images stay
       # untagged and the manifest job assembles them into the real tags, so no
       # arch-specific tag ever shows up in the registry.
-      - name: build and push by digest
+      #
+      # The perl variant is built in this same job rather than as its own matrix
+      # entry on purpose. It is a --target on the very same Dockerfile, so every
+      # builder layer is already in this runner's buildx state: the second build
+      # only has to run the handful of runtime instructions. A separate job
+      # would instead re-import the whole layer set from the GHA cache -- and
+      # two jobs writing the same cache scope would race.
+      - name: build and push by digest (default)
         if: needs.meta.outputs.push == 'true'
         id: push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.flavor == 'alpine' && 'Dockerfile.alpine' || 'Dockerfile' }}
+          target: default
           build-args: TENGINE_VERSION=${{ needs.meta.outputs.version }}
           cache-from: type=gha,scope=${{ matrix.flavor }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.flavor }}-${{ matrix.arch }}
           outputs: type=image,name=${{ needs.meta.outputs.image }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: record digest
+      - name: build and push by digest (perl)
+        if: needs.meta.outputs.push == 'true'
+        id: push_perl
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.flavor == 'alpine' && 'Dockerfile.alpine' || 'Dockerfile' }}
+          target: perl
+          build-args: TENGINE_VERSION=${{ needs.meta.outputs.version }}
+          cache-from: type=gha,scope=${{ matrix.flavor }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.flavor }}-${{ matrix.arch }}
+          outputs: type=image,name=${{ needs.meta.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      # One artifact per (flavour, arch) holding both variants' digests. The
+      # file name carries the variant AND the arch because the manifest job
+      # downloads with merge-multiple, which flattens every artifact into one
+      # directory -- same-named files would overwrite each other.
+      - name: record digests
         if: needs.meta.outputs.push == 'true'
         run: |
           set -eu
           mkdir -p /tmp/digests
-          echo "${{ steps.push.outputs.digest }}" > "/tmp/digests/${{ matrix.flavor }}-${{ matrix.arch }}"
+          echo "${{ steps.push.outputs.digest }}"      > "/tmp/digests/default-${{ matrix.arch }}"
+          echo "${{ steps.push_perl.outputs.digest }}" > "/tmp/digests/perl-${{ matrix.arch }}"
 
       - uses: actions/upload-artifact@v4
         if: needs.meta.outputs.push == 'true'
@@ -139,23 +171,39 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
 
-      # Build-only path: load the image into the local daemon and exercise it
+      # Build-only path: load the images into the local daemon and exercise them
       # right here, since there will be no published tag to verify later.
-      - name: build locally
+      - name: build locally (default)
         if: needs.meta.outputs.push != 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.flavor == 'alpine' && 'Dockerfile.alpine' || 'Dockerfile' }}
+          target: default
           build-args: TENGINE_VERSION=${{ needs.meta.outputs.version }}
           cache-from: type=gha,scope=${{ matrix.flavor }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.flavor }}-${{ matrix.arch }}
           load: true
           tags: tengine-local:test
 
-      - name: verify the local image
+      - name: build locally (perl)
         if: needs.meta.outputs.push != 'true'
-        run: ./.github/scripts/verify-image.sh tengine-local:test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.flavor == 'alpine' && 'Dockerfile.alpine' || 'Dockerfile' }}
+          target: perl
+          build-args: TENGINE_VERSION=${{ needs.meta.outputs.version }}
+          cache-from: type=gha,scope=${{ matrix.flavor }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.flavor }}-${{ matrix.arch }}
+          load: true
+          tags: tengine-local:test-perl
+
+      - name: verify the local images
+        if: needs.meta.outputs.push != 'true'
+        run: |
+          ./.github/scripts/verify-image.sh tengine-local:test
+          ./.github/scripts/verify-image.sh tengine-local:test-perl --variant perl
 
   # buildx assembles the per-architecture digests into one multi-arch tag.
   manifest:
@@ -166,10 +214,13 @@ jobs:
       fail-fast: false
       matrix:
         flavor: [debian, alpine]
+        variant: [default, perl]
     steps:
       # image-tags.sh reads the base images back out of the Dockerfiles.
       - uses: actions/checkout@v4
 
+      # Pulls in both variants' digests for this flavour; the tag step picks
+      # out the ones belonging to matrix.variant by file-name prefix.
       - uses: actions/download-artifact@v4
         with:
           pattern: digest-${{ matrix.flavor }}-*
@@ -189,6 +240,7 @@ jobs:
           IMAGE: ${{ needs.meta.outputs.image }}
           VERSION: ${{ needs.meta.outputs.version }}
           FLAVOR: ${{ matrix.flavor }}
+          VARIANT: ${{ matrix.variant }}
           MOVE_LATEST: ${{ needs.meta.outputs.latest }}
         run: |
           set -eu
@@ -197,15 +249,25 @@ jobs:
           # the -alpine suffix, matching how the nginx images are published.
           # The script also derives the minor/major series tags and the
           # distro-suffixed ones (-trixie, -alpine3.24) from the Dockerfiles.
-          tags=$(./.github/scripts/image-tags.sh "$FLAVOR" "$VERSION" "$MOVE_LATEST")
+          # "default" is spelled as no variant at all, so its tags stay bare.
+          if [ "$VARIANT" = default ]; then
+              tags=$(./.github/scripts/image-tags.sh "$FLAVOR" "$VERSION" "$MOVE_LATEST")
+          else
+              tags=$(./.github/scripts/image-tags.sh "$FLAVOR" "$VERSION" "$MOVE_LATEST" "$VARIANT")
+          fi
 
           set --
           for t in $tags; do
               set -- "$@" --tag "$IMAGE:$t"
           done
-          for f in digests/*; do
+          # Only this variant's digests -- the artifact holds both.
+          found=0
+          for f in digests/"$VARIANT"-*; do
+              [ -e "$f" ] || continue
               set -- "$@" "$IMAGE@$(cat "$f")"
+              found=$((found + 1))
           done
+          [ "$found" -gt 0 ] || { echo "no digests for variant $VARIANT" >&2; exit 1; }
 
           echo "docker buildx imagetools create $*"
           docker buildx imagetools create "$@"
@@ -225,6 +287,7 @@ jobs:
       matrix:
         flavor: [debian, alpine]
         arch: [amd64, arm64]
+        variant: [default, perl]
     steps:
       - uses: actions/checkout@v4
 
@@ -238,12 +301,18 @@ jobs:
         env:
           IMAGE: ${{ needs.meta.outputs.image }}
           VERSION: ${{ needs.meta.outputs.version }}
+          VARIANT: ${{ matrix.variant }}
         run: |
           set -eu
-          if [ "${{ matrix.flavor }}" = alpine ]; then
-              ref="$IMAGE:$VERSION-alpine"
-          else
-              ref="$IMAGE:$VERSION"
-          fi
+          # Reassemble the version-pinned tag this variant was published under:
+          # 3.2.0, 3.2.0-alpine, 3.2.0-perl, 3.2.0-alpine-perl.
+          ref="$IMAGE:$VERSION"
+          [ "${{ matrix.flavor }}" = alpine ] && ref="$ref-alpine"
+          [ "$VARIANT" = default ] || ref="$ref-$VARIANT"
+
           docker pull "$ref"
-          ./.github/scripts/verify-image.sh "$ref"
+          if [ "$VARIANT" = default ]; then
+              ./.github/scripts/verify-image.sh "$ref"
+          else
+              ./.github/scripts/verify-image.sh "$ref" --variant "$VARIANT"
+          fi

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -276,6 +276,11 @@ jobs:
           (\`-trixie\`, \`-alpine<ver>\`) are published as well -- a pre-release
           only gets the version-pinned tags.
 
+          A \`-perl\` variant of each image adds \`ngx_http_perl_module\`
+          (\`$version-perl\`, \`$version-alpine-perl\`, and the same rolling
+          aliases). The module is already loaded in the shipped configuration,
+          so \`perl\`, \`perl_set\` and \`perl_modules\` work out of the box.
+
           ## Verify
 
           \`\`\`sh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,7 +27,7 @@ jobs:
   # A single timestamp for the whole run: the matrix jobs run on separate
   # runners, so each computing its own date would give every artifact a
   # different Release. This job also downloads the pinned third-party sources
-  # once so that all 36 matrix jobs build from the identical bytes instead of
+  # once so that all 40 matrix jobs build from the identical bytes instead of
   # each re-fetching them.
   prepare:
     runs-on: ubuntu-24.04
@@ -79,6 +79,8 @@ jobs:
           - el9
           - el10
           - anolis8
+          - anolis23
+          - openeuler2203
           - openeuler2403
           - sles15
           - sles16

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,23 @@
 #     docker build -t tengine .
 #     docker run --rm -p 8080:80 tengine
 #
+# Two variants are built from this file, mirroring how the nginx official
+# images are published:
+#
+#     docker build -t tengine .                        # default
+#     docker build -t tengine:perl --target perl .     # + ngx_http_perl_module
+#
+# There is only ever ONE compile. ngx_http_perl_module is always built, as a
+# dynamic module, and its two files are set aside in /out-perl by the builder;
+# the default runtime simply does not copy them. So the perl variant costs a
+# `perl` runtime package and a few hundred KB rather than a second 90-minute
+# build, and both variants share every builder layer in the buildx cache.
+#
+# A side effect worth knowing: `tengine -V` in the DEFAULT image lists
+# --with-http_perl_module=dynamic even though the .so is not there. That is the
+# same thing nginx's own images do -- their slim variants advertise dynamic
+# modules they do not ship, because one build feeds every variant.
+#
 # Both stages are parameterised so the image can be rebased, e.g.
 #     --build-arg BASE_IMAGE=openanolis/anolisos:8.8 \
 #     --build-arg RUNTIME_IMAGE=openanolis/anolisos:8.8
@@ -30,12 +47,13 @@ ARG RUNTIME_IMAGE=debian:13-slim
 FROM ${BASE_IMAGE} AS builder
 
 # cmake + g++ are for xquic, perl configures Tongsuo, curl fetches the pinned
-# dependency tarballs.
+# dependency tarballs. libperl-dev carries the perl headers and
+# ExtUtils::Embed, which auto/lib/perl/conf refuses to build without.
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update -qq; \
     apt-get install -y --no-install-recommends \
-        build-essential cmake perl curl ca-certificates \
+        build-essential cmake perl libperl-dev curl ca-certificates \
         libssl-dev zlib1g-dev libpcre2-dev; \
     rm -rf /var/lib/apt/lists/*
 
@@ -59,6 +77,7 @@ RUN set -eux; \
 RUN set -eux; \
     . /tmp/deps-build/deps-env.sh; \
     export TENGINE_LIBDIR=/usr/lib; \
+    export TENGINE_WITH_PERL=yes; \
     ./configure \
         $(sh packages/build/configure-args.sh) \
         --with-cc-opt="-Wno-error" \
@@ -79,8 +98,20 @@ RUN set -eux; \
     sed -i -e 's|@TENGINE_LIBDIR@|/usr/lib|g' /out/etc/tengine/tengine.conf; \
     rm -rf /out/run /out/var/run
 
+# Move the perl module out of the default tree so only the "perl" stage picks
+# it up. nginx.pm lands in the private libdir because configure-args.sh passes
+# --with-perl_modules_path; the .packlist and perllocal.pod MakeMaker leaves
+# behind are build bookkeeping and are dropped rather than shipped.
+RUN set -eux; \
+    install -d /out-perl/usr/lib/tengine/modules; \
+    mv /out/usr/lib/tengine/modules/ngx_http_perl_module.so \
+       /out-perl/usr/lib/tengine/modules/; \
+    install -d /out-perl/usr/lib/tengine/perl; \
+    mv /out/usr/lib/tengine/perl/nginx.pm /out-perl/usr/lib/tengine/perl/; \
+    rm -rf /out/usr/lib/tengine/perl
 
-FROM ${RUNTIME_IMAGE}
+
+FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG TENGINE_VERSION=dev
 LABEL org.opencontainers.image.title="Tengine" \
@@ -118,3 +149,43 @@ EXPOSE 80 443 443/udp
 STOPSIGNAL SIGQUIT
 
 CMD ["/usr/sbin/tengine", "-g", "daemon off;"]
+
+
+# --------------------------------------------------------------- perl variant
+#
+# Adds ngx_http_perl_module and a perl runtime. Unlike the nginx official perl
+# image, which only drops the module in and leaves loading it to the operator,
+# the load_module line is prepended here -- so `perl_set` and friends work out
+# of the box, and the `tengine -t` below actually proves the module loads
+# instead of merely proving the file exists.
+#
+# perl (not just perl-base) is what pulls in libperl.so.*, which the module
+# links against.
+FROM runtime AS perl
+
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update -qq; \
+    apt-get install -y --no-install-recommends perl; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /out-perl/ /
+
+# load_module is only valid in the main context, and the packaged tengine.conf
+# has no include there, so prepend it to the file itself. printf+cat rather
+# than `sed -i 1i` to stay identical to the Alpine image, whose BusyBox sed
+# does not expand \n in inserted text.
+RUN set -eux; \
+    { printf 'load_module /usr/lib/tengine/modules/ngx_http_perl_module.so;\n\n'; \
+      cat /etc/tengine/tengine.conf; } > /tmp/tengine.conf; \
+    cat /tmp/tengine.conf > /etc/tengine/tengine.conf; \
+    rm -f /tmp/tengine.conf; \
+    /usr/sbin/tengine -t
+
+
+# ------------------------------------------------------------ default variant
+#
+# Last stage on purpose: a plain `docker build .` with no --target has to keep
+# producing the default image, not the perl one. Nothing is added here; the
+# alias exists so `--target default` also works.
+FROM runtime AS default

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,6 +6,10 @@
 # out, as in the apk package) and the single base image for both stages.
 #
 #     docker build -f Dockerfile.alpine -t tengine:alpine .
+#     docker build -f Dockerfile.alpine -t tengine:alpine-perl --target perl .
+#
+# See the Debian Dockerfile for why the perl variant costs one apk package
+# rather than a second full compile.
 #
 
 # Tracks the newest Alpine the nginx official images are built on, so the
@@ -18,9 +22,10 @@ ARG RUNTIME_IMAGE=alpine:3.24
 FROM ${BASE_IMAGE} AS builder
 
 # cmake + g++ are for xquic, perl configures Tongsuo, curl fetches the pinned
-# dependency tarballs.
+# dependency tarballs. perl-dev carries the headers and ExtUtils::Embed that
+# auto/lib/perl/conf refuses to build without.
 RUN apk add --no-cache \
-        build-base cmake perl curl ca-certificates \
+        build-base cmake perl perl-dev curl ca-certificates \
         linux-headers openssl-dev pcre2-dev zlib-dev
 
 WORKDIR /usr/src/tengine
@@ -45,6 +50,7 @@ RUN set -eux; \
     . /tmp/deps-build/deps-env.sh; \
     export TENGINE_LIBDIR=/usr/lib; \
     export TENGINE_WITH_BACKTRACE=no; \
+    export TENGINE_WITH_PERL=yes; \
     ./configure \
         $(sh packages/build/configure-args.sh) \
         --with-cc-opt="-Wno-error" \
@@ -65,8 +71,17 @@ RUN set -eux; \
     sed -i -e 's|@TENGINE_LIBDIR@|/usr/lib|g' /out/etc/tengine/tengine.conf; \
     rm -rf /out/run /out/var/run
 
+# Set the perl module aside for the "perl" stage -- see the Debian Dockerfile.
+RUN set -eux; \
+    install -d /out-perl/usr/lib/tengine/modules; \
+    mv /out/usr/lib/tengine/modules/ngx_http_perl_module.so \
+       /out-perl/usr/lib/tengine/modules/; \
+    install -d /out-perl/usr/lib/tengine/perl; \
+    mv /out/usr/lib/tengine/perl/nginx.pm /out-perl/usr/lib/tengine/perl/; \
+    rm -rf /out/usr/lib/tengine/perl
 
-FROM ${RUNTIME_IMAGE}
+
+FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG TENGINE_VERSION=dev
 LABEL org.opencontainers.image.title="Tengine" \
@@ -100,3 +115,29 @@ EXPOSE 80 443 443/udp
 STOPSIGNAL SIGQUIT
 
 CMD ["/usr/sbin/tengine", "-g", "daemon off;"]
+
+
+# --------------------------------------------------------------- perl variant
+# Mirrors the Debian one; on Alpine the runtime package is just "perl", which
+# brings libperl.so with it.
+FROM runtime AS perl
+
+RUN apk add --no-cache perl
+
+COPY --from=builder /out-perl/ /
+
+# Prepending with printf+cat rather than `sed -i 1i`: BusyBox sed does not
+# expand \n in inserted text, so the Debian and Alpine images would end up with
+# different files.
+RUN set -eux; \
+    { printf 'load_module /usr/lib/tengine/modules/ngx_http_perl_module.so;\n\n'; \
+      cat /etc/tengine/tengine.conf; } > /tmp/tengine.conf; \
+    cat /tmp/tengine.conf > /etc/tengine/tengine.conf; \
+    rm -f /tmp/tengine.conf; \
+    /usr/sbin/tengine -t
+
+
+# ------------------------------------------------------------ default variant
+# Last stage on purpose, so a plain build with no --target stays the default
+# image. See the Debian Dockerfile.
+FROM runtime AS default

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -92,20 +92,30 @@ packages/build/build.sh docker el9 --platform linux/arm64
 
 [.github/workflows/package.yml](../../.github/workflows/package.yml) —
 **不在日常 push/PR 上触发**：每个目标要编 Tongsuo（两遍）、xquic、LuaJIT 与
-Tengine，36 个 job 全跑一遍代价很高，因此仅：
+Tengine，40 个 job 全跑一遍代价很高，因此仅：
 
 - push tag `tengine-*` 时自动触发（并发布 Release）
 - 手动 `workflow_dispatch`（可传 `dist_tag`，如 `.el7u2`）
 
-矩阵为 18 目标 × 2 架构 = 36 个 job，单 job `timeout-minutes: 150`。`aarch64` 跑在
+矩阵为 20 目标 × 2 架构 = 40 个 job，单 job `timeout-minutes: 150`。`aarch64` 跑在
 原生 `ubuntu-24.04-arm` runner（QEMU 模拟会让单次编译慢 5~10 倍）。`fedora`
-（rolling）、`anolis23`、`openeuler2203`、`sles12` 未进矩阵，需要时用
-`build.sh docker <目标>`。
+与 `sles12` 未进矩阵，需要时用 `build.sh docker <目标>`。
+
+`fedora` 刻意不进矩阵：nginx 官方包支持清单本就不含 Fedora，而 `fedora:latest`
+是 rolling tag，每半年换一个大版本，产出的 `%dist`（`.fc43` 之类）会随之漂移，
+损害构建可复现性；单版本 EOL 也只有约 13 个月。它的用途是本地
+`build.sh docker fedora` 随手验证，不需要 CI 常驻。
 
 矩阵已完整覆盖 nginx 官方包支持的发行版清单（RHEL 8/9/10、Debian 11/12/13、
 Ubuntu 22.04/24.04/26.04、SLES 15 SP6+/16、Alpine 3.21~3.24，均双架构），并额外
-包含 `el7`、`anolis8`、`openeuler2403`，以及 nginx 只发 x86_64 的 SLES 15 的
-aarch64。
+包含 `el7`、`anolis8`、`anolis23`、`openeuler2203`、`openeuler2403`，以及 nginx
+只发 x86_64 的 SLES 15 的 aarch64。信创发行版（龙蜥、openEuler）是 Tengine 的核心
+用户群，因此两个版本各覆盖一条 LTS。
+
+> openEuler 镜像的 `%dist` 为空，两个 openEuler 目标会产出同名 rpm，因此
+> `build.sh` 为它们分别指定 `.oe2203` / `.oe2403`（见 `run_docker_target` 的
+> `target_dist`）。Anolis 无此问题 —— 其镜像自带 `%dist`，产物形如
+> `tengine-3.2.0-<ts>.an8.x86_64.rpm`。
 
 **只有 `el7` + `aarch64` 标记 `continue-on-error`**：CentOS 7 EOL 后镜像源迁到
 `vault.centos.org`，其主树只有 x86_64，aarch64 归档在 `/altarch/` 另一路径下，

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -165,15 +165,18 @@ artifact 90 天过期且需要登录 GitHub。
 
 ## Docker 镜像
 
-两条线，都是 multi-arch（amd64 + arm64），推到 ghcr.io：
+两条线 × 两个变体，都是 multi-arch（amd64 + arm64），推到 ghcr.io：
 
-| Dockerfile | 基底 | 镜像 tag |
-|---|---|---|
-| [Dockerfile](../../Dockerfile) | `debian:13` → `debian:13-slim` | `3.2.0`、`3.2`、`3`、`latest`、`3.2.0-trixie`、`3.2-trixie`、`3-trixie`、`trixie` |
-| [Dockerfile.alpine](../../Dockerfile.alpine) | `alpine:3.24` | `3.2.0-alpine`、`3.2-alpine`、`3-alpine`、`alpine`、`3.2.0-alpine3.24`、`3.2-alpine3.24`、`3-alpine3.24`、`alpine3.24` |
+| Dockerfile | 基底 | 变体 | 镜像 tag |
+|---|---|---|---|
+| [Dockerfile](../../Dockerfile) | `debian:13` → `debian:13-slim` | 默认 | `3.2.0`、`3.2`、`3`、`latest`、`3.2.0-trixie`、`3.2-trixie`、`3-trixie`、`trixie` |
+| 同上 | 同上 | `--target perl` | 上面每个 tag 加 `-perl` 后缀，浮动别名为 `perl` / `trixie-perl` |
+| [Dockerfile.alpine](../../Dockerfile.alpine) | `alpine:3.24` | 默认 | `3.2.0-alpine`、`3.2-alpine`、`3-alpine`、`alpine`、`3.2.0-alpine3.24`、`3.2-alpine3.24`、`3-alpine3.24`、`alpine3.24` |
+| 同上 | 同上 | `--target perl` | 同样加 `-perl`：`3.2.0-alpine-perl`、`alpine-perl`、`3.2.0-alpine3.24-perl`、`alpine3.24-perl` |
 
 基底与 nginx 官方镜像一致（trixie + 最新 Alpine），tag 形状也照其体系：版本号、
-minor/major 系列、浮动别名，各自再带一份发行版后缀。tag 清单由
+minor/major 系列、浮动别名，各自再带一份发行版后缀，变体后缀再乘一遍（nginx 的
+写法是 `perl` / `alpine-perl`，不是 `latest-perl`，此处一致）。tag 清单由
 [.github/scripts/image-tags.sh](../../.github/scripts/image-tags.sh) 统一生成，
 发行版部分是从两个 Dockerfile 的 `BASE_IMAGE` 反解出来的——换基底时 tag 自动跟着变，
 Debian 只需在脚本的版本号→代号表里补一行。
@@ -184,7 +187,8 @@ Debian 只需在脚本的版本号→代号表里补一行。
 本地构建：
 
 ```sh
-docker build -t tengine .
+docker build -t tengine .                                    # 默认
+docker build -t tengine:perl --target perl .                 # + perl 模块
 docker build -f Dockerfile.alpine -t tengine:alpine .
 docker run --rm -p 8080:80 tengine
 ```
@@ -195,17 +199,43 @@ configure 参数同样出自 [configure-args.sh](configure-args.sh)，因此镜�
 一致。日志软链到 `/dev/stdout` 与 `/dev/stderr`，`STOPSIGNAL SIGQUIT`（Tengine 的
 优雅退出信号），暴露 `80 443 443/udp`（HTTP/3 走 UDP）。
 
+#### perl 变体只多一层，不是第二次编译
+
+`ngx_http_perl_module` **始终**被编译（永远是动态模块），builder 随后把
+`ngx_http_perl_module.so` 与 `nginx.pm` 挪到 `/out-perl`，默认 runtime 不拷贝它们；
+`--target perl` 的 stage 从默认镜像继承（`FROM runtime`），只多装一个 perl 运行时包
+再把这两个文件拷进去。因此 perl 变体的成本是一层几百 KB，而不是再跑一遍 90 分钟的
+Tongsuo + xquic 编译，两个变体在 buildx 里共享全部 builder 层。
+
+- **`tengine -V` 在默认镜像里也会列出 `--with-http_perl_module=dynamic`，但 `.so`
+  不在镜像内。** 这与 nginx 官方镜像行为一致（其 slim 变体同样列着没随包发的动态
+  模块），因为一次构建喂多个变体。要判断某个镜像是否真带 perl，看
+  `/usr/lib/tengine/modules/ngx_http_perl_module.so` 是否存在，`verify-image.sh`
+  正是这么断言的（并且反向断言默认镜像里**没有**它）。
+- perl 变体的 `tengine.conf` 顶部预置了 `load_module`，开箱即用（nginx 官方 perl
+  镜像只放模块、要用户自己加载）；这也让 stage 内的 `tengine -t` 真正验证了模块可加载。
+- `nginx.pm` 装在 `/usr/lib/tengine/perl`（`--with-perl_modules_path`），该路径被
+  编译进二进制的 `@INC`，`use nginx;` 无需额外配置。
+- 系统包（rpm/deb/apk）**不含** perl 模块：`TENGINE_WITH_PERL` 默认 `no`，因为 spec
+  的 `%files` 没有对应条目，rpmbuild 会因 unpackaged files 直接失败。
+
 发布由 [docker.yml](../../.github/workflows/docker.yml) 负责，触发与打包一致
 （tag `tengine-*` 自动，`workflow_dispatch` 手动且默认只构建不推送）：
 
 - 每个 flavor × 架构在原生 runner 上构建，**按 digest 推送**，再由 `manifest` job
   用 `docker buildx imagetools create` 合成 multi-arch tag，注册表里不留架构专用 tag
+- 两个变体在**同一个 job 内**先后构建（`--target default` / `--target perl`），不拆成
+  独立 matrix 项：第二次构建的 builder 层已在该 runner 的 buildx 里，只需跑几条
+  runtime 指令；拆开则要从 GHA cache 重新导入整套层，且两个 job 写同一 cache scope
+  会互相竞争。digest 按 `<变体>-<架构>` 命名放进同一 artifact，`manifest` job 按前缀取用
 - **RC 不动 `latest` / `alpine` / `3.2` / `3` 等滚动 tag**（避免 `docker pull tengine`
   拉到预发布），但 RC 的版本化 tag 与正式版一样永久留在 ghcr
 - `verify` job 把发布出去的 tag 拉回来跑
   [verify-image.sh](../../.github/scripts/verify-image.sh)：断言三模块编入、Tongsuo
   在位、`tengine -t` 通过、HTTP 可访问，并真跑一段 Lua
-  （`require "resty.core"` + `cjson`）验证 `lua_package_path` / `cpath` 正确
+  （`require "resty.core"` + `cjson`）验证 `lua_package_path` / `cpath` 正确；
+  `--variant perl` 再额外请求一个 perl handler，用返回的 `$nginx::VERSION` 证明
+  `nginx.pm` 确实从编译进 `@INC` 的路径解析成功
 
 ### ⚠️ 一次性手动操作
 

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -477,11 +477,14 @@ run_docker_target() {
     # as tengine-<ver>-<ts>.<arch>.rpm with nothing naming the target -- two
     # different distributions producing the same file name once a release
     # directory is assembled. Give them one unless the caller asked for its own.
+    # Anolis is deliberately absent: its images do define %dist (an8 packages
+    # ship as ...-<ts>.an8.<arch>.rpm), so anolis8 and anolis23 already differ.
     target_dist=""
     if [ -z "$DIST_TAG" ]; then
         case "$target" in
             sles15)        target_dist=".sles15" ;;
             sles16)        target_dist=".sles16" ;;
+            openeuler2203) target_dist=".oe2203" ;;
             openeuler2403) target_dist=".oe2403" ;;
         esac
     fi

--- a/packages/build/configure-args.sh
+++ b/packages/build/configure-args.sh
@@ -34,6 +34,11 @@
 #   TENGINE_WITH_GEOIP      yes|no  stream geoip module   [no]  needs libGeoIP
 #   TENGINE_WITH_MAIL       yes|no  mail proxy modules    [yes]
 #   TENGINE_WITH_PCRE_JIT   yes|no  PCRE JIT compilation  [yes]
+#   TENGINE_WITH_PERL       yes|no  ngx_http_perl_module  [no]  needs libperl-dev
+#                           Always dynamic. Off by default because the distro
+#                           packages have no %files entry for the module or for
+#                           nginx.pm, and rpmbuild fails on unpackaged files.
+#                           The container images turn it on -- see Dockerfile.
 #
 #   TENGINE_TONGSUO_SRC     Tongsuo source tree for --with-openssl
 #   TENGINE_XQUIC_INC       xquic headers
@@ -53,6 +58,7 @@ set -e
 : "${TENGINE_WITH_GEOIP:=no}"
 : "${TENGINE_WITH_MAIL:=yes}"
 : "${TENGINE_WITH_PCRE_JIT:=yes}"
+: "${TENGINE_WITH_PERL:=no}"
 
 # Private directory for the libraries this package brings along (libxquic.so,
 # libluajit) plus the compiled Lua C modules.
@@ -153,6 +159,22 @@ if [ "$TENGINE_WITH_MAIL" = yes ]; then
 fi
 
 [ "$TENGINE_WITH_GEOIP" = yes ] && echo "--with-stream_geoip_module"
+
+#
+# Perl.  Only ever built as a dynamic module, so the same Tengine binary serves
+# the images that ship it and the ones that do not.
+#
+# The module's own install rule (auto/install) runs `$(MAKE) install` inside the
+# generated ExtUtils::MakeMaker tree, which puts nginx.pm wherever MakeMaker's
+# site directory happens to be -- a path that differs per distro and per perl
+# release. Pinning it next to the other private files keeps the layout the same
+# everywhere, and configure compiles the path into the binary's @INC, so nothing
+# has to be configured at runtime for `use nginx;` to resolve.
+#
+if [ "$TENGINE_WITH_PERL" = yes ]; then
+    echo "--with-http_perl_module=dynamic"
+    echo "--with-perl_modules_path=${TENGINE_PRIVATE_LIBDIR}/perl"
+fi
 
 #
 # Tongsuo.  ngx_tongsuo_ntls only defines T_NGX_SSL_NTLS when USE_OPENSSL is


### PR DESCRIPTION
系统包侧的发行版清单原本已完整覆盖RHEL 8/9/10、Debian 11/12/13、Ubuntu 22.04/24.04/26.04、SLES 15 SP6+/16、Alpine 3.21~3.24，均双架构，镜像侧的基底与 tag 形状也已一致，因此这里针对的是**信创发行版覆盖**与**镜像变体**。

## 1. 打包矩阵新增 openEuler 22.03 与 Anolis 23

`build.sh` 早就支持这两个目标，只是没进 CI 矩阵，于是龙蜥和 openEuler —— Tengine 最主要的用户群 —— 每条线只有一个 LTS 有现成的包。现在各覆盖两条，矩阵从 18 目标变 20 目标（40 个 job）。

`openeuler2203` 必须同时钉上 dist tag。openEuler 镜像的 `%dist` 是空的（这也是 `openeuler2403` 当初显式指定 `.oe2403` 的原因），两个 openEuler 目标若都不带 dist，产出的 rpm 文件名会完全相同。`collect-release.sh` 有撞名兜底，不会丢包，但裸名归谁取决于 artifact 目录的遍历顺序，同一份代码两次发布可能给出不同结果。

Anolis 不需要这道手脚：其镜像自带 `%dist`，已发布的 rc1 资产名 `tengine-3.2.0-<ts>.an8.x86_64.rpm` 可以印证，`anolis23` 会相应拿到 `.an23`。

`fedora` 仍不进矩阵，理由写进了 README：nginx 官方清单本就不含 Fedora，而 `fedora:latest` 是 rolling tag，半年一换大版本，`%dist` 随之漂移会损害构建可复现性，单版本 EOL 也只有 13 个月左右。

## 2. 两个镜像各发一个 `-perl` 变体

nginx 官方每条线发 perl / otel / slim 三个变体，我们一个都没有。perl 是其中唯一在 Tengine 上代价合理的：`src/http/modules/perl` 本来就在树里，只是从未构建过。

**关键是不能照抄 nginx 的做法。** 它的镜像从 nginx.org 的 apt/apk 仓库装预编译包，加一个变体只是多装几个 `.so`，构建是秒级的；我们的镜像每次从源码全量编译（Tongsuo 两遍加 xquic、LuaJIT、Tengine），照抄就是 4 变体 × 2 flavor × 2 架构个 90 分钟的 job。

所以这里**只编译一次**：`ngx_http_perl_module` 无条件编成动态模块，builder 把 `.so` 与 `nginx.pm` 挪到 `/out-perl`，默认 runtime 不拷贝，`perl` stage 从默认镜像继承（`FROM runtime`）后再拷回来。两个变体共享全部 builder 层，perl 的增量是一层几百 KB。CI 里两个变体也在**同一个 job 内**先后构建：第二次构建的 builder 层已在该 runner 的 buildx 状态里，拆成独立 matrix 项反而要从 GHA cache 重新导入整套层，且两个 job 写同一 cache scope 会互相竞争。

一次构建喂多个变体的代价是：默认镜像的 `tengine -V` 也会列出 `--with-http_perl_module=dynamic`，而 `.so` 并不在镜像内。nginx 官方镜像同样如此（其 slim 变体也列着没随包发的动态模块），故保持该行为，但 `verify-image.sh` 改为用文件存在性判定变体，并**反向断言默认镜像里没有那个 `.so`** —— 万一 builder 哪天不再分离产物，默认镜像悄悄变胖会被立即拦住。

其他：`nginx.pm` 装在私有 libdir（`--with-perl_modules_path`），该路径由 configure 编进二进制的 `@INC`，`use nginx;` 无需运行时配置；perl 变体的 `tengine.conf` 顶部预置 `load_module`，比 nginx 官方 perl 镜像（只放模块、要用户自己加载）更接近开箱即用，也让 stage 内的 `tengine -t` 真正验证了模块可加载。tag 形状继续照 nginx：每个 tag 加 `-perl` 后缀，浮动别名是 `perl` / `alpine-perl` 而不是 `latest-perl`，预发布依旧只发版本号形态。

**系统包不受影响**：`TENGINE_WITH_PERL` 默认 `no`，因为 spec 的 `%files` 没有 perl 模块与 `nginx.pm` 的条目，rpmbuild 会因 unpackaged files 直接失败。


## 未纳入本 MR

otel 与 alpine-slim 变体经评估暂不做。otel 的源码级兼容性风险其实不高（只 include `ngx_config.h` / `ngx_core.h` / `ngx_http.h` 三个标准头），但它默认用 `FetchContent` 从源码编译 gRPC v1.49.4（含 protobuf / abseil / re2）加 opentelemetry-cpp v1.23.0，构建成本极高；且其 `config` 调 cmake 时未传 `-G`，而 `config.make` 用 `$(MAKE) -C`，在 Alpine 3.23+（CMake 默认 Ninja）会直接失败，需 patch 上游。slim 则在语义上对 Tengine 不成立 —— 剥掉 Tongsuo / xquic / Lua 后剩下的东西没有受众。
