### PR TITLE
Bugfix: drain leftover health-check body so keepalive reuse works

### DIFF
--- a/modules/ngx_http_upstream_check_module/config
+++ b/modules/ngx_http_upstream_check_module/config
@@ -4,7 +4,7 @@ ngx_feature_run=no
 ngx_feature_incs=
 ngx_feature_libs=
 ngx_feature_path="$ngx_addon_dir"
-ngx_feature_deps="$ngx_addon_dir/ngx_http_upstream_check_module.h"
+ngx_feature_deps="$ngx_addon_dir/ngx_http_upstream_check_module.h $ngx_addon_dir/ngx_http_upstream_check_http_parse.h"
 ngx_check_src="$ngx_addon_dir/ngx_http_upstream_check_module.c"
 ngx_feature_test="int a;"
 . auto/feature

--- a/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_http_parse.h
+++ b/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_http_parse.h
@@ -358,4 +358,42 @@ ngx_http_upstream_check_chunked_drain(ngx_buf_t *b, ngx_uint_t *state,
 }
 
 
+/*
+ * Drain response-body bytes from b, whichever framing the response uses, so
+ * that both the initial pass over the buffer that already holds part of the
+ * body and the later passes over freshly-read data go through one code path.
+ * Advances b->pos past everything consumed. Returns:
+ *   NGX_OK    - the body is fully drained; the connection is clean for reuse.
+ *   NGX_AGAIN - more body bytes are still expected.
+ *   NGX_ERROR - malformed chunk framing (chunked only).
+ *
+ * On the first call *remaining must hold the full Content-Length, or, when
+ * chunked is set, *state must be sw_chunk_size and *remaining 0. Both are
+ * carried across calls unchanged by the caller.
+ */
+static ngx_int_t
+ngx_http_upstream_check_body_drain(ngx_buf_t *b, ngx_uint_t chunked,
+    ngx_uint_t *state, off_t *remaining)
+{
+    off_t  avail;
+
+    if (chunked) {
+        return ngx_http_upstream_check_chunked_drain(b, state, remaining);
+    }
+
+    avail = b->last - b->pos;
+
+    if (avail < *remaining) {
+        b->pos = b->last;
+        *remaining -= avail;
+        return NGX_AGAIN;
+    }
+
+    b->pos += (size_t) *remaining;
+    *remaining = 0;
+
+    return NGX_OK;
+}
+
+
 #endif /* _NGX_HTTP_UPSTREAM_CHECK_HTTP_PARSE_H_INCLUDED_ */

--- a/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
+++ b/modules/ngx_http_upstream_check_module/ngx_http_upstream_check_module.c
@@ -1795,7 +1795,9 @@ static void
 ngx_http_upstream_check_discard_handler(ngx_event_t *event)
 {
     u_char                          buf[4096];
+    ngx_buf_t                       b;
     ssize_t                         size;
+    ngx_int_t                       rc;
     ngx_connection_t               *c;
     ngx_http_upstream_check_peer_t *peer;
 
@@ -1814,6 +1816,51 @@ ngx_http_upstream_check_discard_handler(ngx_event_t *event)
         size = c->recv(c, buf, 4096);
 
         if (size > 0) {
+            if (!peer->recv_body_pending) {
+                /*
+                 * Nothing is owed on this connection, so whatever arrived is
+                 * unsolicited. Keep discarding it as before.
+                 */
+                continue;
+            }
+
+            /*
+             * Finish draining the response body left over from the last check,
+             * tracking the framing so we know when the connection is clean
+             * again -- that is what lets connect_handler reuse it instead of
+             * reconnecting.
+             */
+            b.start = b.pos = buf;
+            b.last = b.end = buf + size;
+
+            rc = ngx_http_upstream_check_body_drain(&b,
+                                                    peer->recv_body_chunked,
+                                                    &peer->recv_chunk_state,
+                                                    &peer->recv_body_remaining);
+            if (rc == NGX_ERROR) {
+                ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                              "check peer sent a malformed response body, "
+                              "peer: %V ", &peer->check_peer_addr->name);
+                goto check_discard_fail;
+            }
+
+            if (rc == NGX_OK) {
+                peer->recv_body_pending = 0;
+
+                if (b.pos < b.last) {
+                    /*
+                     * Bytes beyond the end of the body: the peer is sending
+                     * something we never asked for, so the socket cannot be
+                     * trusted for the next check.
+                     */
+                    ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                                  "check peer sent %z byte(s) past the response "
+                                  "body, peer: %V ", (ssize_t) (b.last - b.pos),
+                                  &peer->check_peer_addr->name);
+                    goto check_discard_fail;
+                }
+            }
+
             continue;
 
         } else if (size == NGX_AGAIN) {
@@ -2124,7 +2171,6 @@ ngx_http_upstream_check_http_init(ngx_http_upstream_check_peer_t *peer)
 static ngx_int_t
 ngx_http_upstream_check_http_parse(ngx_http_upstream_check_peer_t *peer)
 {
-    off_t                                avail, cl;
     ngx_int_t                            rc;
     ngx_buf_t                           *b;
     ngx_uint_t                           code, code_n;
@@ -2244,33 +2290,9 @@ ngx_http_upstream_check_http_parse(ngx_http_upstream_check_peer_t *peer)
         peer->recv_chunk_state = sw_chunk_size;
         peer->recv_body_remaining = 0;
 
-        rc = ngx_http_upstream_check_chunked_drain(b, &peer->recv_chunk_state,
-                                                   &peer->recv_body_remaining);
-        if (rc == NGX_ERROR) {
-            /*
-             * Malformed chunk framing. The verdict is already decided from the
-             * status line, but the connection cannot be reused safely.
-             */
-            c->error = 1;
-            peer->recv_body_pending = 0;
-        } else {
-            peer->recv_body_pending = (rc == NGX_AGAIN);
-        }
-
     } else if (ctx->http_headers.seen_cl) {
         peer->recv_body_chunked = 0;
-        cl = ctx->http_headers.content_length;
-        avail = b->last - b->pos;
-
-        if (avail >= cl) {
-            b->pos += (size_t) cl;
-            peer->recv_body_remaining = 0;
-            peer->recv_body_pending = 0;
-        } else {
-            b->pos = b->last;
-            peer->recv_body_remaining = cl - avail;
-            peer->recv_body_pending = 1;
-        }
+        peer->recv_body_remaining = ctx->http_headers.content_length;
 
     } else {
         /*
@@ -2281,7 +2303,30 @@ ngx_http_upstream_check_http_parse(ngx_http_upstream_check_peer_t *peer)
          */
         c->error = 1;
         peer->recv_body_pending = 0;
+        goto parse_done;
     }
+
+    rc = ngx_http_upstream_check_body_drain(b, peer->recv_body_chunked,
+                                            &peer->recv_chunk_state,
+                                            &peer->recv_body_remaining);
+    if (rc == NGX_ERROR) {
+        /*
+         * Malformed chunk framing. The verdict is already decided from the
+         * status line, but the connection cannot be reused safely.
+         */
+        c->error = 1;
+        peer->recv_body_pending = 0;
+
+    } else {
+        /*
+         * NGX_AGAIN means part of the body has not arrived yet; the discard
+         * handler installed by clean_event() drains the rest while the check is
+         * idle, and clears recv_body_pending once it is done.
+         */
+        peer->recv_body_pending = (rc == NGX_AGAIN);
+    }
+
+ parse_done:
 
     ctx->parse_phase = NGX_CHECK_PARSE_DONE;
 

--- a/modules/ngx_http_upstream_check_module/tests/test_check_http_parse.c
+++ b/modules/ngx_http_upstream_check_module/tests/test_check_http_parse.c
@@ -271,11 +271,105 @@ test_chunked(void)
     CHECK(rc == NGX_OK, "chunk: drip with ext+trailer");
 }
 
+/* --- body drain tests ------------------------------------------------- */
+
+/*
+ * These cover the framing-agnostic entry point used both by the parser (over
+ * body bytes that arrived together with the headers) and by the discard handler
+ * (over body bytes that arrive later, across several reads).
+ */
+static void
+test_body_drain(void)
+{
+    ngx_buf_t   b;
+    ngx_uint_t  state;
+    off_t       rem;
+    ngx_int_t   rc;
+    const char *s;
+
+    /* Content-Length fully present in one buffer */
+    s = "0123456789";
+    b.start = b.pos = (u_char *) s;
+    b.last = b.end = (u_char *) s + 10;
+    state = sw_chunk_size;
+    rem = 10;
+    rc = ngx_http_upstream_check_body_drain(&b, 0, &state, &rem);
+    CHECK(rc == NGX_OK, "drain CL: complete -> OK");
+    CHECK(rem == 0, "drain CL: remaining zeroed");
+    CHECK(b.pos == b.last, "drain CL: buffer consumed");
+
+    /* Content-Length of zero completes without consuming anything */
+    s = "";
+    b.start = b.pos = (u_char *) s;
+    b.last = b.end = (u_char *) s;
+    rem = 0;
+    rc = ngx_http_upstream_check_body_drain(&b, 0, &state, &rem);
+    CHECK(rc == NGX_OK, "drain CL: zero-length -> OK");
+
+    /* Content-Length split across two reads, as the discard handler sees it */
+    s = "0123456789";
+    rem = 10;
+    b.start = b.pos = (u_char *) s;
+    b.last = b.end = (u_char *) s + 4;
+    rc = ngx_http_upstream_check_body_drain(&b, 0, &state, &rem);
+    CHECK(rc == NGX_AGAIN, "drain CL: partial -> AGAIN");
+    CHECK(rem == 6, "drain CL: remaining decremented to 6");
+    CHECK(b.pos == b.last, "drain CL: partial buffer consumed");
+
+    b.start = b.pos = (u_char *) s + 4;
+    b.last = b.end = (u_char *) s + 10;
+    rc = ngx_http_upstream_check_body_drain(&b, 0, &state, &rem);
+    CHECK(rc == NGX_OK, "drain CL: rest -> OK");
+    CHECK(rem == 0, "drain CL: remaining zeroed after rest");
+
+    /* bytes past the body are left in the buffer for the caller to notice */
+    s = "0123456789EXTRA";
+    b.start = b.pos = (u_char *) s;
+    b.last = b.end = (u_char *) s + 15;
+    rem = 10;
+    rc = ngx_http_upstream_check_body_drain(&b, 0, &state, &rem);
+    CHECK(rc == NGX_OK, "drain CL: overshoot -> OK");
+    CHECK(b.last - b.pos == 5, "drain CL: 5 bytes left past body");
+
+    /* chunked framing is delegated, single buffer */
+    s = "3\r\nabc\r\n0\r\n\r\n";
+    b.start = b.pos = (u_char *) s;
+    b.last = b.end = (u_char *) s + strlen(s);
+    state = sw_chunk_size;
+    rem = 0;
+    rc = ngx_http_upstream_check_body_drain(&b, 1, &state, &rem);
+    CHECK(rc == NGX_OK, "drain chunked: complete -> OK");
+
+    /* chunked split mid-chunk keeps state across calls */
+    s = "5\r\nhello\r\n0\r\n\r\n";
+    state = sw_chunk_size;
+    rem = 0;
+    b.start = b.pos = (u_char *) s;
+    b.last = b.end = (u_char *) s + 5;
+    rc = ngx_http_upstream_check_body_drain(&b, 1, &state, &rem);
+    CHECK(rc == NGX_AGAIN, "drain chunked: partial -> AGAIN");
+
+    b.start = b.pos = (u_char *) s + 5;
+    b.last = b.end = (u_char *) s + strlen(s);
+    rc = ngx_http_upstream_check_body_drain(&b, 1, &state, &rem);
+    CHECK(rc == NGX_OK, "drain chunked: resumed -> OK");
+
+    /* malformed chunk framing is reported */
+    s = "5\r\nhelloXY\r\n0\r\n\r\n";
+    b.start = b.pos = (u_char *) s;
+    b.last = b.end = (u_char *) s + strlen(s);
+    state = sw_chunk_size;
+    rem = 0;
+    rc = ngx_http_upstream_check_body_drain(&b, 1, &state, &rem);
+    CHECK(rc == NGX_ERROR, "drain chunked: malformed -> ERROR");
+}
+
 int
 main(void)
 {
     test_headers();
     test_chunked();
+    test_body_drain();
 
     printf("\n%d tests, %d failed\n", tests_run, tests_failed);
     return tests_failed == 0 ? 0 : 1;

--- a/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check_keepalive_body.t
+++ b/tests/test-nginx/cases/ngx_http_upstream_check_module/http_check_keepalive_body.t
@@ -14,21 +14,30 @@
 # default HTTP/1.0 path is unchanged, and a non-2xx response still marks the
 # peer down.
 #
+# TEST 6 covers the other half of the fix -- that the drained connection is then
+# genuinely reused. Peer state cannot show this: a discard handler that ignores
+# the body framing leaves recv_body_pending set forever, so every check simply
+# reconnects and the peer stays up throughout. The block therefore asserts on
+# $connection_requests as the backend sees it, which only exceeds 1 once a
+# connection survives a check.
+#
 # Fine-grained parser coverage (Content-Length / chunked / fragmented arrival /
 # malformed framing) lives in the C unit tests under
 # modules/ngx_http_upstream_check_module/tests/.
 #
-# Every block waits in "--- init" before requesting: peers start out down
+# TEST 1 to TEST 5 wait in "--- init" before requesting: peers start out down
 # (default_down defaults to true) and the first check fires after a random delay
 # of up to 1s, while the test framework sends its request roughly 100ms after
 # the server starts. Without the wait the proxied request races the first check
-# and returns 502.
+# and returns 502. TEST 6 needs its wait on every repeated run instead, so it
+# uses "--- wait"; see the comment there.
 
 use lib 'lib';
 use Test::Nginx::LWP;
 use Test::Nginx::Socket;
 
-plan tests => repeat_each(2) * 2 * blocks();
+# two assertions per block, plus the extra "--- error_log" one in TEST 6
+plan tests => repeat_each(2) * (2 * blocks() + 1);
 
 no_root_location();
 
@@ -207,3 +216,76 @@ GET /
 GET /
 --- response_body chomp
 still-up
+
+=== TEST 6: a drained connection is actually reused by the next check
+--- http_config
+    # The health check's own requests are logged into error.log -- the file
+    # "--- error_log" inspects -- so this block can assert on the reuse itself
+    # rather than on the peer's up/down state. That distinction matters: when
+    # the discard handler does not track the body, recv_body_pending is never
+    # cleared, connect_handler drops the socket and reconnects before every
+    # check, and the peer still stays happily up. The only visible difference
+    # is on the backend side, where every check then arrives on a brand-new
+    # connection and $connection_requests never leaves 1.
+    log_format check_conn "healthcheck-conn requests=$connection_requests";
+
+    upstream backend {
+        server 127.0.0.1:1970;
+
+        check interval=3000 rise=1 fall=5 timeout=1000 type=http default_down=false;
+        check_keepalive_requests 10;
+        check_http_send "GET /slow HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n";
+        check_http_expect_alive http_2xx http_3xx;
+    }
+
+    server {
+        listen 1970;
+
+        # The body must not fit in the first write, or it reaches the check
+        # together with the headers, the parser drains it inline, and the
+        # discard handler is never exercised -- the very path under test.
+        # ngx_http_write_filter allows limit_rate_after + limit_rate * 1 bytes
+        # during the first second, i.e. 2048 here, so the ~2700-byte response
+        # spills into the next second and its tail lands on the idle
+        # connection. The check interval is well past that, so by the time the
+        # next check starts the discard handler has finished and the socket is
+        # clean: reusable with the fix, always reconnected without it.
+        location /slow {
+            access_log logs/error.log check_conn;
+
+            limit_rate_after 1024;
+            limit_rate 1024;
+            return 200 "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+        }
+
+        location / {
+            return 200 "still-up";
+        }
+    }
+
+--- config
+    location / {
+        proxy_pass http://backend;
+    }
+
+# "--- wait" rather than "--- init": the wait has to happen on every repeated
+# run, and "--- init" is evaluated once per block, before the repeat loop. The
+# error_log cursor, in contrast, advances per run, so the second run only sees
+# what was logged after the first one read the file -- with the sleep in
+# "--- init" that window is a few hundred milliseconds and holds no check at
+# all. "--- wait" sleeps right before each run's error_log assertion instead,
+# giving every run a window of its own. Ten seconds fits at least two checks:
+# begin_handler polls every check_interval / 2 and starts a check once
+# check_interval has passed since the previous one started, so checks land
+# 3s to 4.5s apart here.
+--- wait: 10
+--- request
+GET /
+--- response_body chomp
+still-up
+--- error_log eval
+# Any count above 1 proves reuse. It cannot be pinned to "requests=2": the
+# second run picks up the error log where the first left off, and by then the
+# surviving connection is already several checks in. Without the fix every line
+# reads requests=1 and nothing here matches.
+qr/healthcheck-conn requests=(?!1\b)\d+/


### PR DESCRIPTION
## 问题

`ngx_http_upstream_check_module` 在 keepalive 模式下解析出 `recv_body_remaining` 与 `recv_chunk_state` 之后，并没有任何代码消费它们：discard handler 一直无条件丢弃所有到达的数据，不跟踪响应体边界。

`recv_body_pending` 因此只能等到下一次 `http_init` 才被清零，而 `http_init` 只在首次检查时调用一次（后续走 `reinit`，且 `reinit` 有意不重置这组状态）。结果是 `connect_handler` 每次都判定连接不可复用、关闭重连——只要响应体没有与响应头在同一次读中到达，`check_keepalive_requests` 就形同虚设。代码注释里描述的排空机制此前并不存在。

这是一次安全降级：健康判定始终正确，peer 不会误下线，所以现有用例完全观察不到。

## 改动

**Bugfix**

- discard handler 按响应体分帧精确排空，完成后清零 `recv_body_pending`，连接得以真正复用
- 排空入口提取为 `ngx_http_upstream_check_body_drain()`，放在头文件中且不依赖 peer 结构，便于单元测试直接覆盖
- 响应头解析路径改用同一函数，删除其中手写的 Content-Length 增减逻辑，「随响应头到达的响应体」与「后续读到的响应体」共用一份代码
- 补充两处防御：chunk 分帧非法、响应体结束后仍有多余字节，均记录日志并关闭连接
- `config` 把 `ngx_http_upstream_check_http_parse.h` 加入 `ngx_feature_deps`，此前改动该头文件不会触发重新编译

**Test**

新增 TEST 6。原有五个块只断言 peer 的上下线，拦不住这个回归。新块让后端把 `$connection_requests` 写入 error.log 并直接断言复用：修复后计数逐次递增，修复前每行都是 `requests=1`。

两个参数是必需的，否则用例会静默失去鉴别力：响应体必须撑过第一次 write（`ngx_http_write_filter` 首秒只放行 `limit_rate_after + limit_rate` 字节），否则它随响应头一同抵达、由解析路径就地排空，discard handler 根本不被触及；检查间隔需明显长于响应体拖尾时间，使下次检查开始时套接字已经干净。
