### PR TITLE
Packaging: extend the distro matrix, publish -perl images, refresh the CI actions

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -24,10 +24,10 @@ jobs:
          - { compiler: LLVM, CC: clang, CXX: clang++}
     steps:
       - name: Checkout Tengine
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: 'checkout luajit2'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: openresty/luajit2
           # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
          - { compiler: GNU,  CC: gcc,  CXX: g++}
          - { compiler: LLVM, CC: clang, CXX: clang++}
    steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v7
      - name: get dependencies
        run: |
          sudo apt update
          sudo apt remove nginx libgd3
          sudo apt install -y libgd-dev libgeoip-dev libxslt1-dev libpcre3 libpcre3-dev liblua5.1-0-dev lua5.1 libperl-dev cpanminus libssl-dev
      - name: 'checkout luajit2'
-       uses: actions/checkout@v3
+       uses: actions/checkout@v7
        with:
          repository: openresty/luajit2
          # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.
@@ -39,7 +39,7 @@ jobs:
          make
          sudo make install
      - name: 'checkout lua-resty-lrucache'
-       uses: actions/checkout@v3
+       uses: actions/checkout@v7
        with:
          repository: openresty/lua-resty-lrucache
          # Pinned (resty.core's dependency); keep in sync with packages/build/deps.env.
@@ -50,7 +50,7 @@ jobs:
        run: |
          sudo make install
      - name: 'checkout lua-resty-core'
-       uses: actions/checkout@v3
+       uses: actions/checkout@v7
        with:
          repository: openresty/lua-resty-core
          # lua-resty-core pins the ngx_lua version with a strict equality check
@@ -161,7 +161,7 @@ jobs:
    name: test tengine native tunnel
    runs-on: "ubuntu-24.04"
    steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v7
      - name: get dependencies
        run: |
          sudo apt update

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
       push: ${{ steps.calc.outputs.push }}
       latest: ${{ steps.calc.outputs.latest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: compute image name and tags
         id: calc
@@ -104,7 +104,7 @@ jobs:
         flavor: [debian, alpine]
         arch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: docker/setup-buildx-action@v3
 
@@ -164,7 +164,7 @@ jobs:
           echo "${{ steps.push.outputs.digest }}"      > "/tmp/digests/default-${{ matrix.arch }}"
           echo "${{ steps.push_perl.outputs.digest }}" > "/tmp/digests/perl-${{ matrix.arch }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: needs.meta.outputs.push == 'true'
         with:
           name: digest-${{ matrix.flavor }}-${{ matrix.arch }}
@@ -217,11 +217,11 @@ jobs:
         variant: [default, perl]
     steps:
       # image-tags.sh reads the base images back out of the Dockerfiles.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Pulls in both variants' digests for this flavour; the tag step picks
       # out the ones belonging to matrix.variant by file-name prefix.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: digest-${{ matrix.flavor }}-*
           path: digests
@@ -289,7 +289,7 @@ jobs:
         arch: [amd64, arm64]
         variant: [default, perl]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,12 +38,12 @@ jobs:
         id: ts
         run: echo "value=$(date +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: fetch and verify the pinned dependency sources
         run: packages/build/fetch-deps.sh --outdir dist/deps
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: deps
           path: dist/deps
@@ -95,12 +95,12 @@ jobs:
           - alpine323
           - alpine324
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # build.sh looks for the dependency tarballs here and skips downloading
       # anything whose checksum already matches, so this doubles as an offline
       # cache for the container build.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: deps
           path: dist/deps
@@ -138,7 +138,7 @@ jobs:
               echo "ok: package names carry $want"
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: tengine-${{ matrix.target }}-${{ matrix.arch }}
           path: |
@@ -162,7 +162,7 @@ jobs:
           - { arch: x86_64,  target: ubuntu2404, image: 'ubuntu:24.04', kind: deb }
           - { arch: aarch64, target: ubuntu2404, image: 'ubuntu:24.04', kind: deb }
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: tengine-${{ matrix.target }}-${{ matrix.arch }}
           path: pkgs
@@ -211,11 +211,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # "tengine-*" matches the per-target package artifacts and skips the
       # dependency-source artifact.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: tengine-*
           path: artifacts

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -113,8 +113,30 @@ jobs:
             --timestamp ${{ needs.prepare.outputs.timestamp }} \
             ${{ inputs.dist_tag && format('--dist {0}', inputs.dist_tag) || '' }}
 
+      # The dist tag is what keeps two builds of the same distro family apart in
+      # a release directory, so assert it reached the file name instead of
+      # leaving that to whoever downloads the artifact. Two groups matter:
+      # openEuler and SLES images leave %dist empty and build.sh fills it in;
+      # Anolis is trusted to define its own, which is only an assumption until
+      # something checks it.
       - name: list artifacts
-        run: ls -lh dist/
+        run: |
+          set -eu
+          ls -lh dist/
+          case "${{ matrix.target }}" in
+              sles15)        want=.sles15 ;;
+              sles16)        want=.sles16 ;;
+              openeuler2203) want=.oe2203 ;;
+              openeuler2403) want=.oe2403 ;;
+              anolis8)       want=.an8    ;;
+              anolis23)      want=.an23   ;;
+              *)             want=        ;;
+          esac
+          if [ -n "$want" ]; then
+              ls dist/ | grep -qF -- "$want" \
+                  || { echo "MISSING dist tag '$want' in the package names above"; exit 1; }
+              echo "ok: package names carry $want"
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-nginx-core.yml
+++ b/.github/workflows/test-nginx-core.yml
@@ -20,7 +20,7 @@ jobs:
          - { compiler: GNU,  CC: gcc,  CXX: g++}
          - { compiler: LLVM, CC: clang, CXX: clang++}
    steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v7
      - name: get dependencies
        run: |
          sudo apt update
@@ -31,7 +31,7 @@ jobs:
          # for running cases in nginx-tests
          sudo apt install -y uwsgi-plugin-python3 uwsgi ffmpeg memcached libsofthsm2-dev
      - name: 'checkout luajit2'
-       uses: actions/checkout@v3
+       uses: actions/checkout@v7
        with:
          repository: openresty/luajit2
          # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.
@@ -43,7 +43,7 @@ jobs:
          make
          sudo make install
      - name: 'checkout lua-resty-lrucache'
-       uses: actions/checkout@v3
+       uses: actions/checkout@v7
        with:
          repository: openresty/lua-resty-lrucache
          # Pinned (resty.core's dependency); keep in sync with packages/build/deps.env.
@@ -54,7 +54,7 @@ jobs:
        run: |
          sudo make install
      - name: 'checkout lua-resty-core'
-       uses: actions/checkout@v3
+       uses: actions/checkout@v7
        with:
          repository: openresty/lua-resty-core
          # lua-resty-core pins the ngx_lua version with a strict equality check

--- a/.github/workflows/test-ntls.yml
+++ b/.github/workflows/test-ntls.yml
@@ -20,14 +20,14 @@ jobs:
           - { compiler: GNU,  CC: gcc,  CXX: g++}
           - { compiler: LLVM, CC: clang, CXX: clang++}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           path: tengine
       - name: get dependencies
         run: |
           sudo apt install -y libpcre3 libpcre3-dev libevent-dev cmake
       - name: 'checkout luajit2'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: openresty/luajit2
           # Pinned (the LuaJIT fork ngx_http_lua_module requires); keep in sync with packages/build/deps.env.
@@ -39,7 +39,7 @@ jobs:
           make
           sudo make install
       - name: 'checkout lua-resty-lrucache'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: openresty/lua-resty-lrucache
           # Pinned (resty.core's dependency); keep in sync with packages/build/deps.env.
@@ -50,7 +50,7 @@ jobs:
         run: |
           sudo make install
       - name: 'checkout lua-resty-core'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: openresty/lua-resty-core
           # lua-resty-core pins the ngx_lua version with a strict equality check
@@ -64,7 +64,7 @@ jobs:
         run: |
           sudo make install
       - name: checkout Tongsuo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: Tongsuo-Project/Tongsuo
           ref: 8.4-stable
@@ -79,7 +79,7 @@ jobs:
           make install_sw
           make clean
       - name: checkout xquic
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: alibaba/xquic
           path: xquic

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,15 +99,25 @@ RUN set -eux; \
     rm -rf /out/run /out/var/run
 
 # Move the perl module out of the default tree so only the "perl" stage picks
-# it up. nginx.pm lands in the private libdir because configure-args.sh passes
-# --with-perl_modules_path; the .packlist and perllocal.pod MakeMaker leaves
-# behind are build bookkeeping and are dropped rather than shipped.
+# it up.
+#
+# The .so is placed by nginx's own install rule, which honours DESTDIR, so it is
+# under /out as expected. nginx.pm is NOT: auto/install delegates it to
+# `$(MAKE) install` inside the generated MakeMaker tree, and that copy does not
+# reliably land under DESTDIR. Take it straight from blib instead -- pm_to_blib
+# is a plain product of the build that already has %%VERSION%% substituted, so
+# this is both more direct and independent of MakeMaker's install semantics.
+#
+# Whatever MakeMaker did drop under /out (man3, .packlist, the arch directory)
+# is build bookkeeping the images do not ship, hence the rm.
 RUN set -eux; \
+    find /out -name 'nginx.pm' -o -name 'ngx_http_perl_module.so' | sort; \
     install -d /out-perl/usr/lib/tengine/modules; \
     mv /out/usr/lib/tengine/modules/ngx_http_perl_module.so \
        /out-perl/usr/lib/tengine/modules/; \
     install -d /out-perl/usr/lib/tengine/perl; \
-    mv /out/usr/lib/tengine/perl/nginx.pm /out-perl/usr/lib/tengine/perl/; \
+    install -m 0644 objs/src/http/modules/perl/blib/lib/nginx.pm \
+        /out-perl/usr/lib/tengine/perl/nginx.pm; \
     rm -rf /out/usr/lib/tengine/perl
 
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -71,13 +71,16 @@ RUN set -eux; \
     sed -i -e 's|@TENGINE_LIBDIR@|/usr/lib|g' /out/etc/tengine/tengine.conf; \
     rm -rf /out/run /out/var/run
 
-# Set the perl module aside for the "perl" stage -- see the Debian Dockerfile.
+# Set the perl module aside for the "perl" stage. nginx.pm comes from blib
+# rather than from /out -- see the Debian Dockerfile for why.
 RUN set -eux; \
+    find /out -name 'nginx.pm' -o -name 'ngx_http_perl_module.so' | sort; \
     install -d /out-perl/usr/lib/tengine/modules; \
     mv /out/usr/lib/tengine/modules/ngx_http_perl_module.so \
        /out-perl/usr/lib/tengine/modules/; \
     install -d /out-perl/usr/lib/tengine/perl; \
-    mv /out/usr/lib/tengine/perl/nginx.pm /out-perl/usr/lib/tengine/perl/; \
+    install -m 0644 objs/src/http/modules/perl/blib/lib/nginx.pm \
+        /out-perl/usr/lib/tengine/perl/nginx.pm; \
     rm -rf /out/usr/lib/tengine/perl
 
 


### PR DESCRIPTION
## 1. 打包矩阵新增 openEuler 22.03 与 Anolis 23

`build.sh` 早就支持这两个目标，只是没进 CI 矩阵，于是龙蜥和 openEuler —— Tengine 最主要的用户群 —— 每条线只有一个 LTS 有现成的包。现在各覆盖两条，矩阵从 18 目标变 20 目标（40 个 job）。

`openeuler2203` 必须同时钉上 dist tag。openEuler 镜像的 `%dist` 是空的（这也是 `openeuler2403` 当初显式指定 `.oe2403` 的原因），两个 openEuler 目标若都不带 dist，产出的 rpm 文件名会完全相同。`collect-release.sh` 有撞名兜底，不会丢包，但裸名归谁取决于 artifact 目录的遍历顺序，同一份代码两次发布可能给出不同结果。

Anolis 不需要这道手脚：其镜像自带 `%dist`（已发布的 rc1 资产名 `tengine-3.2.0-<ts>.an8.x86_64.rpm` 可以印证）。

`fedora` 仍不进矩阵，理由写进了 README：nginx 官方清单本就不含 Fedora，而 `fedora:latest` 是 rolling tag，半年一换大版本，`%dist` 随之漂移会损害构建可复现性，单版本 EOL 也只有 13 个月左右。

**已在 CI 实跑验证**：40 个 job 全绿，`tengine-anolis23-*` 与 `tengine-openeuler2203-*` 四份 artifact 均正常产出。

## 2. 两个镜像各发一个 `-perl` 变体

nginx 官方每条线发 perl / otel / slim 三个变体，我们一个都没有。perl 是其中唯一在 Tengine 上代价合理的：`src/http/modules/perl` 本来就在树里，只是从未构建过。

**关键是不能照抄 nginx 的做法。** 它的镜像从 nginx.org 的 apt/apk 仓库装预编译包，加一个变体只是多装几个 `.so`，构建是秒级的；我们的镜像每次从源码全量编译（Tongsuo 两遍加 xquic、LuaJIT、Tengine），照抄就是 4 变体 × 2 flavor × 2 架构个 90 分钟的 job。

所以这里**只编译一次**：`ngx_http_perl_module` 无条件编成动态模块，builder 把 `.so` 与 `nginx.pm` 挪到 `/out-perl`，默认 runtime 不拷贝，`perl` stage 从默认镜像继承（`FROM runtime`）后再拷回来。两个变体共享全部 builder 层，perl 的增量是一层几百 KB。CI 里两个变体也在**同一个 job 内**先后构建：第二次构建的 builder 层已在该 runner 的 buildx 状态里，拆成独立 matrix 项反而要从 GHA cache 重新导入整套层，且两个 job 写同一 cache scope 会互相竞争。

一次构建喂多个变体的代价是：默认镜像的 `tengine -V` 也会列出 `--with-http_perl_module=dynamic`，而 `.so` 并不在镜像内。nginx 官方镜像同样如此（其 slim 变体也列着没随包发的动态模块），故保持该行为，但 `verify-image.sh` 改为用文件存在性判定变体，并**反向断言默认镜像里没有那个 `.so`** —— 万一 builder 哪天不再分离产物，默认镜像悄悄变胖会被立即拦住。

**首轮 CI 暴露了一个 bug，已在本 MR 内修掉**：`nginx.pm` 取不到。根因不是 `DESTDIR`（已用三层 make 结构实测确认它一路传到了 perl 子目录），而是 `auto/install` 把 `nginx.pm` 的安装完全委托给 MakeMaker 的 `make install`，那份拷贝不可靠地落在 `DESTDIR` 下。改为直接从 `blib` 取 —— `pm_to_blib` 是构建的普通产物且 `%%VERSION%%` 已替换，比 install 语义可控得多；同时加了一行 `find` 打印实际布局，将来布局变化会直接出现在日志里。

其他：`nginx.pm` 装在私有 libdir（`--with-perl_modules_path`），该路径由 configure 编进二进制的 `@INC`，`use nginx;` 无需运行时配置（`XSLoader::load` 会走 `nginx::bootstrap` 快捷路径，不需要 `auto/nginx/nginx.so`）；perl 变体的 `tengine.conf` 顶部预置 `load_module`，比 nginx 官方 perl 镜像更接近开箱即用，也让 stage 内的 `tengine -t` 真正验证了模块可加载。tag 形状继续照 nginx：每个 tag 加 `-perl` 后缀，浮动别名是 `perl` / `alpine-perl` 而不是 `latest-perl`，预发布依旧只发版本号形态。

**系统包不受影响**：`TENGINE_WITH_PERL` 默认 `no`，因为 spec 的 `%files` 没有 perl 模块与 `nginx.pm` 的条目，rpmbuild 会因 unpackaged files 直接失败。

## 3. dist tag 由 CI 自证

`list artifacts` 这一步现在直接断言文件名带上了预期的 dist tag：`sles15/sles16/openeuler2203/openeuler2403` 对应 `.sles15/.sles16/.oe2203/.oe2403`（build.sh 显式填），`anolis8/anolis23` 对应 `.an8/.an23`（依赖镜像自带）。前者是我们控制的，后者原本只是个假设 —— 加上断言才算真的验证过，也省掉每次发布下载 artifact 人工核对文件名。

## 4. 升级 Node 20 的 actions

`actions/checkout`（v3/v4，24 处）、`actions/upload-artifact`（v4）、`actions/download-artifact`（v4）都还跑在 Node 20 上，每个 job 都报一条弃用警告（上一轮 package 运行共 45 条）。分别升到 v7 / v7 / v8，六个 workflow 全部覆盖。升级前核对过各自 `action.yml`：三个都已是 `node24`，且用到的每个输入（`name`/`path`/`if-no-files-found`/`pattern`/`merge-multiple`）在新版都还在，无 breaking change。`docker/*` 与 `softprops/action-gh-release` 未出现在警告列表中（已是 node24 或非 Node action），未改动，避免引入不必要的风险。

