### PR TITLE
CI: verify the apk packages and stop exempting the el7 aarch64 build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -54,17 +54,17 @@ jobs:
     # aarch64 runs on native ARM runners: QEMU emulation would make a single
     # Tengine compile take 5-10x longer and risk the job timeout.
     runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    # Only el7 on aarch64 is best effort: CentOS 7 is EOL and its mirrors moved
-    # to vault.centos.org, whose main tree is x86_64-only -- the aarch64 archive
-    # lives under a different /altarch path that the bootstrap rewrite does not
-    # cover, so that combination cannot succeed at all.
+    # No target is best effort, el7 included -- a failure anywhere here is real
+    # news rather than an expected casualty.
     #
-    # el7 on x86_64 is NOT exempt. The full feature set was verified to build
-    # with gcc 4.8.5 (Tongsuo's OpenSSL 3.0 base and xquic's -std=gnu11 with its
-    # own -Werror both compile fine); the only real obstacle was CMake, which
-    # bootstrap now installs from Kitware's static tarball. A failure there is
-    # therefore real news, not an expected casualty.
-    continue-on-error: ${{ matrix.target == 'el7' && matrix.arch == 'aarch64' }}
+    # CentOS 7 is EOL and its mirrors moved to vault.centos.org, which the
+    # bootstrap rewrites the repo files for. That covers aarch64 as well: the
+    # rewrite only replaces the host part of each baseurl, and the /altarch/
+    # path the aarch64 images carry in theirs exists on vault too, so yum
+    # resolves the AltArch tree there unaided. The full feature set builds with
+    # gcc 4.8.5 (Tongsuo's OpenSSL 3.0 base and xquic's -std=gnu11 with its own
+    # -Werror both compile fine); the one real obstacle was CMake, which
+    # bootstrap installs from Kitware's static tarball.
     # Tongsuo is compiled twice, plus xquic, LuaJIT and Tengine itself.
     timeout-minutes: 150
     strategy:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -188,9 +188,16 @@ jobs:
             dist/*.apk
           if-no-files-found: error
 
-  # Smoke-test one RPM and one DEB per architecture: install the package, check
+  # Smoke-test one package of every format per architecture: install it, check
   # the binary name and config path, that the config actually parses, and that
   # the three bundled subsystems really are in the build.
+  #
+  # All three formats are covered because the parts under test are three
+  # independent implementations, not one shared script: the spec, debian/rules
+  # and the APKBUILD each lay out the private libdir and split the perl
+  # subpackage on their own. Alpine is the odd one out twice over -- musl, and
+  # the only format whose subpackages are carved out of the install tree by hand
+  # (amove plus two install calls in mod_perl()).
   verify:
     needs: package
     runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
@@ -202,6 +209,8 @@ jobs:
           - { arch: aarch64, target: el9,        image: 'rockylinux:9', kind: rpm }
           - { arch: x86_64,  target: ubuntu2404, image: 'ubuntu:24.04', kind: deb }
           - { arch: aarch64, target: ubuntu2404, image: 'ubuntu:24.04', kind: deb }
+          - { arch: x86_64,  target: alpine324,  image: 'alpine:3.24',  kind: apk }
+          - { arch: aarch64, target: alpine324,  image: 'alpine:3.24',  kind: apk }
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -212,10 +221,14 @@ jobs:
         run: |
           docker run --rm -v "$PWD/pkgs:/pkgs:ro" ${{ matrix.image }} sh -euc '
             export DEBIAN_FRONTEND=noninteractive
-            # `uname -m` keeps the glob off the .src.rpm that rpmbuild -ba emits
+            # `uname -m` keeps the glob off the .src.rpm that rpmbuild -ba emits.
+            # --allow-untrusted is unconditional for the apk: the build signs
+            # with a key this container has no public half of -- a throwaway one
+            # when APK_PRIVKEY is unset, the release key otherwise.
             case "${{ matrix.kind }}" in
                 rpm) dnf -y install /pkgs/*."$(uname -m)".rpm ;;
                 deb) apt-get update -qq && apt-get install -y /pkgs/*.deb ;;
+                apk) apk add --no-cache --allow-untrusted /pkgs/*.apk ;;
             esac
             test -x /usr/sbin/tengine
             test -f /etc/tengine/tengine.conf


### PR DESCRIPTION
两处 package 工作流的修正，均来自上一轮 package CI（09927ade）的实际结果。

## 1. verify 补上 apk 覆盖（063f247f）

此前 `verify` job 只装 el9 的 rpm 和 ubuntu2404 的 deb，共 4 个组合；40 个产物里
其余 36 个只验到「构建出包」。其中 apk 是完全空白的一档，而 spec、`debian/rules`
和 APKBUILD 是三份彼此独立的实现——各自铺私有 libdir、各自切 perl 子包，Alpine
还额外特殊两次：musl，且是唯一靠手工 `amove` 加两个 `install` 从安装树里抠出
子包的格式。上一轮 alpine 全线因 apk 索引缺失而失败（ad9a07d3 已修），正说明
构建绿灯不等于包能装、能跑。

改动：

- `verify` matrix 增加 `alpine324` / `alpine:3.24` 两条（x86_64 + aarch64），
  4 个 job 变 6 个，三种包格式齐备
- 安装分支增加 `apk) apk add --no-cache --allow-untrusted /pkgs/*.apk`
- `--allow-untrusted` 是无条件的，与当前用临时 key 无关：验证容器里永远没有
  签名公钥的另一半，配好 `APK_PRIVKEY` 之后也一样

后续的断言全部复用，未改一行。已核对其在 busybox 环境成立：`tee` / `grep -qE` /
`printf` / `ls` 均具备；Alpine 的安装布局与另两家一致（`/usr/sbin/tengine`、
`/etc/tengine/tengine.conf`、模块位于 `/usr/lib/tengine/modules/`，glob
`/usr/lib*/` 正好命中）；`mod_perl()` 虽只声明了 `depends="$pkgname"`，但
`ngx_http_perl_module.so` 链接 libperl，abuild 会自动补 `so:libperl.so.*`，
因此 `perl` 会被拉入，`perl_set` 那步的前提成立。

## 2. 去掉 el7 aarch64 的 best-effort 豁免（a8d661d1）

原注释断言这个组合「cannot succeed at all」——理由是 vault.centos.org 主树只有
x86_64，aarch64 在 `/altarch/` 下而 bootstrap 的重写没覆盖——并为此设了
`continue-on-error`。但上一轮该 job 是绿的，日志显示 yum 导入了
`CentOS AltArch SIG - AArch64` 的 GPG key 并从 base 仓库正常下载了 87 MB。

原因是 bootstrap 的那条 sed 只替换 baseurl 的主机名部分
（`s|^#*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|`），
aarch64 镜像 baseurl 里自带的 `/altarch/` 路径段被原样保留，而 vault 上同样有
这棵树，于是 yum 自行就解析到了 AltArch 仓库。

改动：删除 `continue-on-error`，并把注释改写为上述事实。留着错误的注释会让后来
人以为这个 job 天生该红，而豁免本身会永久隐藏该目标上真实的回归。整个 workflows
目录现在没有任何 best-effort 豁免。

