### PR TITLE
Docs: record the xquic session ticket key warning in the changelogs

### DIFF
--- a/CHANGES.cn
+++ b/CHANGES.cn
@@ -47,6 +47,7 @@ Tengine 3.2.0 [2026-07-31]
 * Bugfix: 适配HTTP/3 XQUIC模块到xquic v1.9.1接口 (drawing)
 * Bugfix: 修复ssl_certificate_compression在Tongsuo下的编译问题 (lianglli)
 * Bugfix: 仅在Linux上设置管道缓冲区大小 (drawing)
+* Bugfix: xquic会话票据密钥读取失败时输出警告，此前各worker会静默退化为各自随机生成的密钥，导致多worker下0-RTT始终失败 [XQUIC] (lianglli)
 
 
 Tengine 3.1.0 [2023-10-27]

--- a/CHANGES.te
+++ b/CHANGES.te
@@ -153,6 +153,10 @@ Changes with Tengine 3.2.0                                         31 Jul 2026
 
     *) Bugfix: set the pipe buffer size only on Linux (drawing)
 
+    *) Bugfix: warn when the xquic session ticket key cannot be read, instead
+       of silently letting each worker fall back to a random key, which makes
+       0-RTT always fail with more than one worker [XQUIC] (lianglli)
+
 
 Changes with Tengine 3.1.0                                         27 Oct 2023
 


### PR DESCRIPTION
115c53df 把「会话票据密钥读不到」从 debug 级日志提升为 WARN 并关闭流。
这是用户可见的可诊断性修复而非日志美化：多 worker 部署下各 worker 会各自
退化为随机密钥，0-RTT 必然被拒，而此前唯一线索是一行 debug 日志。

同 commit 里把 ngx_xquic_read_file_data() 挪进头文件只是为了让单测能覆盖它， 属于内部改动，不记入 changelog。

两个文件成对修改，条目数与分类计数保持一致（各 49 条、Bugfix 各 17 条）。
CHANGES 是 nginx 上游原文，不涉及。