### PR TITLE
XQUIC: warn on session ticket key failure and close the stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,11 @@ jobs:
      - name: upstream check HTTP parser unit tests
        run: |
          make -C modules/ngx_http_upstream_check_module/tests
+     # Stand-alone: stubs the handful of ngx types it needs, so it runs here even
+     # though this job does not build the xquic module.
+     - name: xquic key file unit tests
+       run: |
+         make -C modules/ngx_http_xquic_module/test/unit
 
   # Separate build that enables the native ngx_http_tunnel_module explicitly
   # (--with-http_tunnel_module; it is off by default) and does NOT link

--- a/modules/ngx_http_xquic_module/ngx_xquic.c
+++ b/modules/ngx_http_xquic_module/ngx_xquic.c
@@ -12,6 +12,7 @@
 #include <ngx_xquic_intercom.h>
 #include <ngx_xquic_recv.h>
 #include <ngx_xquic_send.h>
+#include <ngx_xquic_file.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
@@ -80,30 +81,8 @@ ngx_xquic_get_time()
 }
 
 
-/* TODO: close file */
-ngx_int_t 
-ngx_xquic_read_file_data( char * data, size_t data_len, char *filename)
-{
-    FILE * fp = fopen(filename, "rb");
-
-    if(fp == NULL){
-        return -1;
-    }
-    fseek(fp, 0 , SEEK_END);
-    size_t total_len  = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
-    if(total_len > data_len){
-        return -1;
-    }
-
-    size_t read_len = fread(data, 1, total_len, fp);
-    if (read_len != total_len){
-
-        return -1;
-    }
-
-    return read_len;
-}
+/* ngx_xquic_read_file_data() lives in ngx_xquic_file.h so that it can be
+ * covered by the stand-alone unit test under test/unit/ */
 
 
 /* run main logic */
@@ -293,13 +272,25 @@ ngx_xquic_engine_init(ngx_cycle_t *cycle)
                                                        sizeof(g_session_ticket_key), 
                                                        g_ticket_file);
 
-        ngx_log_error(NGX_LOG_DEBUG, cycle->log, 0, 
-                      "|xquic|ngx_xquic_engine_init: ticket_key_len=%i|", ticket_key_len); 
-
         if(ticket_key_len < 0){
+            /*
+             * Without a shared key, each worker falls back to a randomly
+             * generated session ticket key of its own. A ticket issued by one
+             * worker then fails to decrypt on any other worker, so 0-RTT is
+             * always rejected once more than one worker is running. Warn here
+             * rather than degrade silently at debug level.
+             */
+            ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+                          "|xquic|ngx_xquic_engine_init: cannot read session ticket key "
+                          "\"%s\", 0-RTT will be unavailable with multiple workers|",
+                          g_ticket_file);
+
             engine_ssl_config->session_ticket_key_data = NULL;
             engine_ssl_config->session_ticket_key_len = 0;
         } else {
+            ngx_log_error(NGX_LOG_DEBUG, cycle->log, 0,
+                          "|xquic|ngx_xquic_engine_init: ticket_key_len=%d|", ticket_key_len);
+
             engine_ssl_config->session_ticket_key_data = ngx_pcalloc(cycle->pool, (size_t)ticket_key_len);
             if (engine_ssl_config->session_ticket_key_data == NULL) {
                 ngx_log_error(NGX_LOG_EMERG, cycle->log, 0, 

--- a/modules/ngx_http_xquic_module/ngx_xquic_file.h
+++ b/modules/ngx_http_xquic_module/ngx_xquic_file.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Alibaba Group Holding Limited
+ */
+
+#ifndef _NGX_XQUIC_FILE_H_INCLUDED_
+#define _NGX_XQUIC_FILE_H_INCLUDED_
+
+
+#include <stdio.h>
+
+/*
+ * Read the entire content of filename into data.
+ *
+ * Returns the number of bytes read, or -1 when the file cannot be opened, does
+ * not fit into data_len, or is short-read. The stream is closed on every path.
+ *
+ * Only ngx_int_t is required from the surrounding translation unit, so the
+ * stand-alone unit test under test/unit/ can exercise this very source with a
+ * minimal stub instead of a full nginx build.
+ */
+static ngx_int_t
+ngx_xquic_read_file_data(char *data, size_t data_len, char *filename)
+{
+    FILE * fp = fopen(filename, "rb");
+
+    if(fp == NULL){
+        return -1;
+    }
+    fseek(fp, 0 , SEEK_END);
+    size_t total_len  = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    if(total_len > data_len){
+        fclose(fp);
+        return -1;
+    }
+
+    size_t read_len = fread(data, 1, total_len, fp);
+    fclose(fp);
+
+    if (read_len != total_len){
+
+        return -1;
+    }
+
+    return read_len;
+}
+
+
+#endif /* _NGX_XQUIC_FILE_H_INCLUDED_ */

--- a/modules/ngx_http_xquic_module/test/unit/.gitignore
+++ b/modules/ngx_http_xquic_module/test/unit/.gitignore
@@ -1,0 +1,4 @@
+# build artifacts of the stand-alone unit tests
+test_xquic_read_file_data
+*.dSYM/
+*.o

--- a/modules/ngx_http_xquic_module/test/unit/Makefile
+++ b/modules/ngx_http_xquic_module/test/unit/Makefile
@@ -1,0 +1,24 @@
+# Stand-alone unit tests for the xquic key file helper.
+#
+#   make        - build and run the tests
+#   make clean  - remove the built binary
+
+CC      ?= cc
+CFLAGS  ?= -Wall -Wextra -Werror -g -O0
+
+BIN     := test_xquic_read_file_data
+SRC     := test_xquic_read_file_data.c
+HDR     := ../../ngx_xquic_file.h
+
+.PHONY: all check clean
+
+all: check
+
+$(BIN): $(SRC) $(HDR)
+	$(CC) $(CFLAGS) -o $@ $(SRC)
+
+check: $(BIN)
+	./$(BIN)
+
+clean:
+	rm -f $(BIN)

--- a/modules/ngx_http_xquic_module/test/unit/test_xquic_read_file_data.c
+++ b/modules/ngx_http_xquic_module/test/unit/test_xquic_read_file_data.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2026 Alibaba Group Holding Limited
+ */
+
+/*
+ * Stand-alone unit tests for ngx_xquic_read_file_data() (ngx_xquic_file.h).
+ *
+ * That helper loads the xquic session ticket key and token key from disk. When
+ * it fails, xquic silently falls back to a per-worker random session ticket
+ * key, which makes 0-RTT impossible to resume across workers -- so its return
+ * value contract and its file descriptor hygiene both matter.
+ *
+ * The header only needs ngx_int_t from its translation unit, which is stubbed
+ * below so the exact same source that ships in the module is exercised without
+ * requiring a full nginx build:
+ *
+ *     cc -Wall -Wextra -o test_xquic_read_file_data test_xquic_read_file_data.c
+ *     ./test_xquic_read_file_data
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+/* --- minimal ngx compatibility layer --------------------------------- */
+
+typedef intptr_t        ngx_int_t;
+
+#include "../../ngx_xquic_file.h"
+
+/* --- tiny test framework --------------------------------------------- */
+
+static int tests_run = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                                                      \
+    do {                                                                      \
+        tests_run++;                                                          \
+        if (!(cond)) {                                                        \
+            tests_failed++;                                                   \
+            printf("FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__);          \
+        }                                                                     \
+    } while (0)
+
+/* --- helpers --------------------------------------------------------- */
+
+static char  tmpl[] = "/tmp/ngx_xquic_key_test_XXXXXX";
+static char  path[sizeof(tmpl)];
+
+/* Create a temp file holding len bytes of deterministic content. */
+static int
+write_temp_file(size_t len)
+{
+    size_t   i;
+    int      fd;
+    FILE    *fp;
+
+    memcpy(path, tmpl, sizeof(tmpl));
+
+    fd = mkstemp(path);
+    if (fd == -1) {
+        return -1;
+    }
+
+    fp = fdopen(fd, "wb");
+    if (fp == NULL) {
+        close(fd);
+        return -1;
+    }
+
+    for (i = 0; i < len; i++) {
+        if (fputc((int) (i & 0xff), fp) == EOF) {
+            fclose(fp);
+            return -1;
+        }
+    }
+
+    fclose(fp);
+    return 0;
+}
+
+/* Number of currently open descriptors, used to detect leaks. */
+static int
+count_open_fds(void)
+{
+    int  fd, n = 0;
+
+    for (fd = 0; fd < 256; fd++) {
+        if (fcntl(fd, F_GETFD) != -1) {
+            n++;
+        }
+    }
+
+    return n;
+}
+
+/* --- test cases ------------------------------------------------------ */
+
+/* A 48-byte key -- the size recommended for xquic_ssl_session_ticket_key. */
+static void
+test_reads_whole_file(void)
+{
+    char       buf[512];
+    ngx_int_t  ret;
+    size_t     i;
+    int        ok = 1;
+
+    if (write_temp_file(48) != 0) {
+        CHECK(0, "failed to create temp file");
+        return;
+    }
+
+    memset(buf, 0, sizeof(buf));
+    ret = ngx_xquic_read_file_data(buf, sizeof(buf), path);
+
+    CHECK(ret == 48, "48-byte key should return 48");
+
+    for (i = 0; i < 48; i++) {
+        if ((unsigned char) buf[i] != (unsigned char) (i & 0xff)) {
+            ok = 0;
+            break;
+        }
+    }
+    CHECK(ok, "content should match what was written");
+
+    unlink(path);
+}
+
+/*
+ * A missing file must return -1. This is the case that bit in practice: the
+ * default xquic_ssl_session_ticket_key value is the relative path
+ * "./session_ticket.key", which usually does not exist.
+ */
+static void
+test_missing_file(void)
+{
+    char       buf[512];
+    ngx_int_t  ret;
+
+    ret = ngx_xquic_read_file_data(buf, sizeof(buf), "/tmp/ngx_xquic_no_such_key");
+
+    CHECK(ret == -1, "missing file should return -1");
+}
+
+/* A file larger than the destination buffer must be rejected, not truncated. */
+static void
+test_file_larger_than_buffer(void)
+{
+    char       buf[16];
+    ngx_int_t  ret;
+
+    if (write_temp_file(64) != 0) {
+        CHECK(0, "failed to create temp file");
+        return;
+    }
+
+    ret = ngx_xquic_read_file_data(buf, sizeof(buf), path);
+
+    CHECK(ret == -1, "file larger than buffer should return -1");
+
+    unlink(path);
+}
+
+/* An empty file reads back as zero bytes rather than as an error. */
+static void
+test_empty_file(void)
+{
+    char       buf[512];
+    ngx_int_t  ret;
+
+    if (write_temp_file(0) != 0) {
+        CHECK(0, "failed to create temp file");
+        return;
+    }
+
+    ret = ngx_xquic_read_file_data(buf, sizeof(buf), path);
+
+    CHECK(ret == 0, "empty file should return 0");
+
+    unlink(path);
+}
+
+/* Exactly filling the buffer is allowed; one byte more is not. */
+static void
+test_exact_buffer_size(void)
+{
+    char       buf[32];
+    ngx_int_t  ret;
+
+    if (write_temp_file(32) != 0) {
+        CHECK(0, "failed to create temp file");
+        return;
+    }
+
+    ret = ngx_xquic_read_file_data(buf, sizeof(buf), path);
+
+    CHECK(ret == 32, "file exactly filling the buffer should be accepted");
+
+    unlink(path);
+}
+
+/*
+ * The stream must be closed on every return path. Regression test: the helper
+ * used to leak a FILE * on success and on the too-large path, which accumulated
+ * once per worker on every reload.
+ */
+static void
+test_no_fd_leak(void)
+{
+    char       buf[512];
+    char       small[16];
+    int        before, after, i;
+
+    if (write_temp_file(48) != 0) {
+        CHECK(0, "failed to create temp file");
+        return;
+    }
+
+    /* warm up so that any one-off allocation is not counted */
+    (void) ngx_xquic_read_file_data(buf, sizeof(buf), path);
+
+    before = count_open_fds();
+
+    for (i = 0; i < 200; i++) {
+        /* success path */
+        (void) ngx_xquic_read_file_data(buf, sizeof(buf), path);
+        /* too-large path */
+        (void) ngx_xquic_read_file_data(small, sizeof(small), path);
+        /* open failure path */
+        (void) ngx_xquic_read_file_data(buf, sizeof(buf),
+                                        "/tmp/ngx_xquic_no_such_key");
+    }
+
+    after = count_open_fds();
+
+    CHECK(before == after, "no file descriptor should leak across calls");
+
+    unlink(path);
+}
+
+/* --- main ------------------------------------------------------------ */
+
+int
+main(void)
+{
+    test_reads_whole_file();
+    test_missing_file();
+    test_file_larger_than_buffer();
+    test_empty_file();
+    test_exact_buffer_size();
+    test_no_fd_leak();
+
+    printf("%d tests run, %d failed\n", tests_run, tests_failed);
+
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## 背景

对应 issue #2074。该 issue 报告开启 `reuseport` 后 Chrome 无法稳定使用 HTTP/3。排查过程中定位到两个相互独立的缺陷，本 PR 修复其中属于 Tengine 侧的一个（另一个位于 XQUIC 库，与 `reuseport` 无关，将单独跟进）。

未显式配置 `xquic_ssl_session_ticket_key` 时，其默认值是相对路径 `./session_ticket.key`，该文件通常并不存在。读取失败后每个 worker 会各自退化为随机生成的 session ticket key，于是某个 worker 签发的 ticket 在其他 worker 上无法解密——**多 worker 部署下 0-RTT 必然被拒绝**，而唯一线索仅是一行 debug 级别的日志。

issue 中的实测数据（80 worker）：

| | `ticket_key_len` | `0rtt_accept:1` |
|---|---|---|
| 未配置 key | `4294967295`（实为 `-1`） | 0 |
| 配置绝对路径后 | 48 | 3 |

## 改动

1. **读取失败由 `NGX_LOG_DEBUG` 提升为 `NGX_LOG_WARN`**，并输出失败的文件路径与对 0-RTT 的影响，避免静默降级。
2. **修正日志格式符**：`ticket_key_len` 为 `int`，却误用了 `%i`（对应 64 位的 `ngx_int_t`），这正是失败时显示为 `4294967295` 而非 `-1` 的原因，显著增加了排查难度。
3. **修复 `FILE *` 泄漏**：`ngx_xquic_read_file_data()` 在读取成功以及「文件大于缓冲区」两条返回路径上都没有 `fclose`，每个 worker 每次 reload 泄漏一个。该函数原有 `/* TODO: close file */` 标记。

## 测试

为便于覆盖，将 `ngx_xquic_read_file_data()` 移入 `ngx_xquic_file.h`，并新增 `test/unit/` 下的独立单元测试。测试桩化了 `ngx_int_t`，**无需完整 nginx 构建**即可运行，与 `modules/ngx_http_upstream_check_module/tests` 已有的 C 单测采用同一模式：

```console
$ cd modules/ngx_http_xquic_module/test/unit && make
cc -Wall -Wextra -Werror -g -O0 -o test_xquic_read_file_data test_xquic_read_file_data.c
./test_xquic_read_file_data
7 tests run, 0 failed
```

共 6 个用例：48 字节正常读取、文件不存在、文件大于缓冲区、空文件、恰好填满缓冲区，以及 **fd 泄漏回归验证**。

最后一条做过破坏性验证：临时移除 `fclose` 后该用例报 `FAIL: no file descriptor should leak across calls`，恢复后通过，确认它能真正拦住回归。

Refs #2074