### PR TITLE
Packaging: pin the openEuler build repos to a CDN mirror

### DIFF
--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -134,6 +134,15 @@ Ubuntu 22.04/24.04/26.04、SLES 15 SP6+/16、Alpine 3.21~3.24，均双架构）�
 > `target_dist`）。Anolis 无此问题 —— 其镜像自带 `%dist`，产物形如
 > `tengine-3.2.0-<ts>.an8.x86_64.rpm`。
 
+> openEuler 镜像的仓库默认走 `mirrors.openeuler.org` 的 metalink，而它给出的镜像
+> 站都在国内：GitHub runner 上拉包只有几 kB/s，librepo 会以 “Operation too slow”
+> 或 HTTP/2 流截断逐个放弃镜像，最终 `cmake`（约 30 MB）这类包必然下载失败。因此
+> bootstrap 把 openEuler 的 repo 文件（含 `gpgkey`）改指华为云镜像 —— 同一份目录树，
+> 走 CDN —— 并注掉 `metalink`（否则它会盖掉改写后的 `baseurl`），同时把 dnf 限成
+> 单连接下载：并行下载复用同一条 HTTP/2 连接，一个流被重置会带走整批。此外 rpm 家族
+> 的 bootstrap 安装命令统一由 `retry_install` 重试 4 次（10s 起指数退避），已下载的包
+> 留在 cache 里，重试只补缺失的部分。
+
 **只有 `el7` + `aarch64` 标记 `continue-on-error`**：CentOS 7 EOL 后镜像源迁到
 `vault.centos.org`，其主树只有 x86_64，aarch64 归档在 `/altarch/` 另一路径下，
 bootstrap 的源改写没覆盖，该组合不可能成功。

--- a/packages/build/build.sh
+++ b/packages/build/build.sh
@@ -456,7 +456,50 @@ bootstrap_cmd() {
     case "$1" in
         rpm)
             cat <<'EOS'
+# A repository that stalls or resets a connection is the one failure mode this
+# bootstrap sees regularly, and librepo only retries a mirror a couple of times
+# before dropping it -- once the list is empty the whole transaction fails. Retry
+# the installer itself: whatever already came down stays in the package cache, so
+# each attempt only refetches what is still missing.
+retry_install() {
+    _try=1
+    _delay=10
+    while :; do
+        if "$@"; then return 0; fi
+        [ "$_try" -lt 4 ] || return 1
+        echo "bootstrap: package install failed, retrying in ${_delay}s ($_try/4)"
+        sleep "$_delay"
+        _try=$((_try + 1))
+        _delay=$((_delay * 2))
+    done
+}
+
+_dnfopt=
 if command -v dnf >/dev/null 2>&1; then
+    # The openEuler images resolve every repo through mirrors.openeuler.org, and
+    # the mirror list it hands back is served from China: from a GitHub runner the
+    # rpm transfers crawl along at a few kB/s until librepo gives up on them
+    # ("Operation too slow", truncated HTTP/2 streams), and a 30 MB package like
+    # cmake never makes it. Huawei Cloud carries the same trees behind a CDN, so
+    # pin the repo files to it -- gpgkey included, since that host would stall the
+    # same way -- and comment the metalink out, which is what otherwise wins over
+    # the rewritten baseurl.
+    if grep -qi '^ID="\{0,1\}openEuler' /etc/os-release 2>/dev/null; then
+        sed -i -e 's|^metalink=|#metalink=|' \
+            -e 's|^baseurl=https\{0,1\}://repo\.openeuler\.org/|baseurl=https://repo.huaweicloud.com/openeuler/|' \
+            -e 's|^gpgkey=https\{0,1\}://repo\.openeuler\.org/|gpgkey=https://repo.huaweicloud.com/openeuler/|' \
+            /etc/yum.repos.d/*.repo
+        # A repo whose metalink is now commented out but whose baseurl did not match
+        # would be left with no source at all, so say so here rather than let dnf
+        # report the packages as simply missing.
+        grep -q '^baseurl=https://repo.huaweicloud.com/openeuler/' /etc/yum.repos.d/*.repo \
+            || { echo "bootstrap: no openEuler baseurl was rewritten"; exit 1; }
+        # And keep dnf to one download at a time: the parallel ones share a single
+        # HTTP/2 connection, so one reset stream takes the whole batch with it.
+        # Scoped to openEuler because these are dnf 4 option names; el10 runs dnf 5
+        # and would refuse an option it does not know.
+        _dnfopt="--setopt=max_parallel_downloads=1 --setopt=timeout=120 --setopt=retries=10 --setopt=minrate=100"
+    fi
     if dnf -q list pcre2-devel >/dev/null 2>&1; then _pcre=pcre2-devel; else _pcre=pcre-devel; fi
     # el9 images carry curl-minimal, which conflicts with the full curl package.
     # It provides /usr/bin/curl all the same, so only ask for curl when the image
@@ -471,7 +514,9 @@ if command -v dnf >/dev/null 2>&1; then
     # perl-devel and ExtUtils::Embed are for ngx_http_perl_module rather than
     # Tongsuo: the embedded interpreter compiles against the perl headers and
     # links libperl, which the RHEL family splits out of the base perl package.
-    dnf -y install rpm-build gcc gcc-c++ make cmake tar findutils diffutils $_curl \
+    # $_dnfopt is an option list and is meant to word-split; empty adds nothing.
+    retry_install dnf -y $_dnfopt install \
+        rpm-build gcc gcc-c++ make cmake tar findutils diffutils $_curl \
         perl "perl(FindBin)" "perl(IPC::Cmd)" "perl(lib)" \
         perl-devel "perl(ExtUtils::Embed)" \
         openssl-devel zlib-devel systemd "$_pcre"
@@ -486,7 +531,7 @@ else
     # one by one just moves the failure to the next module.
     # perl-devel is already one of perl-core's dependencies, but it is listed
     # here too because ngx_http_perl_module -- not Tongsuo -- is what needs it.
-    yum -y install rpm-build gcc gcc-c++ make tar findutils diffutils curl \
+    retry_install yum -y install rpm-build gcc gcc-c++ make tar findutils diffutils curl \
         perl-core perl-devel openssl-devel zlib-devel pcre-devel systemd
     # el7 packages CMake 2.8 and xquic needs >= 3.5. The usual answer, cmake3,
     # lives only in EPEL 7 -- itself EOL, with a dead metalink and nothing but
@@ -494,7 +539,8 @@ else
     # repo files. Kitware's own build is a static tarball needing just glibc
     # 2.17, which el7 has. build.sh detects that rpm does not own this CMake
     # and drops the matching BuildRequires by itself.
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-linux-$(uname -m).tar.gz" \
+    curl -fsSL --retry 3 --retry-delay 5 \
+        "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-linux-$(uname -m).tar.gz" \
         | tar xz --strip-components=1 -C /usr/local
     cmake --version
 fi


### PR DESCRIPTION
openEuler 镜像的仓库默认走 mirrors.openeuler.org 的 metalink，而它给出的 镜像站都在国内：GitHub runner 上只有几 kB/s，librepo 以 "Operation too slow" 和 HTTP/2 流截断逐个放弃镜像，cmake（约 30 MB）必然下载失败，整个
dnf 事务随之报错。

* openEuler 的 repo 文件（baseurl 与 gpgkey）改指华为云镜像，同一份目录树 走 CDN，并注掉 metalink —— 否则它会盖掉改写后的 baseurl。改写后校验至少 命中一条 baseurl，避免出现"metalink 已注、baseurl 未匹配"的无源仓库， 以"找不到包"的形式莫名失败。
* openEuler 上把 dnf 限成单连接下载（max_parallel_downloads=1，另加 timeout / retries / minrate）：并行下载复用同一条 HTTP/2 连接，一个流被 重置会带走整批。只对 openEuler 生效 —— 这些是 dnf 4 的选项名，el10 用的 是 dnf 5，不认识的选项会直接报错。
* rpm 家族的 dnf / yum 安装统一由 retry_install 重试 4 次（10s 起指数退避）， 已下载的包留在 cache，重试只补缺失部分；el7 取 Kitware CMake 的 curl 也 补上 --retry。

验证：build.sh 与抽出的 bootstrap 片段 sh -n 通过；retry_install 的成功、 退避、放弃与 set -e 传播四条路径实测符合预期；sed 对官方 repo 文件样本
（http:// 的 baseurl 加 metalink）改写正确，ID="openEuler" 与 ID=openEuler 均识别、rocky 不误伤；华为云上 22.03-LTS-SP4 与 24.03-LTS 的
OS / update / everything / EPOL、双架构、RPM-GPG-KEY-openEuler，以及失败 日志里的 cmake-3.22.0-11.oe2203sp4.aarch64.rpm 实测均 200。本机无 docker，容器内 bootstrap 的端到端执行未跑，华为云在 runner 上的实际速率
需重跑 openeuler2203 确认。