### PR TITLE
XQUIC: update integration baseline to v1.9.5

### DIFF
--- a/.github/workflows/test-ntls.yml
+++ b/.github/workflows/test-ntls.yml
@@ -82,6 +82,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: alibaba/xquic
+          # Supported API baseline; keep in sync with packages/build/deps.env.
+          ref: v1.9.5
           path: xquic
       - name: build xquic
         working-directory: xquic

--- a/modules/ngx_http_xquic_module/README.md
+++ b/modules/ngx_http_xquic_module/README.md
@@ -11,20 +11,36 @@ ngx_http_xquic_module 编译依赖
 * Tongsuo: https://github.com/Tongsuo-Project/Tongsuo
 * xquic: https://github.com/alibaba/xquic
 
-```shell
-# 下载 Tongsuo，示例中下载 8.3.2 版本
-wget -c "https://github.com/Tongsuo-Project/Tongsuo/archive/refs/tags/8.3.2.tar.gz"
-tar -x 8.3.2.tar.gz
+## XQUIC 版本兼容性
 
-# 下载 xquic，示例中下载 1.6.0 版本
-wget -c "https://github.com/alibaba/xquic/archive/refs/tags/v1.6.0.tar.gz"
-tar -xf v1.6.0.tar.gz
+Tengine 与 XQUIC 的兼容性主要取决于 CID 和默认连接设置等关键公开 C API。
+下表中的 API 兼容范围表示相同的函数签名世代；推荐版本是经过 Tengine 构建和
+HTTP/3 集成测试验证的组合。未列出的组合不承诺兼容。
+
+| Tengine 版本 | 关键 XQUIC API 兼容范围 | 推荐并验证的 XQUIC 版本 | 说明 |
+| --- | --- | --- | --- |
+| 3.1.0 | v1.8.0 之前 | v1.6.0 | 使用不带 `xqc_engine_t` 参数的旧式 CID 和连接设置 API；不兼容 v1.8.0 及后续版本。 |
+| 3.2.0 及 master | v1.8.0 至 v1.9.5 | v1.9.5 | 使用 engine-scoped CID 和连接设置 API；v1.9.5 是当前打包和 CI 基线。 |
+
+XQUIC v1.8.0 将 `xqc_scid_str`、`xqc_dcid_str` 和
+`xqc_server_set_conn_settings` 等接口改为接收 `xqc_engine_t`，这是两代
+API 的兼容边界。使用发布包时应优先选择表中的推荐组合；API 兼容不
+代表未经测试的版本组合具备完整的运行时兼容性。
+
+```shell
+# 下载 Tongsuo，示例中下载 8.4.0 版本
+wget -c "https://github.com/Tongsuo-Project/Tongsuo/archive/refs/tags/8.4.0.tar.gz"
+tar -xf 8.4.0.tar.gz
+
+# 下载与当前 Tengine API 兼容并经过验证的 xquic 1.9.5
+wget -c "https://github.com/alibaba/xquic/archive/refs/tags/v1.9.5.tar.gz"
+tar -xf v1.9.5.tar.gz
 
 # 下载 Tengine 3.0.0 以上版本，示例从 master 获取最新版本，也可下载指定版本
 git clone git@github.com:alibaba/tengine.git
 
 # 编译 Tongsuo
-cd Tongsuo-8.3.2
+cd Tongsuo-8.4.0
 ./config --prefix=/usr/local/babassl
 make
 make install
@@ -35,9 +51,9 @@ export SSL_LIB_PATH_STR="${PWD}/libssl.a;${PWD}/libcrypto.a"
 cd ../../
 
 # 编译 xquic 库
-cd xquic-1.6.0/
+cd xquic-1.9.5/
 mkdir -p build; cd build
-cmake -DXQC_SUPPORT_SENDMMSG_BUILD=1 -DXQC_ENABLE_BBR2=1 -DXQC_DISABLE_RENO=0 -DSSL_TYPE=${SSL_TYPE_STR} -DSSL_PATH=${SSL_PATH_STR} -DSSL_INC_PATH=${SSL_INC_PATH_STR} -DSSL_LIB_PATH=${SSL_LIB_PATH_STR} ..
+cmake -DXQC_SUPPORT_SENDMMSG_BUILD=1 -DXQC_ENABLE_BBR2=1 -DXQC_ENABLE_RENO=1 -DSSL_TYPE=${SSL_TYPE_STR} -DSSL_PATH=${SSL_PATH_STR} -DSSL_INC_PATH=${SSL_INC_PATH_STR} -DSSL_LIB_PATH=${SSL_LIB_PATH_STR} ..
 make
 cp "libxquic.so" /usr/local/lib/
 cd ..
@@ -49,12 +65,12 @@ cd tengine
 ./configure \
   --prefix=/usr/local/tengine \
   --sbin-path=sbin/tengine \
-  --with-xquic-inc="../xquic-1.6.0/include" \
-  --with-xquic-lib="../xquic-1.6.0/build" \
+  --with-xquic-inc="../xquic-1.9.5/include" \
+  --with-xquic-lib="../xquic-1.9.5/build" \
   --with-http_v2_module \
   --without-http_rewrite_module \
   --add-module=modules/ngx_http_xquic_module \
-  --with-openssl="../Tongsuo-8.3.2"
+  --with-openssl="../Tongsuo-8.4.0"
 
 make
 make install

--- a/packages/build/deps.env
+++ b/packages/build/deps.env
@@ -31,7 +31,7 @@ TENGINE_DEP_IDS="tongsuo xquic luajit2 resty_core resty_lrucache cjson resty_str
 dep_tongsuo="Tongsuo-Project/Tongsuo 8.4.0 Tongsuo-8.4.0 57c2741750a699bfbdaa1bbe44a5733e9c8fc65d086c210151cfbc2bbd6fc975"
 
 # QUIC/HTTP-3 transport. Built with -DSSL_TYPE=babassl against Tongsuo.
-dep_xquic="alibaba/xquic v1.9.4 xquic-1.9.4 088c8970ef4a9e882cf8f1b1de0bfa4165530e4fb6bb9a955467856027c909fd"
+dep_xquic="alibaba/xquic v1.9.5 xquic-1.9.5 5975ae91ed00124f467e63ae04fc11fcd052d7c6a92e25affffaf51f8bb132ec"
 
 # OpenResty's LuaJIT fork -- the only one ngx_http_lua_module supports.
 dep_luajit2="openresty/luajit2 v2.1-20260724 luajit2-2.1-20260724 f5b09359b2939ccc769949acf42e0ad2721fa9bb7678c34789059cb44977fc8a"


### PR DESCRIPTION
## Summary

- pin the packaged and CI-tested XQUIC dependency to v1.9.5
- document the Tengine/XQUIC API compatibility generations and verified pairings
- refresh the module build instructions for the current XQUIC and Tongsuo baselines

## Motivation

Tengine 3.1.0 documents XQUIC v1.6.0 and uses the legacy CID and default
connection settings API. XQUIC v1.8.0 introduced engine-scoped signatures.
Tengine 3.2.0 and master already use those signatures, but the module
documentation still pointed to v1.6.0 and CI followed XQUIC's moving default
branch.

This change makes v1.9.5 the reproducible package and CI baseline and records
the API compatibility boundary explicitly.

Related: alibaba/xquic#825

## Validation

- verified the official XQUIC v1.9.5 archive checksum
- built the XQUIC v1.9.5 library against Tongsuo 8.4.0
- compiled all Tengine XQUIC module sources against v1.9.5 with `-Werror`
- linked and inspected an arm64 Tengine 3.2.0 binary against `libxquic.dylib`
  after translating the Linux-only rpath and `librt` flags for Darwin
- started Tengine locally and fetched `/` with the XQUIC v1.9.5 `test_client`
  after local-only Darwin path and Unix socket adjustments: ALPN `h3`, HTTP
  200, expected 43-byte body, `recv_fin:1`, `err:0`, and no retransmission
- passed the module unit suite: 7 tests, 0 failures
- parsed the updated workflow YAML and passed `git diff --check`

The pinned Linux CI job builds Tengine and runs the HTTP/3 integration suite
against XQUIC v1.9.5.
