### PR TITLE
XQUIC: align H3 header-path return codes and fix max_headers test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,13 @@ jobs:
          prove -v -Inginx-tests/lib ../../modules/ngx_debug_timer/t
          prove -v -Inginx-tests/lib ../../modules/ngx_debug_conn/t
          prove -v -Inginx-tests/lib ../../modules/ngx_slab_stat/t
+         # test-ntls.yml is where these actually run: it builds xquic and
+         # points TEST_XQUIC_CLIENT at the client binary. Here the module is
+         # not built, so every case in the directory must skip_all on
+         # has(xquic) -- which is exactly what this invocation guards. A case
+         # added without that guard fails here on "unknown directive xquic_*"
+         # long before anyone notices it in the ntls workflow.
+         prove -v -Inginx-tests/lib ../../modules/ngx_http_xquic_module/t
      - name: tengine test cases using test-nginx lib
        working-directory: tests/test-nginx
        run: |

--- a/modules/ngx_http_xquic_module/ngx_http_v3_stream.c
+++ b/modules/ngx_http_xquic_module/ngx_http_v3_stream.c
@@ -933,8 +933,15 @@ ngx_http_v3_request_process_header(ngx_http_request_t *r,
     if (r->headers_in.count++ >= cscf->max_headers) {
         ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
                       "client sent too many header lines");
+
         ngx_http_finalize_request(r, NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
-        return NGX_ERROR;
+
+        /*
+         * request has been finalized already, which this function reports
+         * as NGX_ABORT, the same way ngx_http_v3_parse_path() and
+         * ngx_http_v3_parse_authority() do
+         */
+        return NGX_ABORT;
     }
 
     h = ngx_list_push(&r->headers_in.headers);
@@ -959,7 +966,11 @@ ngx_http_v3_request_process_header(ngx_http_request_t *r,
                        h->lowcase_key, h->key.len);
 
     if (hh && hh->handler(r, h, hh->offset) != NGX_OK) {
-        return NGX_ERROR;
+        /*
+         * a failing header handler has finalized the request itself,
+         * e.g. ngx_http_process_host(), so this is NGX_ABORT as well
+         */
+        return NGX_ABORT;
     }
 
     return NGX_OK;
@@ -1254,8 +1265,13 @@ ngx_http_v3_request_read_notify(xqc_h3_request_t *h3_request, xqc_request_notify
             ret = ngx_http_v3_request_process_header(user_stream->request, 
                         &(headers->headers[i]), h3_request);
 
-            /* NGX_ABORT - request has been closed */
-            /* NGX_ERROR,NGX_DECLINED - request err but not closed */   
+            /*
+             * NGX_ABORT - request has been closed
+             * NGX_ERROR, NGX_DECLINED - request err but not closed
+             *
+             * all of them are currently collapsed into the same handling:
+             * the header block is abandoned and the read notify fails
+             */
 
             if (ret != NGX_OK) {
                 ngx_log_error(NGX_LOG_WARN, ngx_cycle->log, 0,

--- a/modules/ngx_http_xquic_module/t/h3_max_headers.t
+++ b/modules/ngx_http_xquic_module/t/h3_max_headers.t
@@ -55,9 +55,30 @@ if (!$test_client) {
 # 4 e2e tests (baseline 200 + bomb rejected, x2 servers) when
 # test_client is available — otherwise skipped, but still counted
 # in the plan since Test::More's skip() emits "ok # SKIP" lines.
+#
+# todo_alerts(): running xquic at all produces two classes of [alert]
+# that say nothing about max_headers, and the framework's own "no
+# alerts" check in Test::Nginx::DESTROY would fail on both.
+#
+#   - "setsockopt(new-udp-hash) failed, ignored" (95: not supported):
+#     the SOL_UDP option 200 set in ngx_open_listening_sockets() only
+#     exists in Alibaba kernels; elsewhere it returns EOPNOTSUPP and
+#     the code carries on, as "ignored" says.
+#   - "open socket #N left in connection 3" / "aborting" on shutdown,
+#     one pair per worker: xquic listeners are not torn down through
+#     ngx_close_connection(), so the leak check trips on every stop.
+#
+# Both are pre-existing xquic behaviour, not something this test can
+# fix or should mask for other suites, so downgrade the check to TODO.
+#
+# Clearing error.log instead is not an option, for two reasons: DESTROY
+# calls stop() before reading the log, so the shutdown alerts are written
+# after any clearing a test body could do; and it would swallow a real
+# emerg from a bad config along with them.
 
-my $t = Test::Nginx->new()->has(qw/http rewrite/)
+my $t = Test::Nginx->new()->has(qw/http rewrite xquic/)
     ->has_daemon('openssl')
+    ->todo_alerts()
     ->plan(6)
     ->write_file_expand('nginx.conf', <<'EOF');
 
@@ -142,8 +163,12 @@ sleep 1;
 my $error_log = $t->read_file('error.log');
 unlike($error_log, qr/unknown directive.*max_headers/i,
        'max_headers directive recognized in xquic server block');
-unlike($error_log, qr/\[(emerg|alert)\]/,
-       'no emerg/alert in error log on startup');
+# Only [emerg] is fatal here. The startup [alert] this reliably emits on
+# non-Alibaba kernels -- setsockopt(new-udp-hash), see the todo_alerts()
+# note above -- is explicitly ignored by the server, so matching bare
+# [alert] would fail the suite for a reason unrelated to max_headers.
+unlike($error_log, qr/\[emerg\]/,
+       'no emerg in error log on startup');
 
 ###############################################################################
 
@@ -182,10 +207,6 @@ SKIP: {
     unlike($bomb_b, qr/:status = 200/,
            'server B bomb - request not 200');
 }
-
-# Clear error log so the framework's own no-alerts check doesn't trip
-# on the noise test_client and finalize_request(494) generate.
-$t->write_file('error.log', '') if $has_test_client;
 
 $t->stop();
 

--- a/modules/ngx_http_xquic_module/t/ngx_http_xquic.t
+++ b/modules/ngx_http_xquic_module/t/ngx_http_xquic.t
@@ -40,8 +40,18 @@ if (!$test_client) {
 
 my $test_count = $has_test_client ? 5 : 4;
 
-my $t = Test::Nginx->new()->has(qw/http/)
+# todo_alerts(): running xquic at all produces [alert]s that say nothing
+# about this test -- setsockopt(new-udp-hash) on non-Alibaba kernels at
+# startup, "open socket left in connection" on shutdown.  See the longer
+# note in h3_max_headers.t.  Downgrading the framework's own "no alerts"
+# check to TODO is the only way to tolerate them: clearing error.log
+# cannot work, because Test::Nginx::DESTROY stops the server *before*
+# reading the log, so the shutdown alerts land after any clearing this
+# file could do -- and it would swallow a real emerg on the way.
+
+my $t = Test::Nginx->new()->has(qw/http xquic/)
     ->has_daemon('openssl')
+    ->todo_alerts()
     ->plan($test_count)
     ->write_file_expand('nginx.conf', <<'EOF');
 
@@ -160,9 +170,6 @@ if ($has_test_client) {
     } else {
         fail('xquic test_client failed to parse output');
     }
-    
-    # Clear error log to avoid alerts from test_client failures
-    $t->write_file('error.log', '');
 }
 
 # Output detailed error information for debugging

--- a/tests/nginx-tests/tengine-tests/h2_max_headers.t
+++ b/tests/nginx-tests/tengine-tests/h2_max_headers.t
@@ -32,7 +32,7 @@ use Test::Nginx::HTTP2;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http http_v2 rewrite/)->plan(5)
+my $t = Test::Nginx->new()->has(qw/http http_v2 rewrite/)->plan(10)
 	->write_file_expand('nginx.conf', <<'EOF');
 
 %%TEST_GLOBALS%%
@@ -92,9 +92,13 @@ is($frame->{headers}->{':status'}, 200, 'baseline - 200 OK');
 
 # 2) the HPACK indexed-reference bomb.
 #
-# First field: literal-with-incremental-indexing.  This both sends the
-# header and parks one (name, value) entry in the dynamic table at the
-# first dynamic index, one byte of wire encoding per later use.
+# First field: literal-with-incremental-indexing, new name (mode 2).
+# This both sends the header and parks one (name, value) entry in the
+# dynamic table at the first dynamic index, one byte of wire encoding
+# per later use.  The new-name form is required here: the indexed-name
+# form (mode 1) resolves "x-bomb" against the encoder table *after*
+# inserting the entry, so it emits a self-referential name index that
+# the peer decodes as whatever already sits at that slot.
 #
 # Following fields: 60 indexed references to that same entry.  Each
 # reference is one wire byte, but every one of them is a fresh header
@@ -106,7 +110,7 @@ push @bomb, { name => ':method',    value => 'GET',       mode => 0 };
 push @bomb, { name => ':scheme',    value => 'http',      mode => 0 };
 push @bomb, { name => ':path',      value => '/',         mode => 0 };
 push @bomb, { name => ':authority', value => 'localhost', mode => 1 };
-push @bomb, { name => 'x-bomb',     value => 'v',         mode => 1 };
+push @bomb, { name => 'x-bomb',     value => 'v',         mode => 2 };
 push @bomb, { name => 'x-bomb',     value => 'v',         mode => 0 } for 1 .. 60;
 
 $s = Test::Nginx::HTTP2->new();
@@ -127,7 +131,7 @@ push @big, { name => ':method',    value => 'GET',       mode => 0 };
 push @big, { name => ':scheme',    value => 'http',      mode => 0 };
 push @big, { name => ':path',      value => '/',         mode => 0 };
 push @big, { name => ':authority', value => 'localhost', mode => 1 };
-push @big, { name => 'x-bomb',     value => 'v',         mode => 1 };
+push @big, { name => 'x-bomb',     value => 'v',         mode => 2 };
 push @big, { name => 'x-bomb',     value => 'v',         mode => 0 } for 1 .. 1100;
 
 $s = Test::Nginx::HTTP2->new(port(8081));
@@ -139,5 +143,78 @@ isnt($frame && $frame->{headers}->{':status'}, '200',
 	'default cap - request rejected, not 200');
 like($frame && $frame->{headers}->{':status'}, qr/^4\d\d$/,
 	'default cap - 4xx status returned');
+
+# 4) the cap trips while the HEADERS frame still carries many more fields.
+#
+# Hitting max_headers finalizes the request from inside the header handler,
+# which only queues the termination on r->main->posted_requests; the decoder
+# then detaches h2c->state.stream and keeps decoding the rest of the frame.
+# If the posted request is not driven before that, it is finalized later
+# against an already detached stream and a stale h2c->state.
+#
+# With the limit at 50 and 200 references sent, roughly 150 fields are still
+# decoded after the request has been finalized.
+
+my @rest;
+push @rest, { name => ':method',    value => 'GET',       mode => 0 };
+push @rest, { name => ':scheme',    value => 'http',      mode => 0 };
+push @rest, { name => ':path',      value => '/',         mode => 0 };
+push @rest, { name => ':authority', value => 'localhost', mode => 1 };
+push @rest, { name => 'x-bomb',     value => 'v',         mode => 2 };
+push @rest, { name => 'x-bomb',     value => 'v',         mode => 0 } for 1 .. 200;
+
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => \@rest });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq 'HEADERS' } @$frames;
+like($frame && $frame->{headers}->{':status'}, qr/^4\d\d$/,
+	'trailing fields - 4xx status returned');
+
+# 5) the connection must survive it: a fresh stream on the SAME connection
+# still has to complete normally.  This is the regression guard - if the
+# termination was left queued, the connection state is inconsistent by now
+# and this request does not get its 200 back.
+
+$sid = $s->new_stream({ headers => [
+	{ name => ':method',    value => 'GET',       mode => 0 },
+	{ name => ':scheme',    value => 'http',      mode => 0 },
+	{ name => ':path',      value => '/',         mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 1 },
+]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq 'HEADERS' } @$frames;
+is($frame && $frame->{headers}->{':status'}, 200,
+	'trailing fields - connection still usable');
+
+# 6) same thing, but the cap trips while decoding a CONTINUATION frame:
+# the first 20 bytes of the HPACK stream stay in HEADERS, everything else
+# (including the field that trips the limit) arrives in CONTINUATION.
+
+$s = Test::Nginx::HTTP2->new();
+$sid = $s->new_stream({ headers => \@rest, continuation => [20] });
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq 'HEADERS' } @$frames;
+like($frame && $frame->{headers}->{':status'}, qr/^4\d\d$/,
+	'continuation - 4xx status returned');
+
+$sid = $s->new_stream({ headers => [
+	{ name => ':method',    value => 'GET',       mode => 0 },
+	{ name => ':scheme',    value => 'http',      mode => 0 },
+	{ name => ':path',      value => '/',         mode => 0 },
+	{ name => ':authority', value => 'localhost', mode => 1 },
+]});
+$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+($frame) = grep { $_->{type} eq 'HEADERS' } @$frames;
+is($frame && $frame->{headers}->{':status'}, 200,
+	'continuation - connection still usable');
+
+# 7) no worker died along the way.
+
+unlike($t->read_file('error.log'), qr/exited on signal/,
+	'no worker process crash');
 
 ###############################################################################


### PR DESCRIPTION
## 背景

max_headers 在 HTTP/3（xquic）与 HTTP/2 两个问题：
xquic 的 header 处理函数在请求已被 finalize 之后仍返回 NGX_ERROR，与同文件
其余分支不一致；h2 的 max_headers 用例因为 HPACK 编码方式选错，从未真正触发
过限额，一直在空转通过。

## 1. XQUIC: report finalized requests as NGX_ABORT in the H3 header path

`ngx_http_v3_request_process_header()` 有两处在请求已被 finalize 之后返回
NGX_ERROR：超过 max_headers 的分支，以及 headers_in handler 失败的分支。同文件
`ngx_http_v3_parse_path()` / `ngx_http_v3_parse_authority()` 的同类分支返回的都是
NGX_ABORT，这里统一。

"handler 失败即请求已关闭"这一前提已逐个核对：`headers_in_hash` 只由
`ngx_http_headers_in[]` 构建，其中会返回非 NGX_OK 的 handler 全部先做过 finalize
或 close —— `ngx_http_process_host`（含转发到 `ngx_http_set_virtual_server` 的三条
错误路径）、`process_unique_header_line`、`process_proxy_connection`；
`process_connection` / `process_user_agent` 的失败分支转发自恒返回 NGX_OK 的
`process_header_line`，实际不可达。

**纯语义对齐，无行为变化。** 唯一调用点 `ngx_http_v3_request_read_notify()` 把
NGX_ABORT / NGX_ERROR / NGX_DECLINED 折叠为同一处理（放弃整个 header block 并让
read notify 失败），并不区分三者。原注释把这条未落实的约定写成了调用者的既有
行为，一并改正。

## 2. Test: make the h2 max_headers bomb cases actually trip the limit

`h2_max_headers.t` 的 bomb 用例此前从未触发 max_headers。动态表条目用的是
indexed-name 形式（mode 1），`hpack()` 在插入条目之后才解析名字：`x-bomb` 不在
静态表里，只能命中刚插入的槽位并发出自引用索引，对端解出的是该槽位原有内容，
即前一条 `:authority`，于是请求以 "client sent duplicate :authority header" 得到
400。断言只看 4xx，用例空转通过 —— 旧用例实测 error.log 中 "too many header
lines" 出现 0 次。

（`:authority` 自己用 mode 1 没事：静态表 index 1 就是 `:authority`，名字查找会先
命中静态项，所以不会自引用。）

- bomb / default cap / trailing 三组的动态表条目改用 literal-with-new-name 编码
  （mode 2）。改后实测 "too many header lines" 4 次，access.log 4×400 + 3×200。
- 新增三组断言：帧内仍有大量剩余 header、触发点落在 CONTINUATION 帧，以及两种
  场景下同一连接的后续请求仍返回 200。请求在 header 处理函数内被 finalize 后，
  解码器会摘掉 `h2c->state.stream` 并继续解完当前帧，同一连接上的后续请求能否
  正常完成才是这条路径的判据。

## 3. Test: guard the xquic cases on has(xquic) and run the directory in ci.yml

`modules/ngx_http_xquic_module/t` 此前从未被 ci.yml 执行，其中的用例也没有统一
守卫。

- 两个用例都补 `has(xquic)`。`ngx_http_xquic.t` 原先完全没有守卫，在不构建 xquic
  的环境下会以 unknown directive "xquic_log" 直接失败。
- 两个用例都改用 `todo_alerts()`，并删掉清空 error.log 的写法。xquic 一旦启动就会
  产生两类与用例无关的 [alert]（非阿里内核上的 setsockopt(new-udp-hash)、停机时
  的 open socket left），框架 DESTROY 里的 no alerts 硬断言会被它们打挂。清空
  error.log 解决不了问题：DESTROY 先 stop 再读日志，停机那批 alert 落在清空之后，
  而且这种做法会连真正的 emerg 一起吞掉。
- 该目录纳入 ci.yml 的 prove 列表。真正执行这些用例的是 test-ntls.yml，它构建
  xquic 并设置 TEST_XQUIC_CLIENT；ci.yml 这一遍全部 skip_all，作用是守住"漏加
  has(xquic) 就立刻红"这条线。