### PR TITLE
Packaging: fix two missing build artifacts in the -perl images and Ubuntu debs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -138,12 +138,25 @@ jobs:
               echo "ok: package names carry $want"
           fi
 
+          # Debian names the automatic debug-symbol package tengine-dbgsym_*.deb
+          # and Ubuntu names it *.ddeb, so a collection glob that covers only one
+          # of the two drops the symbols on half the deb targets without failing
+          # anything. Assert both families actually shipped one.
+          case "${{ matrix.target }}" in
+              debian*|ubuntu*)
+                  ls dist/ | grep -q '^tengine-dbgsym_.*\.d\?deb$' \
+                      || { echo "MISSING debug symbol package in the list above"; exit 1; }
+                  echo "ok: debug symbols packaged"
+                  ;;
+          esac
+
       - uses: actions/upload-artifact@v7
         with:
           name: tengine-${{ matrix.target }}-${{ matrix.arch }}
           path: |
             dist/*.rpm
             dist/*.deb
+            dist/*.ddeb
             dist/*.apk
           if-no-files-found: error
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,26 +98,38 @@ RUN set -eux; \
     sed -i -e 's|@TENGINE_LIBDIR@|/usr/lib|g' /out/etc/tengine/tengine.conf; \
     rm -rf /out/run /out/var/run
 
-# Move the perl module out of the default tree so only the "perl" stage picks
-# it up.
+# Move the perl payload out of the default tree so only the "perl" stage picks
+# it up. It is THREE files, and only the first is placed correctly by the build:
 #
-# The .so is placed by nginx's own install rule, which honours DESTDIR, so it is
-# under /out as expected. nginx.pm is NOT: auto/install delegates it to
-# `$(MAKE) install` inside the generated MakeMaker tree, and that copy does not
-# reliably land under DESTDIR. Take it straight from blib instead -- pm_to_blib
-# is a plain product of the build that already has %%VERSION%% substituted, so
-# this is both more direct and independent of MakeMaker's install semantics.
+#   1. ngx_http_perl_module.so  - the nginx dynamic module. nginx's own install
+#      rule honours DESTDIR, so this one really is under /out.
+#   2. nginx.pm                 - loaded through the @INC entry that
+#      --with-perl_modules_path compiles into the binary.
+#   3. auto/nginx/nginx.so      - the XS object that nginx.pm's XSLoader::load()
+#      dlopens. Without it the interpreter dies during perl_parse() with
+#      "Can't locate loadable object for module nginx".
 #
-# Whatever MakeMaker did drop under /out (man3, .packlist, the arch directory)
-# is build bookkeeping the images do not ship, hence the rm.
+# Neither 2 nor 3 can be taken from /out. auto/install delegates them to
+# `$(MAKE) install` in the generated MakeMaker tree, which puts the XS object in
+# INSTALLSITEARCH -- <perl_modules_path>/<archname>/auto/nginx/ -- one directory
+# deeper than the single path nginx adds to @INC, so DynaLoader would never find
+# it there. (The nginx packages get away with pointing perl_modules_path at
+# perl's own vendorarch, which already is an arch directory on @INC; this layout
+# keeps the file next to everything else Tengine ships instead.)
+#
+# So both come straight from blib, which is a plain product of the build, and
+# the XS object is placed at <@INC dir>/auto/nginx/ where DynaLoader looks.
 RUN set -eux; \
-    find /out -name 'nginx.pm' -o -name 'ngx_http_perl_module.so' | sort; \
+    ls -l objs/src/http/modules/perl/blib/lib \
+          objs/src/http/modules/perl/blib/arch/auto/nginx; \
     install -d /out-perl/usr/lib/tengine/modules; \
     mv /out/usr/lib/tengine/modules/ngx_http_perl_module.so \
        /out-perl/usr/lib/tengine/modules/; \
-    install -d /out-perl/usr/lib/tengine/perl; \
+    install -d /out-perl/usr/lib/tengine/perl/auto/nginx; \
     install -m 0644 objs/src/http/modules/perl/blib/lib/nginx.pm \
         /out-perl/usr/lib/tengine/perl/nginx.pm; \
+    install -m 0755 objs/src/http/modules/perl/blib/arch/auto/nginx/nginx.so \
+        /out-perl/usr/lib/tengine/perl/auto/nginx/nginx.so; \
     rm -rf /out/usr/lib/tengine/perl
 
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -71,16 +71,21 @@ RUN set -eux; \
     sed -i -e 's|@TENGINE_LIBDIR@|/usr/lib|g' /out/etc/tengine/tengine.conf; \
     rm -rf /out/run /out/var/run
 
-# Set the perl module aside for the "perl" stage. nginx.pm comes from blib
-# rather than from /out -- see the Debian Dockerfile for why.
+# Set the perl payload aside for the "perl" stage: the nginx module, nginx.pm
+# and the XS object it dlopens. The latter two come from blib and the XS object
+# goes to <@INC dir>/auto/nginx/ -- see the Debian Dockerfile for why neither
+# can be taken from /out.
 RUN set -eux; \
-    find /out -name 'nginx.pm' -o -name 'ngx_http_perl_module.so' | sort; \
+    ls -l objs/src/http/modules/perl/blib/lib \
+          objs/src/http/modules/perl/blib/arch/auto/nginx; \
     install -d /out-perl/usr/lib/tengine/modules; \
     mv /out/usr/lib/tengine/modules/ngx_http_perl_module.so \
        /out-perl/usr/lib/tengine/modules/; \
-    install -d /out-perl/usr/lib/tengine/perl; \
+    install -d /out-perl/usr/lib/tengine/perl/auto/nginx; \
     install -m 0644 objs/src/http/modules/perl/blib/lib/nginx.pm \
         /out-perl/usr/lib/tengine/perl/nginx.pm; \
+    install -m 0755 objs/src/http/modules/perl/blib/arch/auto/nginx/nginx.so \
+        /out-perl/usr/lib/tengine/perl/auto/nginx/nginx.so; \
     rm -rf /out/usr/lib/tengine/perl
 
 

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -331,10 +331,14 @@ build_deb() {
     info "dpkg-buildpackage tengine_$debversion"
     ( cd "$debtop" && dpkg-buildpackage -b -uc -us )
 
-    find "$work" -maxdepth 1 -name '*.deb' -exec cp {} "$OUTDIR/" \;
+    # Ubuntu's debhelper names the automatic debug-symbol package
+    # tengine-dbgsym_*.ddeb while Debian's uses a plain .deb, so a glob for
+    # .deb alone silently drops the symbols on every Ubuntu target.
+    find "$work" -maxdepth 1 \( -name '*.deb' -o -name '*.ddeb' \) \
+        -exec cp {} "$OUTDIR/" \;
     [ "$KEEP_BUILDDIR" = yes ] || rm -rf "$work"
     info "artifacts:"
-    ls -1 "$OUTDIR"/*.deb
+    ls -1 "$OUTDIR"/*.deb "$OUTDIR"/*.ddeb 2>/dev/null
 }
 
 # ------------------------------------------------------------------ apk build


### PR DESCRIPTION
两个打包缺陷，根因同类：文件在构建阶段已经正确产出，却在收集/安放环节丢失，
且都不会让 CI 失败，只在用户实际使用时才暴露。

## 1. `-perl` 镜像缺 XS 对象（980afa4f）

`ngx_http_perl_module` 的运行时载荷共三个文件，此前只搬对了一个：

| 文件 | 来源 | 此前状态 |
|---|---|---|
| `ngx_http_perl_module.so` | nginx 安装规则（遵守 DESTDIR） | ✅ 正确落在 `/out` |
| `nginx.pm` | blib | 已从 blib 取 |
| `auto/nginx/nginx.so` | blib | ❌ **完全缺失** |

`nginx.pm` 通过 `XSLoader::load()` dlopen 第三个文件，缺失时解释器会在
`perl_parse()` 阶段直接死掉：

    Can't locate loadable object for module nginx

后两个文件都无法从 `/out` 取：`auto/install` 把它们委托给 MakeMaker 的
`make install`，XS 对象被放进 `INSTALLSITEARCH`，即
`<perl_modules_path>/<archname>/auto/nginx/` —— 比 nginx 编进二进制的那个唯一
`@INC` 路径深一层，DynaLoader 永远找不到。

修复：两者一律从 blib 取，XS 对象直接安放到 DynaLoader 会查的
`<@INC dir>/auto/nginx/`。Debian 与 Alpine 两个 Dockerfile 同步处理。

## 2. Ubuntu 包丢失调试符号（1ebe80ba）

Debian 的 debhelper 把自动调试符号包命名为 `tengine-dbgsym_*.deb`，
Ubuntu 命名为 `*.ddeb`。`build.sh` 的收集 glob 只匹配 `*.deb`，于是
**所有 Ubuntu 目标的调试符号被静默丢弃**——同一套 packaging，Debian 用户有
符号、Ubuntu 用户没有。产物体积可佐证：Debian 约 20 MB，Ubuntu 仅 3.5 MB。

修复三处：
- `build.sh` 收集 glob 放宽为 `*.deb` + `*.ddeb`；
- `package.yml` 的 upload path 增加 `dist/*.ddeb`；
- 新增断言：`debian*` / `ubuntu*` 目标必须产出 `tengine-dbgsym_*.d?deb`，
  否则 job 失败——防止此类静默丢包再次回归（与已有的 dist tag 断言同思路）。

`collect-release.sh` 无需改动，它遍历整个 job 目录，`.ddeb` 自动纳入
release 与 `SHA256SUMS`。