### PR TITLE
XQUIC: reject a missing or unreadable certificate at configuration time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,20 @@ jobs:
          sudo apt update
          sudo apt remove nginx libgd3
          sudo apt install -y libgd-dev libgeoip-dev libxslt1-dev libpcre3 libpcre3-dev liblua5.1-0-dev lua5.1 libperl-dev cpanminus libssl-dev
+     # Stand-alone unit tests: each stubs the handful of ngx types it needs, so
+     # neither depends on a built tengine -- and the xquic ones run even though
+     # this job does not build the xquic module. Kept ahead of the build so a
+     # failing build cannot mask them, and so they fail fast.
+     - name: upstream check HTTP parser unit tests
+       env:
+         CC: ${{ matrix.compiler.CC }}
+       run: |
+         make -C modules/ngx_http_upstream_check_module/tests
+     - name: xquic key file and certificate conf unit tests
+       env:
+         CC: ${{ matrix.compiler.CC }}
+       run: |
+         make -C modules/ngx_http_xquic_module/test/unit
      - name: 'checkout luajit2'
        uses: actions/checkout@v7
        with:
@@ -148,15 +162,6 @@ jobs:
            cases/ngx_http_upstream_check_module/unix_socket_check.t \
            cases/ngx_http_upstream_check_module/websocket.t \
            cases/ngx_http_upstream_check_module/check_interface.t
-     - name: upstream check HTTP parser unit tests
-       run: |
-         make -C modules/ngx_http_upstream_check_module/tests
-     # Stand-alone: stubs the handful of ngx types it needs, so it runs here even
-     # though this job does not build the xquic module.
-     - name: xquic key file unit tests
-       run: |
-         make -C modules/ngx_http_xquic_module/test/unit
-
   # Separate build that enables the native ngx_http_tunnel_module explicitly
   # (--with-http_tunnel_module; it is off by default) and does NOT link
   # ngx_http_proxy_connect_module, so the upstream tunnel*.t cases actually run

--- a/modules/ngx_http_xquic_module/README.md
+++ b/modules/ngx_http_xquic_module/README.md
@@ -2,6 +2,12 @@
 
 Tengine ngx_http_xquic_module 主要用于在服务端启用 QUIC/HTTP3 监听服务。
 
+* [编译](#编译)
+* [证书配置（必需）](#证书配置必需)
+* [配置与启动](#配置与启动)
+* [浏览器使用 HTTP3](#浏览器使用-http3)
+* [启动失败排查](#启动失败排查)
+
 # 编译
 
 ngx_http_xquic_module 编译依赖
@@ -53,6 +59,7 @@ cd ../../
 # 编译 xquic 库
 cd xquic-1.9.5/
 mkdir -p build; cd build
+# 追加 -DXQC_ENABLE_TESTING=1 可一并编出 test_client，用于后文的连通性验证
 cmake -DXQC_SUPPORT_SENDMMSG_BUILD=1 -DXQC_ENABLE_BBR2=1 -DXQC_ENABLE_RENO=1 -DSSL_TYPE=${SSL_TYPE_STR} -DSSL_PATH=${SSL_PATH_STR} -DSSL_INC_PATH=${SSL_INC_PATH_STR} -DSSL_LIB_PATH=${SSL_LIB_PATH_STR} ..
 make
 cp "libxquic.so" /usr/local/lib/
@@ -76,7 +83,88 @@ make
 make install
 ```
 
-精简示例配置，其中 default-fake-certificate.pem 为可用证书。
+# 证书配置（必需）
+
+`xquic_ssl_certificate` 与 `xquic_ssl_certificate_key` 由 xquic engine 在 `http` 级别统一加载，
+**只要配置中出现 `listen ... xquic`，这两条指令就必须配置且文件可读**，否则 Tengine 启动或
+`tengine -t` 会直接失败：
+
+```
+nginx: [emerg] no "xquic_ssl_certificate" is defined for the "listen ... xquic" directive in conf/tengine.conf:97
+nginx: [emerg] cannot read xquic_ssl_certificate "/usr/local/tengine/ssl/default-fake-certificate.pem" (2: No such file or directory)
+```
+
+几点说明：
+
+* 引擎级证书与 `server` 级 `ssl_certificate` 相互独立，xquic 不会复用 `server` 段的 TLS 证书，
+  也不存在缺失时自动回退的行为。多域名场景下 `server` 段仍需各自配置 `ssl_certificate`，
+  引擎级证书仅作为握手时的兜底证书。
+* 证书与私钥可以合并在同一个 PEM 文件中（两条指令指向同一路径，如下文示例），也可以拆成
+  两个文件分别配置。
+* **推荐使用绝对路径。** 相对路径按配置文件所在目录展开（与 `ssl_certificate` 一致），
+  例如 `-p /usr/local/tengine/ -c conf/tengine.conf` 下 `ssl/x.pem` 展开为
+  `/usr/local/tengine/conf/ssl/x.pem`，而不是相对进程的工作目录。
+* **私钥必须对 worker 运行用户（`user` 指令指定的用户）可读**：xquic 是在 worker 降权之后才读取
+  私钥的，若仅 root 可读，则 `tengine -t` 通过、master 启动正常，但 worker 会以
+  `fatal code 2` 退出，导致该实例**所有**监听端口（包括纯 HTTP 的 80）不可用。
+
+## session ticket key（可选，影响 0-RTT）
+
+`xquic_ssl_session_ticket_key` 指定一份所有 worker 共享的 session ticket 密钥文件。
+未配置时启动会有一条告警：
+
+```
+nginx: [warn] no "xquic_ssl_session_ticket_key" is defined, 0-RTT will be unavailable with multiple workers
+```
+
+此时每个 worker 各自生成随机密钥，A worker 签发的 ticket 在 B worker 上无法解密，
+`worker_processes` 大于 1 时 0-RTT 实际不可用（其余功能不受影响）。需要 0-RTT 时生成一份
+48 字节密钥并配置：
+
+```shell
+openssl rand 48 > /usr/local/tengine/ssl/session_ticket.key
+chown root:nobody /usr/local/tengine/ssl/session_ticket.key
+chmod 640 /usr/local/tengine/ssl/session_ticket.key
+```
+
+```nginx
+http {
+    xquic_ssl_session_ticket_key /usr/local/tengine/ssl/session_ticket.key;
+}
+```
+
+该文件同样在 worker 内读取，权限要求与私钥一致；读取失败只降级 0-RTT，不会导致 worker 退出。
+多机部署若要跨机复用 ticket，各机器需使用同一份密钥，并定期轮转。
+
+## 生成自签 fake 证书
+
+以示例中的 `/usr/local/tengine/ssl/default-fake-certificate.pem` 为例，把证书和私钥合并写入
+同一个 PEM 文件：
+
+```shell
+mkdir -p /usr/local/tengine/ssl
+
+# 注：-addext 需要 OpenSSL 1.1.1 及以上版本
+openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+  -keyout /tmp/fake.key -out /tmp/fake.crt \
+  -subj "/O=Tengine/CN=Tengine Fake Certificate" \
+  -addext "subjectAltName=DNS:tengine.fake,DNS:*.tengine.fake"
+
+# 合并为单个 PEM：xquic_ssl_certificate 与 xquic_ssl_certificate_key 可共用此文件
+cat /tmp/fake.crt /tmp/fake.key > /usr/local/tengine/ssl/default-fake-certificate.pem
+rm -f /tmp/fake.key /tmp/fake.crt
+
+# 确保 worker 用户可读，此处以 worker 运行用户为 nobody 为例
+chown root:nobody /usr/local/tengine/ssl/default-fake-certificate.pem
+chmod 640 /usr/local/tengine/ssl/default-fake-certificate.pem
+```
+
+自签证书不被浏览器信任，仅适用于 `test_client` 等本地联调；浏览器访问需按后文
+[浏览器使用 HTTP3](#浏览器使用-http3) 配置受信证书。
+
+# 配置与启动
+
+精简示例配置，其中 default-fake-certificate.pem 为上一节生成的证书。
 
 ```nginx
 worker_processes  1;
@@ -178,7 +266,7 @@ http {
 
 **注意**：
 
-在生产环境中，处于安全性考虑，一般情况会以普通用户权限启动 `Tenigne`，而 `xquic` 功能在普通用户权限下，监听端口必须配置为 1024 以上，如监听 2443 端口，那对外的四层负载均衡需要做 443 到 2443 端口的映射，`Tenigne` `Server`段配置示例：
+在生产环境中，出于安全性考虑，一般情况会以普通用户权限启动 `Tengine`，而 `xquic` 功能在普通用户权限下，监听端口必须配置为 1024 以上，如监听 2443 端口，那对外的四层负载均衡需要做 443 到 2443 端口的映射，`Tengine` `Server`段配置示例：
 
 ```nginx
     server {
@@ -215,3 +303,23 @@ http {
 ```
 
 对用户来讲，还是通过 443 端口访问，通过四层负载均衡设备，转换为 `Tengine` 的 2443 端口。
+
+# 启动失败排查
+
+xquic 的证书由 engine 在 worker 内加载，因此证书类问题的表现与普通 `ssl_certificate` 不同：
+**一旦 worker 初始化失败，master 会判定为 `fatal code 2` 且不再重启 worker，该实例所有监听端口
+（包括纯 HTTP 的 80）全部不可用**。排查时先 `grep xquic` 过滤 `error_log`，`[emerg]` 那条才是根因，
+`[alert] ... fatal code 2` 只是结果。
+
+| 日志 | 原因 | 处置 |
+| --- | --- | --- |
+| `[emerg] no "xquic_ssl_certificate" is defined for the "listen ... xquic" directive in <file>:<line>` | 有 `listen ... xquic` 但 `http` 段未配置引擎级证书 | 按[证书配置](#证书配置必需)补齐两条指令；不需要 HTTP/3 则去掉 `listen` 上的 `xquic` 参数与 `Alt-Svc` 响应头 |
+| `[emerg] cannot read xquic_ssl_certificate "<path>" (2: No such file or directory)` | 路径不存在或相对路径展开位置与预期不同 | 改用绝对路径核对 |
+| `[emerg] \|xquic\|ngx_xquic_engine_init: cannot read xquic_ssl_certificate_key "<path>"\| (13: Permission denied)` | 文件存在，但 worker 运行用户不可读（`tengine -t` 与 master 均能通过） | `chown root:<worker 用户>` + `chmod 640` |
+| `[warn] no "xquic_ssl_session_ticket_key" is defined, ...` | 未配置共享 ticket 密钥 | 仅影响 0-RTT，见 [session ticket key](#session-ticket-key可选影响-0-rtt) |
+
+前两类在配置解析阶段就会拦截，`tengine -t` 与 reload 都能提前发现，reload 被拒绝时旧 worker
+继续提供服务。第三类只能在 worker 降权后暴露，所以 `tengine -t` 通过并不代表私钥权限没问题。
+
+多 worker 下真正的 `[emerg]` 容易被大量 `[alert]`/`[notice]` 淹没，排查时可临时设
+`worker_processes 1;` 复现，日志会清晰很多。

--- a/modules/ngx_http_xquic_module/config
+++ b/modules/ngx_http_xquic_module/config
@@ -16,6 +16,8 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
                 $ngx_addon_dir/ngx_xquic_intercom.h \
                 $ngx_addon_dir/ngx_xquic_recv.h \
                 $ngx_addon_dir/ngx_xquic_send.h \
+                $ngx_addon_dir/ngx_xquic_file.h \
+                $ngx_addon_dir/ngx_xquic_ssl_conf.h \
                 $ngx_addon_dir/ngx_http_v3_stream.h"
 
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS \

--- a/modules/ngx_http_xquic_module/ngx_http_xquic_module.c
+++ b/modules/ngx_http_xquic_module/ngx_http_xquic_module.c
@@ -5,6 +5,7 @@
 #include <ngx_http_xquic_module.h>
 #include <ngx_xquic.h>
 #include <ngx_xquic_intercom.h>
+#include <ngx_xquic_ssl_conf.h>
 #include <unistd.h>
 
 
@@ -80,6 +81,7 @@ static char * ngx_http_xquic_merge_srv_conf(ngx_conf_t *cf, void *parent, void *
 static ngx_int_t ngx_http_xquic_process_init(ngx_cycle_t *cycle);
 static void ngx_http_xquic_process_exit(ngx_cycle_t *cycle);
 static ngx_int_t ngx_http_xquic_init(ngx_conf_t *cf);
+static ngx_int_t ngx_http_xquic_check_ssl_conf(ngx_conf_t *cf);
 static ngx_int_t ngx_http_xquic_access_handler(ngx_http_request_t *r);
 static char * ngx_http_set_xquic_status(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static ngx_int_t ngx_http_xquic_module_init(ngx_cycle_t *cycle);
@@ -1354,16 +1356,38 @@ ngx_http_xquic_init_main_conf(ngx_conf_t *cf, void *conf)
         qmcf->intercom_reload_socket_path.len = sizeof(NGX_XQUIC_DEFAULT_RELOAD_SOCKET_PATH) - 1;
     }
 
-    if (qmcf->certificate.data == NULL) {
-        ngx_str_set(&(qmcf->certificate), "./server.crt");
+    /*
+     * The certificate, its key and the session ticket key are read by the
+     * xquic engine, in the worker, long after this point. They used to default
+     * to the bare relative paths "./server.crt", "./server.key" and
+     * "./session_ticket.key", which resolve against the current working
+     * directory of the worker -- "/" under systemd -- and so never existed.
+     * Every worker then died with fatal code 2 and could not be respawned,
+     * taking the plain HTTP listeners down with it, while "nginx -t" reported
+     * the configuration as valid.
+     *
+     * So leave them unset instead: ngx_http_xquic_check_ssl_conf() rejects the
+     * configuration when an xquic listener is present without a certificate,
+     * and a relative path that was configured explicitly is resolved against
+     * the prefix, the way ssl_certificate does it, rather than against the
+     * working directory of whoever started the master.
+     */
+    if (qmcf->certificate.len
+        && ngx_conf_full_name(cf->cycle, &qmcf->certificate, 1) != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
     }
 
-    if (qmcf->certificate_key.data == NULL) {
-        ngx_str_set(&(qmcf->certificate_key), "./server.key");
+    if (qmcf->certificate_key.len
+        && ngx_conf_full_name(cf->cycle, &qmcf->certificate_key, 1) != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
     }
 
-    if (qmcf->session_ticket_key.data == NULL) {
-        ngx_str_set(&(qmcf->session_ticket_key), "./session_ticket.key");
+    if (qmcf->session_ticket_key.len
+        && ngx_conf_full_name(cf->cycle, &qmcf->session_ticket_key, 1) != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
     }
 
     if (qmcf->stateless_reset_token_key.data == NULL) {
@@ -1592,6 +1616,108 @@ ngx_http_xquic_process_exit(ngx_cycle_t *cycle)
 }
 
 
+/*
+ * Validate the engine level certificate configuration, the way
+ * ngx_http_ssl_init() does it for "listen ... ssl".
+ *
+ * xquic reads the certificate inside the engine, in the worker, which used to
+ * make a missing or unreadable path surface only as "worker process exited with
+ * fatal code 2 and cannot be respawned" -- every listener down, plain HTTP
+ * included -- while "nginx -t" reported the configuration as valid. Failing
+ * here instead means "nginx -t" catches it, and a bad reload is rejected while
+ * the running workers keep serving. It has to stay in the configuration phase
+ * for that: ngx_init_cycle() treats a failing init_module as fatal and exits
+ * the master outright, reload included.
+ *
+ * The check is gated on an xquic listener being configured because
+ * ngx_xquic_process_init() creates the engine under the same condition: a build
+ * with the module compiled in but no "listen ... xquic" must keep starting
+ * without a certificate.
+ */
+static ngx_int_t
+ngx_http_xquic_check_ssl_conf(ngx_conf_t *cf)
+{
+    ngx_uint_t                   a, p;
+    ngx_err_t                    err;
+    const char                  *missing;
+    ngx_http_conf_addr_t        *addr;
+    ngx_http_conf_port_t        *port;
+    ngx_http_core_srv_conf_t    *cscf;
+    ngx_http_core_main_conf_t   *cmcf;
+    ngx_http_xquic_main_conf_t  *qmcf;
+
+    cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+
+    if (cmcf->ports == NULL) {
+        return NGX_OK;
+    }
+
+    qmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_xquic_module);
+
+    port = cmcf->ports->elts;
+    for (p = 0; p < cmcf->ports->nelts; p++) {
+
+        addr = port[p].addrs.elts;
+        for (a = 0; a < port[p].addrs.nelts; a++) {
+
+            if (!addr[a].opt.xquic) {
+                continue;
+            }
+
+            cscf = addr[a].default_server;
+
+            missing = ngx_xquic_ssl_cert_missing(&qmcf->certificate,
+                                                 &qmcf->certificate_key);
+            if (missing != NULL) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                              "no \"%s\" is defined for "
+                              "the \"listen ... xquic\" directive in %s:%ui",
+                              missing, cscf->file_name, cscf->line);
+                return NGX_ERROR;
+            }
+
+            /*
+             * Probe both files while the paths are still reportable. This does
+             * not replace the worker side probe in ngx_xquic_engine_init():
+             * the master usually runs as root, so a key readable by root alone
+             * passes here and only fails once the worker drops privileges.
+             */
+            err = ngx_xquic_cert_file_check((char *) qmcf->certificate.data);
+            if (err != 0) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, err,
+                              "cannot read xquic_ssl_certificate \"%V\"",
+                              &qmcf->certificate);
+                return NGX_ERROR;
+            }
+
+            err = ngx_xquic_cert_file_check((char *) qmcf->certificate_key.data);
+            if (err != 0) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, err,
+                              "cannot read xquic_ssl_certificate_key \"%V\"",
+                              &qmcf->certificate_key);
+                return NGX_ERROR;
+            }
+
+            /*
+             * Warn once here rather than once per worker: without a shared key
+             * every worker generates its own, so a ticket issued by one worker
+             * never resumes on another and 0-RTT is effectively off.
+             */
+            if (qmcf->session_ticket_key.len == 0) {
+                ngx_log_error(NGX_LOG_WARN, cf->log, 0,
+                              "no \"xquic_ssl_session_ticket_key\" is defined, "
+                              "0-RTT will be unavailable with multiple workers");
+            }
+
+            /* the certificate is engine wide, one listener is enough to check */
+            return NGX_OK;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
 static ngx_int_t
 ngx_http_xquic_init(ngx_conf_t *cf)
 {
@@ -1607,7 +1733,9 @@ ngx_http_xquic_init(ngx_conf_t *cf)
 
     *h = ngx_http_xquic_access_handler;
 
-    
+    if (ngx_http_xquic_check_ssl_conf(cf) != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     return NGX_OK;
 }

--- a/modules/ngx_http_xquic_module/ngx_xquic.c
+++ b/modules/ngx_http_xquic_module/ngx_xquic.c
@@ -13,6 +13,7 @@
 #include <ngx_xquic_recv.h>
 #include <ngx_xquic_send.h>
 #include <ngx_xquic_file.h>
+#include <ngx_xquic_ssl_conf.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
@@ -168,6 +169,8 @@ ngx_xquic_engine_init(ngx_cycle_t *cycle)
     ngx_http_xquic_main_conf_t  *qmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_xquic_module);
     xqc_engine_ssl_config_t *engine_ssl_config = NULL;
     xqc_config_t config;
+    ngx_err_t    cert_err;
+    const char  *missing;
 
     if (xqc_engine_get_default_config(&config, XQC_ENGINE_SERVER) < 0) {
         return NGX_ERROR;
@@ -230,11 +233,37 @@ ngx_xquic_engine_init(ngx_cycle_t *cycle)
     /* init ssl config */
     engine_ssl_config = &(qmcf->engine_ssl_config);
 
-    if (qmcf->certificate.len == 0 || qmcf->certificate.data == NULL
-        || qmcf->certificate_key.len == 0 || qmcf->certificate_key.data == NULL)
-    {
-        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0, 
-                    "|xquic|ngx_xquic_engine_init: null certificate or key|");     
+    missing = ngx_xquic_ssl_cert_missing(&qmcf->certificate,
+                                         &qmcf->certificate_key);
+    if (missing != NULL) {
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+                      "|xquic|ngx_xquic_engine_init: no \"%s\" is defined|",
+                      missing);
+        return NGX_ERROR;
+    }
+
+    /*
+     * xqc_engine_create() below reads both files itself and reports nothing but
+     * a bare "fail", after the worker has dropped privileges. Probe them first
+     * so the log names the path and the reason: a key that only root can read
+     * gets through the master side check in ngx_http_xquic_check_ssl_conf() and
+     * fails here, which is exactly the case worth spelling out.
+     */
+    cert_err = ngx_xquic_cert_file_check((char *) qmcf->certificate.data);
+    if (cert_err != 0) {
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, cert_err,
+                      "|xquic|ngx_xquic_engine_init: "
+                      "cannot read xquic_ssl_certificate \"%V\"|",
+                      &qmcf->certificate);
+        return NGX_ERROR;
+    }
+
+    cert_err = ngx_xquic_cert_file_check((char *) qmcf->certificate_key.data);
+    if (cert_err != 0) {
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, cert_err,
+                      "|xquic|ngx_xquic_engine_init: "
+                      "cannot read xquic_ssl_certificate_key \"%V\"|",
+                      &qmcf->certificate_key);
         return NGX_ERROR;
     }
 

--- a/modules/ngx_http_xquic_module/ngx_xquic_ssl_conf.h
+++ b/modules/ngx_http_xquic_module/ngx_xquic_ssl_conf.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Alibaba Group Holding Limited
+ */
+
+#ifndef _NGX_XQUIC_SSL_CONF_H_INCLUDED_
+#define _NGX_XQUIC_SSL_CONF_H_INCLUDED_
+
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+/*
+ * Helpers validating the engine level xquic certificate configuration.
+ *
+ * xquic loads its certificate inside the engine, once per worker, long after
+ * the configuration has been parsed. A missing or unreadable path therefore
+ * used to surface only as
+ *
+ *     worker process exited with fatal code 2 and cannot be respawned
+ *
+ * which takes every listener down with it, plain HTTP included, and leaves no
+ * hint about the actual cause. These helpers let the same condition be
+ * reported while the configuration is still being validated, and with the
+ * offending path named in the message.
+ *
+ * Only ngx_str_t, ngx_err_t and ngx_inline are required from the surrounding
+ * translation unit, so the stand-alone unit test under test/unit/ can exercise
+ * this very source with a minimal stub instead of a full nginx build.
+ */
+
+/*
+ * Report which of the two mandatory certificate directives is missing, or NULL
+ * when both are configured.
+ *
+ * Neither has a default: xquic cannot serve a handshake without an engine
+ * level certificate, so an unset value is a configuration error rather than
+ * something to be guessed at. The returned name is a static string, safe to
+ * log with "%s".
+ */
+static ngx_inline const char *
+ngx_xquic_ssl_cert_missing(ngx_str_t *cert, ngx_str_t *key)
+{
+    if (cert->data == NULL || cert->len == 0) {
+        return "xquic_ssl_certificate";
+    }
+
+    if (key->data == NULL || key->len == 0) {
+        return "xquic_ssl_certificate_key";
+    }
+
+    return NULL;
+}
+
+/*
+ * Check that path can be opened for reading. Returns 0 on success, otherwise
+ * the errno explaining the failure, ready to be passed to ngx_log_error() so
+ * that it appends the system message.
+ *
+ * Opening is deliberate rather than stat()ing: the master runs as root while
+ * the worker does not, and a key that only root can read is the failure this
+ * is most often called upon to explain. Only an open() as the effective user
+ * reproduces it.
+ */
+static ngx_inline ngx_err_t
+ngx_xquic_cert_file_check(const char *path)
+{
+    int        fd;
+    ngx_err_t  err;
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        err = errno;
+        return err ? err : EACCES;
+    }
+
+    close(fd);
+
+    return 0;
+}
+
+
+#endif /* _NGX_XQUIC_SSL_CONF_H_INCLUDED_ */

--- a/modules/ngx_http_xquic_module/test/unit/.gitignore
+++ b/modules/ngx_http_xquic_module/test/unit/.gitignore
@@ -1,4 +1,5 @@
 # build artifacts of the stand-alone unit tests
 test_xquic_read_file_data
+test_xquic_ssl_conf
 *.dSYM/
 *.o

--- a/modules/ngx_http_xquic_module/test/unit/Makefile
+++ b/modules/ngx_http_xquic_module/test/unit/Makefile
@@ -1,24 +1,25 @@
-# Stand-alone unit tests for the xquic key file helper.
+# Stand-alone unit tests for the xquic key file and certificate conf helpers.
 #
 #   make        - build and run the tests
-#   make clean  - remove the built binary
+#   make clean  - remove the built binaries
 
 CC      ?= cc
 CFLAGS  ?= -Wall -Wextra -Werror -g -O0
 
-BIN     := test_xquic_read_file_data
-SRC     := test_xquic_read_file_data.c
-HDR     := ../../ngx_xquic_file.h
+BINS    := test_xquic_read_file_data test_xquic_ssl_conf
 
 .PHONY: all check clean
 
 all: check
 
-$(BIN): $(SRC) $(HDR)
-	$(CC) $(CFLAGS) -o $@ $(SRC)
+test_xquic_read_file_data: test_xquic_read_file_data.c ../../ngx_xquic_file.h
+	$(CC) $(CFLAGS) -o $@ $<
 
-check: $(BIN)
-	./$(BIN)
+test_xquic_ssl_conf: test_xquic_ssl_conf.c ../../ngx_xquic_ssl_conf.h
+	$(CC) $(CFLAGS) -o $@ $<
+
+check: $(BINS)
+	@for b in $(BINS); do echo "==> $$b"; ./$$b || exit 1; done
 
 clean:
-	rm -f $(BIN)
+	rm -f $(BINS)

--- a/modules/ngx_http_xquic_module/test/unit/test_xquic_ssl_conf.c
+++ b/modules/ngx_http_xquic_module/test/unit/test_xquic_ssl_conf.c
@@ -1,0 +1,426 @@
+/*
+ * Copyright (C) 2026 Alibaba Group Holding Limited
+ */
+
+/*
+ * Stand-alone unit tests for the xquic certificate configuration helpers
+ * (ngx_xquic_ssl_conf.h).
+ *
+ * These cover the case reported from the field: a "listen ... xquic" server
+ * without xquic_ssl_certificate. The certificate used to default to the bare
+ * relative path "./server.crt", which resolves against the working directory of
+ * the worker -- "/" under systemd -- so the engine could never load it. Every
+ * worker exited with fatal code 2 and could not be respawned, taking the plain
+ * HTTP listeners down too, while "nginx -t" still reported the configuration as
+ * valid. The helpers below turn that into a startup time error naming the
+ * missing directive, or the unreadable path and why.
+ *
+ * Only ngx_str_t, ngx_err_t and ngx_inline are needed from the surrounding
+ * translation unit; they are stubbed below so the exact same source that ships
+ * in the module is exercised without requiring a full nginx build:
+ *
+ *     cc -Wall -Wextra -o test_xquic_ssl_conf test_xquic_ssl_conf.c
+ *     ./test_xquic_ssl_conf
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+/* --- minimal ngx compatibility layer --------------------------------- */
+
+typedef int             ngx_err_t;
+typedef unsigned char   u_char;
+
+typedef struct {
+    size_t      len;
+    u_char     *data;
+} ngx_str_t;
+
+#define ngx_inline      inline
+
+#include "../../ngx_xquic_ssl_conf.h"
+
+/* --- tiny test framework --------------------------------------------- */
+
+static int tests_run = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                                                      \
+    do {                                                                      \
+        tests_run++;                                                          \
+        if (!(cond)) {                                                        \
+            tests_failed++;                                                   \
+            printf("FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__);          \
+        }                                                                     \
+    } while (0)
+
+/* --- helpers --------------------------------------------------------- */
+
+/*
+ * Build an ngx_str_t over a literal the way ngx_conf_set_str_slot() leaves one:
+ * NUL terminated, len excluding the terminator.
+ */
+static ngx_str_t
+str(char *s)
+{
+    ngx_str_t  v;
+
+    v.data = (u_char *) s;
+    v.len = strlen(s);
+
+    return v;
+}
+
+/* An unset directive: what ngx_pcalloc() of the main conf leaves behind. */
+static ngx_str_t
+unset(void)
+{
+    ngx_str_t  v;
+
+    v.data = NULL;
+    v.len = 0;
+
+    return v;
+}
+
+static char  tmpl[] = "/tmp/ngx_xquic_cert_test_XXXXXX";
+static char  path[sizeof(tmpl)];
+
+/* Create a temp file standing in for a certificate, with the given mode. */
+static int
+write_temp_cert(mode_t mode)
+{
+    int  fd;
+
+    memcpy(path, tmpl, sizeof(tmpl));
+
+    fd = mkstemp(path);
+    if (fd == -1) {
+        return -1;
+    }
+
+    if (write(fd, "-----BEGIN CERTIFICATE-----\n", 28) != 28) {
+        close(fd);
+        unlink(path);
+        return -1;
+    }
+
+    close(fd);
+
+    if (chmod(path, mode) != 0) {
+        unlink(path);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* --- test cases: which directive is missing --------------------------- */
+
+/*
+ * The reported case: an xquic listener with neither directive configured. The
+ * certificate has to be named first, since that is what the user has to add.
+ */
+static void
+test_both_unset_reports_certificate(void)
+{
+    ngx_str_t    cert = unset();
+    ngx_str_t    key = unset();
+    const char  *missing;
+
+    missing = ngx_xquic_ssl_cert_missing(&cert, &key);
+
+    CHECK(missing != NULL, "an unconfigured certificate must be reported");
+    CHECK(missing != NULL && strcmp(missing, "xquic_ssl_certificate") == 0,
+          "the missing directive should be named xquic_ssl_certificate");
+}
+
+/* Half a configuration is still a broken one: the key alone cannot serve. */
+static void
+test_key_only_reports_certificate(void)
+{
+    ngx_str_t    cert = unset();
+    ngx_str_t    key = str("/etc/tengine/server.key");
+    const char  *missing;
+
+    missing = ngx_xquic_ssl_cert_missing(&cert, &key);
+
+    CHECK(missing != NULL && strcmp(missing, "xquic_ssl_certificate") == 0,
+          "a key without a certificate should report the certificate");
+}
+
+static void
+test_cert_only_reports_key(void)
+{
+    ngx_str_t    cert = str("/etc/tengine/server.crt");
+    ngx_str_t    key = unset();
+    const char  *missing;
+
+    missing = ngx_xquic_ssl_cert_missing(&cert, &key);
+
+    CHECK(missing != NULL && strcmp(missing, "xquic_ssl_certificate_key") == 0,
+          "a certificate without a key should report the key");
+}
+
+static void
+test_both_set_reports_nothing(void)
+{
+    ngx_str_t    cert = str("/etc/tengine/server.crt");
+    ngx_str_t    key = str("/etc/tengine/server.key");
+    const char  *missing;
+
+    missing = ngx_xquic_ssl_cert_missing(&cert, &key);
+
+    CHECK(missing == NULL, "a complete configuration must not be rejected");
+}
+
+/*
+ * A zero length value with a non-NULL data pointer counts as unset too: an
+ * empty string is not a usable path, and treating it as one would push the
+ * failure back down into the worker.
+ */
+static void
+test_empty_string_counts_as_unset(void)
+{
+    ngx_str_t    cert = str("");
+    ngx_str_t    key = str("/etc/tengine/server.key");
+    const char  *missing;
+
+    missing = ngx_xquic_ssl_cert_missing(&cert, &key);
+
+    CHECK(missing != NULL && strcmp(missing, "xquic_ssl_certificate") == 0,
+          "an empty certificate path should count as unset");
+}
+
+/*
+ * "Not configured" and "configured but unreadable" have to stay distinguishable.
+ * The old defaults collapsed them: an unset xquic_ssl_certificate became the
+ * literal "./server.crt", so the only symptom left was a missing file, and the
+ * log could not say that the directive was the thing that was absent.
+ */
+static void
+test_unset_is_not_reported_as_unreadable(void)
+{
+    ngx_str_t    cert = unset();
+    ngx_str_t    key = unset();
+    const char  *missing;
+
+    missing = ngx_xquic_ssl_cert_missing(&cert, &key);
+
+    CHECK(missing != NULL,
+          "an unset directive must be reported before any path is probed");
+
+    /* and the reverse: a configured path is never reported as missing */
+    cert = str("/tmp/ngx_xquic_no_such_cert");
+    key = str("/tmp/ngx_xquic_no_such_key");
+
+    missing = ngx_xquic_ssl_cert_missing(&cert, &key);
+
+    CHECK(missing == NULL,
+          "a configured path must be left to the readability probe");
+    CHECK(ngx_xquic_cert_file_check("/tmp/ngx_xquic_no_such_cert") == ENOENT,
+          "the probe should be what reports a configured path that is absent");
+}
+
+/* --- test cases: readability probe ------------------------------------ */
+
+static void
+test_readable_file(void)
+{
+    ngx_err_t  err;
+
+    if (write_temp_cert(0644) != 0) {
+        CHECK(0, "failed to create temp certificate");
+        return;
+    }
+
+    err = ngx_xquic_cert_file_check(path);
+
+    CHECK(err == 0, "a readable certificate should pass");
+
+    unlink(path);
+}
+
+/*
+ * The failure the old default produced: a relative path that resolves nowhere.
+ * ENOENT is what has to reach the log, so that the message can say which path
+ * was tried and that it does not exist.
+ */
+static void
+test_missing_file_reports_enoent(void)
+{
+    ngx_err_t  err;
+
+    err = ngx_xquic_cert_file_check("/tmp/ngx_xquic_no_such_cert");
+
+    CHECK(err == ENOENT, "a missing certificate should report ENOENT");
+}
+
+/*
+ * A certificate the worker cannot read after dropping privileges. This is the
+ * other half of the same symptom -- workers dying with fatal code 2 -- and it
+ * only reproduces as a non-root user, so skip the check when running as root.
+ */
+static void
+test_unreadable_file_reports_eacces(void)
+{
+    ngx_err_t  err;
+
+    if (geteuid() == 0) {
+        printf("SKIP: unreadable certificate check needs a non-root user\n");
+        return;
+    }
+
+    if (write_temp_cert(0000) != 0) {
+        CHECK(0, "failed to create temp certificate");
+        return;
+    }
+
+    err = ngx_xquic_cert_file_check(path);
+
+    CHECK(err == EACCES, "a certificate with no read permission should report EACCES");
+
+    unlink(path);
+}
+
+/* A directory is not a certificate; the errno must still be a real one. */
+static void
+test_directory_is_not_a_certificate(void)
+{
+    ngx_err_t  err;
+
+    err = ngx_xquic_cert_file_check("/tmp");
+
+    /*
+     * open(O_RDONLY) on a directory succeeds on Linux and fails with EISDIR on
+     * some other systems. Either way the probe must not report a bogus errno,
+     * and the engine reports the parse failure afterwards.
+     */
+    CHECK(err == 0 || err == EISDIR, "a directory should not yield a bogus errno");
+}
+
+/*
+ * Reproduce the mechanism behind the report: the very same certificate is
+ * reachable by absolute path and unreachable by the relative one the old default
+ * used, because the latter resolves against the working directory. A worker
+ * started from systemd runs with "/" as its working directory, so "./server.crt"
+ * meant "/server.crt". This is why the paths are now resolved against the prefix
+ * in ngx_http_xquic_init_main_conf() and no longer default to "./".
+ */
+static void
+test_relative_path_follows_cwd(void)
+{
+    ngx_err_t  err;
+    char       relative[sizeof(tmpl) + 2];
+    char       cwd[4096];
+
+    if (getcwd(cwd, sizeof(cwd)) == NULL) {
+        CHECK(0, "failed to read the working directory");
+        return;
+    }
+
+    if (write_temp_cert(0644) != 0) {
+        CHECK(0, "failed to create temp certificate");
+        return;
+    }
+
+    /* "/tmp/ngx_xquic_cert_test_XXXXXX" -> "./ngx_xquic_cert_test_XXXXXX" */
+    snprintf(relative, sizeof(relative), ".%s", path + sizeof("/tmp") - 1);
+
+    err = ngx_xquic_cert_file_check(path);
+    CHECK(err == 0, "the certificate should be readable by absolute path");
+
+    if (chdir("/tmp") != 0) {
+        CHECK(0, "failed to chdir to /tmp");
+        unlink(path);
+        return;
+    }
+
+    err = ngx_xquic_cert_file_check(relative);
+    CHECK(err == 0, "the relative path should resolve inside its own directory");
+
+    /* what the worker actually sees under systemd */
+    if (chdir("/") != 0) {
+        CHECK(0, "failed to chdir to /");
+        unlink(path);
+        return;
+    }
+
+    err = ngx_xquic_cert_file_check(relative);
+    CHECK(err == ENOENT,
+          "the same relative path must fail from another working directory");
+
+    err = ngx_xquic_cert_file_check(path);
+    CHECK(err == 0, "the absolute path must keep working from anywhere");
+
+    if (chdir(cwd) != 0) {
+        CHECK(0, "failed to restore the working directory");
+    }
+
+    unlink(path);
+}
+
+/* The probe must not leak the descriptor it opens. */
+static void
+test_no_fd_leak(void)
+{
+    int  fd, before = 0, after = 0, i;
+
+    if (write_temp_cert(0644) != 0) {
+        CHECK(0, "failed to create temp certificate");
+        return;
+    }
+
+    (void) ngx_xquic_cert_file_check(path);
+
+    for (fd = 0; fd < 256; fd++) {
+        if (fcntl(fd, F_GETFD) != -1) {
+            before++;
+        }
+    }
+
+    for (i = 0; i < 200; i++) {
+        (void) ngx_xquic_cert_file_check(path);
+        (void) ngx_xquic_cert_file_check("/tmp/ngx_xquic_no_such_cert");
+    }
+
+    for (fd = 0; fd < 256; fd++) {
+        if (fcntl(fd, F_GETFD) != -1) {
+            after++;
+        }
+    }
+
+    CHECK(before == after, "no file descriptor should leak across calls");
+
+    unlink(path);
+}
+
+/* --- main ------------------------------------------------------------ */
+
+int
+main(void)
+{
+    test_both_unset_reports_certificate();
+    test_key_only_reports_certificate();
+    test_cert_only_reports_key();
+    test_both_set_reports_nothing();
+    test_empty_string_counts_as_unset();
+    test_unset_is_not_reported_as_unreadable();
+
+    test_readable_file();
+    test_missing_file_reports_enoent();
+    test_unreadable_file_reports_eacces();
+    test_directory_is_not_a_certificate();
+    test_relative_path_follows_cwd();
+    test_no_fd_leak();
+
+    printf("%d tests run, %d failed\n", tests_run, tests_failed);
+
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
未配 xquic_ssl_certificate 时兜底为相对路径 ./server.crt、./server.key，相对 worker 工作目录解析（systemd 下为 /）必然读不到，导致 worker 全部以 fatal code 2 退出且不再 重启，该实例所有端口（含纯 HTTP）不可用，而 nginx -t 判定配置有效。

* 移除三个相对路径兜底值；显式配置的相对路径按配置文件目录展开，与 ssl_certificate 一致。
* 新增 ngx_http_xquic_check_ssl_conf()，在配置解析阶段按 ngx_http_ssl_init() 的方式遍历 cmcf->ports 校验，报错带 file:line。放在配置阶段而非 init_module：后者失败时 ngx_init_cycle() 直接 exit(1)，会连带杀掉 reload 中的 master。
* worker 侧在 xqc_engine_create() 前探测证书可读性，日志给出路径与 errno。仅 root 可读的 私钥能通过 master 侧校验，只有降权后才暴露，两层检查互补。
* 未配 xquic_ssl_session_ticket_key 的 0-RTT 降级告警改为 master 打一次。

新增 test/unit/test_xquic_ssl_conf.c，覆盖指令缺失的判定与优先级、"未配置"与"配了但读不到" 的区分、ENOENT/EACCES、相对路径随工作目录漂移的复现。两个独立单测在 CI 中提前到构建之前并 绑定 matrix 编译器。

README 补充证书必需性、绝对路径建议、session ticket key 与启动失败排查表。