### PR TITLE
Upstream: fix the round robin crashes with re-resolvable servers and cover the private round robin code in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,19 @@ jobs:
        run: |
          sudo cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
          prove -v -Inginx-tests/lib tengine-tests/
+         # Upstream's own zone/resolve cases, run here on purpose: this build has
+         # every private macro on, while test-nginx-core.yml -- the only job that
+         # runs nginx-tests/ -- compiles the private round robin code out with
+         # "-D T_NGX_HTTP_UPSTREAM_RANDOM=0". Without this step a crash in that
+         # code (peers->number reaching 0 when a resolver removes every peer) is
+         # covered by no job at all. These cases need no module beyond this build.
+         prove -v -Inginx-tests/lib \
+           nginx-tests/upstream_resolve.t \
+           nginx-tests/upstream_resolve_reload.t \
+           nginx-tests/upstream_service.t \
+           nginx-tests/upstream_sticky_resolve.t \
+           nginx-tests/upstream_zone.t \
+           nginx-tests/upstream_zone_ssl.t
          prove -v -Inginx-tests/lib ../../modules/ngx_http_proxy_connect_module/t
          prove -v -Inginx-tests/lib ../../modules/ngx_debug_timer/t
          prove -v -Inginx-tests/lib ../../modules/ngx_debug_conn/t

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -1,0 +1,73 @@
+name: test tengine with asan
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # Every other workflow builds without a sanitizer, so a memory error only
+  # shows up when it happens to crash the worker on that runner: an out of
+  # bounds read, a use after free of a shared memory peer or a division by zero
+  # can all pass the suite silently. This job builds with AddressSanitizer and
+  # runs the cases that exercise run time changes of upstream peer sets, where
+  # such errors are most likely. Test::Nginx already asserts "no sanitizer
+  # errors" (it greps the error log for Sanitizer lines, and nginx redirects
+  # stderr there), so the sanitizer report alone fails the case.
+  asan-test:
+   name: test tengine with asan (${{ matrix.compiler.compiler }})
+   runs-on: "ubuntu-24.04"
+   strategy:
+     fail-fast: false
+     matrix:
+       compiler:
+         - { compiler: GNU,  CC: gcc,  CXX: g++}
+         - { compiler: LLVM, CC: clang, CXX: clang++}
+   steps:
+     - uses: actions/checkout@v7
+     - name: get dependencies
+       run: |
+         sudo apt update
+         sudo apt remove nginx
+         sudo apt install -y libpcre3 libpcre3-dev libssl-dev cpanminus
+     - name: build with AddressSanitizer
+       env:
+         CC: ${{ matrix.compiler.CC }}
+         CXX: ${{ matrix.compiler.CXX }}
+       run: |
+         # -O1 keeps the sanitizer reports readable while staying close to the
+         # optimizer behaviour of a release build. No macro is switched off:
+         # the private code paths are what this job is here to check. -Wno-error
+         # only because the sanitizer changes what the optimizer can prove, so it
+         # reports warnings the other jobs (which do enforce -Werror) do not.
+         ./configure \
+            --with-debug \
+            --with-http_ssl_module \
+            --with-http_v2_module \
+            --with-cc-opt="-fsanitize=address -fno-omit-frame-pointer -g -O1 -Wno-error" \
+            --with-ld-opt="-fsanitize=address"
+         make -j2
+         sudo make install
+     - name: run upstream cases under AddressSanitizer
+       working-directory: tests/nginx-tests
+       env:
+         TEST_NGINX_BINARY: /usr/local/tengine/sbin/tengine
+         # nginx frees its pools only where it has to and keeps allocations
+         # alive until exit by design, so LeakSanitizer reports at shutdown are
+         # expected and would drown the reports this job cares about.
+         ASAN_OPTIONS: detect_leaks=0
+       run: |
+         sudo cpanm --notest Net::DNS::Nameserver > build.log 2>&1 || (cat build.log && exit 1)
+         prove -I nginx-tests/lib \
+           nginx-tests/upstream.t \
+           nginx-tests/upstream_resolve.t \
+           nginx-tests/upstream_resolve_reload.t \
+           nginx-tests/upstream_service.t \
+           nginx-tests/upstream_service_reload.t \
+           nginx-tests/upstream_sticky_resolve.t \
+           nginx-tests/upstream_zone.t \
+           nginx-tests/upstream_zone_ssl.t \
+           nginx-tests/proxy_next_upstream.t \
+           tengine-tests/upstream_resolve_empty.t \
+           tengine-tests/upstream_resolve_shrink.t

--- a/.github/workflows/test-nginx-core.yml
+++ b/.github/workflows/test-nginx-core.yml
@@ -166,3 +166,61 @@ jobs:
          sudo groupadd wheel    # for proxy_bind_transparent.t
          sudo TEST_NGINX_BINARY=/usr/local/tengine/sbin/tengine TEST_NGINX_UNSAFE=yes prove -I nginx-tests/lib nginx-tests/proxy_bind_transparent.t nginx-tests/proxy_bind_transparent_capability.t
 
+  # The job above compiles the private round robin code out with
+  # "-D T_NGX_HTTP_UPSTREAM_RANDOM=0", so nginx-tests never exercises it: every
+  # upstream case there runs the stock nginx peer selection. This job keeps the
+  # macros at their defaults (T_NGX_HTTP_UPSTREAM_RANDOM and, on top of it,
+  # T_NGX_HTTP_ROUND_ROBIN_OPT_ALI) and runs the upstream subset, which is what
+  # actually covers ngx_http_upstream_get_peer()'s ring scan and its O(1)
+  # last_peer fast path against the resolver adding and removing peers at run
+  # time. Only the modules the cases need are built: the point is to isolate the
+  # core round robin code, not to test its interaction with private modules
+  # (ci.yml does that with every module linked in).
+  upstream-private-round-robin-test:
+   name: test nginx core upstream (private round robin)
+   runs-on: "ubuntu-24.04"
+   strategy:
+     fail-fast: false
+     matrix:
+       compiler:
+         - { compiler: GNU,  CC: gcc,  CXX: g++}
+         - { compiler: LLVM, CC: clang, CXX: clang++}
+   steps:
+     - uses: actions/checkout@v7
+     - name: get dependencies
+       run: |
+         sudo apt update
+         sudo apt remove nginx
+         sudo apt install -y libpcre3 libpcre3-dev libssl-dev cpanminus memcached
+     - name: build with default macros
+       env:
+         CC: ${{ matrix.compiler.CC }}
+         CXX: ${{ matrix.compiler.CXX }}
+       run: |
+         # no -D overrides on purpose: this build is the one with the private
+         # round robin code in it.
+         ./configure \
+            --with-debug \
+            --with-http_ssl_module \
+            --with-http_v2_module
+         make -j2
+         sudo make install
+     - name: run upstream cases in nginx-tests
+       working-directory: tests/nginx-tests
+       env:
+         TEST_NGINX_BINARY: /usr/local/tengine/sbin/tengine
+       run: |
+         sudo cpanm --notest Net::DNS::Nameserver Cache::Memcached > build.log 2>&1 || (cat build.log && exit 1)
+         # The upstream_sticky cluster (upstream_sticky.t, _drain, _learn,
+         # _learn_header, _route) is left out: it fails on this branch with the
+         # private round robin code both on and off, and not always on the same
+         # assertions, so including it here would only mask regressions in the
+         # code this job exists to cover.
+         prove -I nginx-tests/lib \
+           $(ls nginx-tests/upstream*.t \
+             | grep -vE 'upstream_sticky(\.t|_drain|_learn|_learn_header|_route)') \
+           nginx-tests/proxy_next_upstream.t \
+           nginx-tests/proxy_next_upstream_tries.t \
+           tengine-tests/upstream_resolve_empty.t \
+           tengine-tests/upstream_resolve_shrink.t
+

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -644,6 +644,15 @@ ngx_http_upstream_zone_remove_peer_locked(ngx_http_upstream_rr_peers_t *peers,
     (*peers->config)++;
     peers->weighted = (peers->total_weight != peers->number);
 
+#if (T_NGX_HTTP_ROUND_ROBIN_OPT_ALI)
+    /* drop the cached round robin position, the peer is gone */
+
+    if (peers->last_peer == peer) {
+        peers->last_peer = NULL;
+        peers->last_number = NGX_CONF_UNSET_UINT;
+    }
+#endif
+
     ngx_http_upstream_rr_peer_free(peers, peer);
 }
 

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -863,8 +863,11 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
          * For weighted groups, discard a random number of smooth-weight
          * adaptations once per worker so that workers do not synchronize on
          * the same starting peer after startup/reload.
+         *
+         * note: peers->number may be zero at run time, e.g. when all
+         *       re-resolvable peers have been removed by the resolver
          */
-        if (!ngx_rr_discarded_init && peers->weighted) {
+        if (!ngx_rr_discarded_init && peers->weighted && peers->number) {
             umcf = ngx_http_cycle_get_module_main_conf(ngx_cycle,
                                                        ngx_http_upstream_module);
             discarded_range = peers->number;
@@ -873,7 +876,10 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
             }
 
             discarded_number = ngx_random() % peers->number;
-            discarded_number %= discarded_range;
+            if (discarded_range) {
+                discarded_number %= discarded_range;
+            }
+
             for (i = 0; i <= discarded_number; i++) {
                 ngx_http_upstream_adapte_rr_peer_weight(rrp);
             }
@@ -982,6 +988,19 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp,
     p = 0;
 #endif
 
+#if (T_NGX_HTTP_UPSTREAM_RANDOM)
+    /*
+     * The peer list may be empty at run time: re-resolvable servers keep
+     * peers->number at zero until the first successful resolving, and the
+     * resolver removes all peers again on an empty or negative answer.
+     * Bail out early, the round robin scan below computes peer positions
+     * modulo peers->number.
+     */
+    if (rrp->peers->number == 0) {
+        return NULL;
+    }
+#endif
+
 #if (NGX_HTTP_UPSTREAM_SID)
     st_peer = ngx_http_upstream_get_rr_peer_by_sid(rrp, pc->hint, &p, 0);
 
@@ -1008,6 +1027,16 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp,
 #if (T_NGX_HTTP_UPSTREAM_RANDOM)
     if (rrp->peers->init_number == NGX_CONF_UNSET_UINT) {
          rrp->peers->init_number = ngx_random() % rrp->peers->number;
+
+    } else if (rrp->peers->init_number >= rrp->peers->number) {
+        /*
+         * init_number is a peer position, drawn once against the peer count of
+         * the moment and then kept in the (shared) peers set. The resolver may
+         * have shrunk the set since, so bring it back into range: starting the
+         * scan below past the last peer walks the list to NULL, and the ring
+         * scan would then dereference it and never reach its stop condition.
+         */
+        rrp->peers->init_number %= rrp->peers->number;
     }
 
 #if (T_NGX_HTTP_ROUND_ROBIN_OPT_ALI)
@@ -1030,7 +1059,20 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp,
                 peer = peer->next;
             }
 
-        } else if (rrp->peers->last_peer && rrp->peers->last_peer->next) {
+        } else if (rrp->peers->last_peer
+                   && rrp->peers->last_number < rrp->peers->number
+#if (NGX_HTTP_UPSTREAM_ZONE)
+                   /*
+                    * last_number is the position last_peer had when it was
+                    * selected, and it is what indexes rrp->tried below. Any
+                    * add/remove shifts positions (and may free last_peer), so
+                    * the cache is only usable while the peers set is intact.
+                    */
+                   && (rrp->peers->config == NULL
+                       || rrp->peers->last_config == *rrp->peers->config)
+#endif
+                   && rrp->peers->last_peer->next)
+        {
             begin_number = (rrp->peers->last_number + 1) % rrp->peers->number;
             peer = rrp->peers->last_peer->next;
 
@@ -1100,6 +1142,10 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp,
             best = peer;
             rrp->peers->last_peer = peer;
             rrp->peers->last_number = i;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+            rrp->peers->last_config = rrp->peers->config
+                                      ? *rrp->peers->config : 0;
+#endif
             p = i;
             break;
         }

--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -147,6 +147,10 @@ struct ngx_http_upstream_rr_peers_s {
 #if (T_NGX_HTTP_ROUND_ROBIN_OPT_ALI)
     ngx_uint_t                      last_number;
     ngx_http_upstream_rr_peer_t    *last_peer;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    /* *config as seen when last_peer/last_number were recorded */
+    ngx_uint_t                      last_config;
+#endif
 #endif
 
     ngx_uint_t                      total_weight;

--- a/tests/nginx-tests/tengine-tests/upstream_resolve_empty.t
+++ b/tests/nginx-tests/tengine-tests/upstream_resolve_empty.t
@@ -1,0 +1,345 @@
+#!/usr/bin/perl
+
+# Tests for round robin with an empty re-resolvable upstream.
+#
+# The tengine round robin optimization (T_NGX_HTTP_UPSTREAM_RANDOM,
+# T_NGX_HTTP_ROUND_ROBIN_OPT_ALI) scans peers as a ring, computing positions
+# modulo peers->number and caching the last selected peer.  With re-resolvable
+# servers peers->number is zero before the first successful resolving and again
+# after an empty or negative answer, which used to abort the worker process:
+# either SIGFPE on "% peers->number", or SIGSEGV on the NULL peer list.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+use IO::Select;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy upstream_zone/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+worker_processes 1;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    # not weighted, selected by the O(1) ring scan that caches the last peer
+    upstream u {
+        zone z 1m;
+        server example.net:%%PORT_8081%% resolve max_fails=0;
+    }
+
+    # weighted, selected by the smooth weight scan
+    upstream uw {
+        zone zw 1m;
+        server example.net:%%PORT_8081%% resolve max_fails=0 weight=2;
+    }
+
+    # lower the retry timeout after empty reply
+    resolver 127.0.0.1:%%PORT_8982_UDP%% valid=1s;
+    # retry query shortly after DNS is started
+    resolver_timeout 1s;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        proxy_connect_timeout 1s;
+
+        location /u {
+            proxy_pass http://u/t;
+        }
+
+        location /uw {
+            proxy_pass http://uw/t;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:%%PORT_8081%%;
+        server_name  localhost;
+
+        location /t {
+            root %%TESTDIR%%;
+        }
+    }
+}
+
+EOF
+
+port(8083);
+
+$t->write_file('t', 'SEE-THIS');
+
+$t->run_daemon(\&dns_daemon, $t)->waitforfile($t->testdir . '/' . port(8982));
+$t->try_run('no resolve in upstream server')->plan(9);
+
+###############################################################################
+
+# nothing resolved yet: the peer list is empty from the very first request
+
+like(http_get('/u'), qr/502/, 'not resolved');
+like(http_get('/uw'), qr/502/, 'not resolved weighted');
+
+# two peers, one of them is alive; both upstreams are usable now, and the
+# selected peer gets cached in peers->last_peer
+
+update_name({A => '127.0.0.1 127.0.0.201'});
+
+like(http_get('/u'), qr/SEE-THIS/, 'resolved');
+like(http_get('/u'), qr/SEE-THIS/, 'resolved again');
+like(http_get('/uw'), qr/SEE-THIS/, 'resolved weighted');
+
+# all records removed, peers->number drops back to zero while the cached
+# position still points to a removed peer
+
+update_name();
+
+like(http_get('/u'), qr/502/, 'peers removed');
+like(http_get('/uw'), qr/502/, 'peers removed weighted');
+
+# and the upstreams recover once the name resolves again
+
+update_name({A => '127.0.0.1'});
+
+like(http_get('/u'), qr/SEE-THIS/, 'peers restored');
+
+# note: a peer set that changes while a peer selected earlier stays alive is
+# covered by nginx-tests/upstream_resolve.t ('A AAAA AAAA' steps), which also
+# checks that each peer is tried exactly once. Reproducing it here would depend
+# on which peer the ring scan happens to cache.
+
+unlike($t->read_file('error.log'), qr/exited on signal|SEGV|Sanitizer/,
+	'no worker process crash');
+
+###############################################################################
+
+sub update_name {
+	my ($name, $plan) = @_;
+
+	$plan = 2 if !defined $plan;
+
+	sub sock {
+		IO::Socket::INET->new(
+			Proto => 'tcp',
+			PeerAddr => '127.0.0.1:' . port(8083)
+		)
+			or die "Can't connect to nginx: $!\n";
+	}
+
+	$name->{A} = '' unless $name->{A};
+	$name->{AAAA} = '' unless $name->{AAAA};
+	$name->{ERROR} = '' unless $name->{ERROR};
+
+	my $req =<<EOF;
+GET / HTTP/1.0
+Host: localhost
+X-A: $name->{A}
+X-AAAA: $name->{AAAA}
+X-ERROR: $name->{ERROR}
+
+EOF
+
+	my ($gen) = http($req, socket => sock()) =~ /X-Gen: (\d+)/;
+	for (1 .. 10) {
+		my ($gen2) = http($req, socket => sock()) =~ /X-Gen: (\d+)/;
+
+		# let resolver cache expire to finish upstream reconfiguration
+		select undef, undef, undef, 0.5;
+		last unless ($gen + $plan > $gen2);
+	}
+}
+
+###############################################################################
+
+sub reply_handler {
+	my ($recv_data, $h) = @_;
+
+	my (@name, @rdata);
+
+	use constant NOERROR	=> 0;
+	use constant SERVFAIL	=> 2;
+
+	use constant A		=> 1;
+	use constant AAAA	=> 28;
+	use constant IN		=> 1;
+
+	# default values
+
+	my ($hdr, $rcode, $ttl) = (0x8180, NOERROR, 1);
+
+	# no records until the test asks for them
+
+	$h = {} unless defined $h;
+
+	# decode name
+
+	my ($len, $offset) = (undef, 12);
+	while (1) {
+		$len = unpack("\@$offset C", $recv_data);
+		last if $len == 0;
+		$offset++;
+		push @name, unpack("\@$offset A$len", $recv_data);
+		$offset += $len;
+	}
+
+	$offset -= 1;
+	my ($id, $type, $class) = unpack("n x$offset n2", $recv_data);
+	my $name = join('.', @name);
+
+	if ($h->{ERROR}) {
+		$rcode = SERVFAIL;
+		goto bad;
+	}
+
+	if ($name eq 'example.net') {
+		if ($type == A && $h->{A}) {
+			map { push @rdata, rd_addr($ttl, $_) } @{$h->{A}};
+		}
+		if ($type == AAAA && $h->{AAAA}) {
+			map { push @rdata, rd_addr6($ttl, $_) } @{$h->{AAAA}};
+		}
+	}
+
+bad:
+
+	Test::Nginx::log_core('||', "DNS: $name $type $rcode");
+
+	$len = @name;
+	pack("n6 (C/a*)$len x n2", $id, $hdr | $rcode, 1, scalar @rdata,
+		0, 0, @name, $type, $class) . join('', @rdata);
+}
+
+sub rd_addr {
+	my ($ttl, $addr) = @_;
+
+	my $code = 'split(/\./, $addr)';
+
+	pack 'n3N nC4', 0xc00c, A, IN, $ttl, eval "scalar $code", eval($code);
+}
+
+sub expand_ip6 {
+	my ($addr) = @_;
+
+	substr ($addr, index($addr, "::"), 2) =
+		join "0", map { ":" } (0 .. 8 - (split /:/, $addr) + 1);
+	map { hex "0" x (4 - length $_) . "$_" } split /:/, $addr;
+}
+
+sub rd_addr6 {
+	my ($ttl, $addr) = @_;
+
+	pack 'n3N nn8', 0xc00c, AAAA, IN, $ttl, 16, expand_ip6($addr);
+}
+
+sub dns_daemon {
+	my ($t) = @_;
+	my ($data, $recv_data, $h);
+
+	my $socket = IO::Socket::INET->new(
+		LocalAddr => '127.0.0.1',
+		LocalPort => port(8982),
+		Proto => 'udp',
+	)
+		or die "Can't create listening socket: $!\n";
+
+	my $control = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => "127.0.0.1:" . port(8083),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
+
+	my $sel = IO::Select->new($socket, $control);
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	# signal we are ready
+
+	open my $fh, '>', $t->testdir() . '/' . port(8982);
+	close $fh;
+	my $cnt = 0;
+
+	while (my @ready = $sel->can_read) {
+		foreach my $fh (@ready) {
+			if ($control == $fh) {
+				my $new = $fh->accept;
+				$new->autoflush(1);
+				$sel->add($new);
+
+			} elsif ($socket == $fh) {
+				$fh->recv($recv_data, 65536);
+				$data = reply_handler($recv_data, $h);
+				$fh->send($data);
+				$cnt++;
+
+			} else {
+				$h = process_name($fh, $cnt);
+				$sel->remove($fh);
+				$fh->close;
+			}
+		}
+	}
+}
+
+# parse dns update
+
+sub process_name {
+	my ($client, $cnt) = @_;
+	my $port = $client->sockport();
+
+	my $headers = '';
+	my $uri = '';
+	my %h;
+
+	while (<$client>) {
+		$headers .= $_;
+		last if (/^\x0d?\x0a?$/);
+	}
+	return 1 if $headers eq '';
+
+	$uri = $1 if $headers =~ /^\S+\s+([^ ]+)\s+HTTP/i;
+	return 1 if $uri eq '';
+
+	$headers =~ /X-A: (.*)$/m;
+	map { push @{$h{A}}, $_ } split(/ /, $1);
+	$headers =~ /X-AAAA: (.*)$/m;
+	map { push @{$h{AAAA}}, $_ } split(/ /, $1);
+	$headers =~ /X-ERROR: (.*)$/m;
+	$h{ERROR} = $1;
+
+	Test::Nginx::log_core('||', "$port: response, 200");
+	print $client <<EOF;
+HTTP/1.1 200 OK
+Connection: close
+X-Gen: $cnt
+
+OK
+EOF
+
+	return \%h;
+}
+
+###############################################################################

--- a/tests/nginx-tests/tengine-tests/upstream_resolve_shrink.t
+++ b/tests/nginx-tests/tengine-tests/upstream_resolve_shrink.t
@@ -1,0 +1,336 @@
+#!/usr/bin/perl
+
+# Tests for round robin when a re-resolvable upstream shrinks.
+#
+# The tengine round robin optimization (T_NGX_HTTP_UPSTREAM_RANDOM,
+# T_NGX_HTTP_ROUND_ROBIN_OPT_ALI) starts its ring scan at peers->init_number,
+# a peer position drawn once against the peer count of the moment and then kept
+# in the peers set, which lives in shared memory and survives reload.  Once the
+# resolver returns fewer addresses the position can be past the last peer: the
+# walk to the start peer then ends on NULL and the scan dereferences it, and the
+# stop condition (position back to where it started) can never be reached
+# either, so the worker spins until it is killed.
+#
+# A reload draws a new init_number, so the loop below repeats to cover the
+# positions that are out of range after the answer shrinks.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+use IO::Select;
+use IO::Socket::INET;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy upstream_zone/);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+worker_processes 1;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    # not weighted, selected by the O(1) ring scan that starts at init_number
+    upstream u {
+        zone z 1m;
+        server example.net:%%PORT_8081%% resolve max_fails=0;
+    }
+
+    # lower the retry timeout after empty reply
+    resolver 127.0.0.1:%%PORT_8982_UDP%% valid=1s;
+    # retry query shortly after DNS is started
+    resolver_timeout 1s;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        proxy_connect_timeout 200ms;
+
+        location /u {
+            proxy_pass http://u/t;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:%%PORT_8081%%;
+        server_name  localhost;
+
+        location /t {
+            root %%TESTDIR%%;
+        }
+    }
+}
+
+EOF
+
+port(8083);
+
+$t->write_file('t', 'SEE-THIS');
+
+$t->run_daemon(\&dns_daemon, $t)->waitforfile($t->testdir . '/' . port(8982));
+$t->try_run('no resolve in upstream server')->plan(2);
+
+###############################################################################
+
+for my $cycle (1 .. 10) {
+	# four dead peers: whichever one is selected last gets cached, and the
+	# next answer drops it, so the cached position is dropped as well and the
+	# scan falls back to starting at init_number -- drawn here against four
+	# peers, while only two are left by then
+	update_name({A => '127.0.0.201 127.0.0.202 127.0.0.203 127.0.0.204'});
+
+	# a reload rebuilds the peers set, so init_number is drawn again
+	$t->reload();
+	select undef, undef, undef, 2;
+
+	http_get('/u');
+
+	update_name({A => '127.0.0.1 127.0.0.201'});
+
+	http_get('/u');
+	http_get('/u');
+
+	if ($t->read_file('error.log') =~ /exited on signal|SEGV|Sanitizer/) {
+		diag("worker process crashed at cycle $cycle");
+		last;
+	}
+}
+
+unlike($t->read_file('error.log'), qr/exited on signal|SEGV|Sanitizer/,
+	'no worker process crash');
+
+# the remaining peers are still usable, the alive one is reached through
+# proxy_next_upstream
+
+like(http_get('/u'), qr/SEE-THIS/, 'shrunk upstream still works');
+
+###############################################################################
+
+sub update_name {
+	my ($name, $plan) = @_;
+
+	$plan = 2 if !defined $plan;
+
+	sub sock {
+		IO::Socket::INET->new(
+			Proto => 'tcp',
+			PeerAddr => '127.0.0.1:' . port(8083)
+		)
+			or die "Can't connect to nginx: $!\n";
+	}
+
+	$name->{A} = '' unless $name->{A};
+	$name->{AAAA} = '' unless $name->{AAAA};
+	$name->{ERROR} = '' unless $name->{ERROR};
+
+	my $req =<<EOF;
+GET / HTTP/1.0
+Host: localhost
+X-A: $name->{A}
+X-AAAA: $name->{AAAA}
+X-ERROR: $name->{ERROR}
+
+EOF
+
+	my ($gen) = http($req, socket => sock()) =~ /X-Gen: (\d+)/;
+	for (1 .. 10) {
+		my ($gen2) = http($req, socket => sock()) =~ /X-Gen: (\d+)/;
+
+		# let resolver cache expire to finish upstream reconfiguration
+		select undef, undef, undef, 0.5;
+		last unless ($gen + $plan > $gen2);
+	}
+}
+
+###############################################################################
+
+sub reply_handler {
+	my ($recv_data, $h) = @_;
+
+	my (@name, @rdata);
+
+	use constant NOERROR	=> 0;
+	use constant SERVFAIL	=> 2;
+
+	use constant A		=> 1;
+	use constant AAAA	=> 28;
+	use constant IN		=> 1;
+
+	# default values
+
+	my ($hdr, $rcode, $ttl) = (0x8180, NOERROR, 1);
+
+	# no records until the test asks for them
+
+	$h = {} unless defined $h;
+
+	# decode name
+
+	my ($len, $offset) = (undef, 12);
+	while (1) {
+		$len = unpack("\@$offset C", $recv_data);
+		last if $len == 0;
+		$offset++;
+		push @name, unpack("\@$offset A$len", $recv_data);
+		$offset += $len;
+	}
+
+	$offset -= 1;
+	my ($id, $type, $class) = unpack("n x$offset n2", $recv_data);
+	my $name = join('.', @name);
+
+	if ($h->{ERROR}) {
+		$rcode = SERVFAIL;
+		goto bad;
+	}
+
+	if ($name eq 'example.net') {
+		if ($type == A && $h->{A}) {
+			map { push @rdata, rd_addr($ttl, $_) } @{$h->{A}};
+		}
+		if ($type == AAAA && $h->{AAAA}) {
+			map { push @rdata, rd_addr6($ttl, $_) } @{$h->{AAAA}};
+		}
+	}
+
+bad:
+
+	Test::Nginx::log_core('||', "DNS: $name $type $rcode");
+
+	$len = @name;
+	pack("n6 (C/a*)$len x n2", $id, $hdr | $rcode, 1, scalar @rdata,
+		0, 0, @name, $type, $class) . join('', @rdata);
+}
+
+sub rd_addr {
+	my ($ttl, $addr) = @_;
+
+	my $code = 'split(/\./, $addr)';
+
+	pack 'n3N nC4', 0xc00c, A, IN, $ttl, eval "scalar $code", eval($code);
+}
+
+sub expand_ip6 {
+	my ($addr) = @_;
+
+	substr ($addr, index($addr, "::"), 2) =
+		join "0", map { ":" } (0 .. 8 - (split /:/, $addr) + 1);
+	map { hex "0" x (4 - length $_) . "$_" } split /:/, $addr;
+}
+
+sub rd_addr6 {
+	my ($ttl, $addr) = @_;
+
+	pack 'n3N nn8', 0xc00c, AAAA, IN, $ttl, 16, expand_ip6($addr);
+}
+
+sub dns_daemon {
+	my ($t) = @_;
+	my ($data, $recv_data, $h);
+
+	my $socket = IO::Socket::INET->new(
+		LocalAddr => '127.0.0.1',
+		LocalPort => port(8982),
+		Proto => 'udp',
+	)
+		or die "Can't create listening socket: $!\n";
+
+	my $control = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalHost => "127.0.0.1:" . port(8083),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
+
+	my $sel = IO::Select->new($socket, $control);
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	# signal we are ready
+
+	open my $fh, '>', $t->testdir() . '/' . port(8982);
+	close $fh;
+	my $cnt = 0;
+
+	while (my @ready = $sel->can_read) {
+		foreach my $fh (@ready) {
+			if ($control == $fh) {
+				my $new = $fh->accept;
+				$new->autoflush(1);
+				$sel->add($new);
+
+			} elsif ($socket == $fh) {
+				$fh->recv($recv_data, 65536);
+				$data = reply_handler($recv_data, $h);
+				$fh->send($data);
+				$cnt++;
+
+			} else {
+				$h = process_name($fh, $cnt);
+				$sel->remove($fh);
+				$fh->close;
+			}
+		}
+	}
+}
+
+# parse dns update
+
+sub process_name {
+	my ($client, $cnt) = @_;
+	my $port = $client->sockport();
+
+	my $headers = '';
+	my $uri = '';
+	my %h;
+
+	while (<$client>) {
+		$headers .= $_;
+		last if (/^\x0d?\x0a?$/);
+	}
+	return 1 if $headers eq '';
+
+	$uri = $1 if $headers =~ /^\S+\s+([^ ]+)\s+HTTP/i;
+	return 1 if $uri eq '';
+
+	$headers =~ /X-A: (.*)$/m;
+	map { push @{$h{A}}, $_ } split(/ /, $1);
+	$headers =~ /X-AAAA: (.*)$/m;
+	map { push @{$h{AAAA}}, $_ } split(/ /, $1);
+	$headers =~ /X-ERROR: (.*)$/m;
+	$h{ERROR} = $1;
+
+	Test::Nginx::log_core('||', "$port: response, 200");
+	print $client <<EOF;
+HTTP/1.1 200 OK
+Connection: close
+X-Gen: $cnt
+
+OK
+EOF
+
+	return \%h;
+}
+
+###############################################################################


### PR DESCRIPTION
私有轮询优化（T_NGX_HTTP_UPSTREAM_RANDOM、T_NGX_HTTP_ROUND_ROBIN_OPT_ALI）
把 peer 的位置下标当作环形扫描的坐标，并把上次选中的位置缓存在 peers 里。
这套坐标只在 peer 集合不变时成立，而同步进来的 server ... resolve 让
resolver 在运行期增删 peer：peers->number 可以为 0，位置会整体漂移，被
缓存的 peer 也可能已经释放。acd315ef 引入环形扫描时这些前提都还成立，
a6262716 之后不再成立，6f68d662 的位置缓存又放大了后果。

* peers->number 为 0 时（首次解析成功之前，以及空答案或否定答案之后）：
  ngx_random() % number 与 discarded_number %= discarded_range 除零。
  x86_64 上是 SIGFPE；arm64 的 UDIV 不陷入，随后解引用空链表得到 SIGSEGV。
  get_peer 开头直接返回 NULL，权重预热那段一并跳过。

* last_number 是选中时的位置，同时用来索引 rrp->tried。peer 集合一变位置
  就漂移，位图记到别的 peer 上：某个 peer 被试两次，另一个从未被试。改为
  连同 *peers->config（zone 模块每次增删都自增）一起缓存，代次不符就整表
  重扫，与 hash / random / ip_hash 判断缓存失效的方式一致。

* init_number 是一次性抽取的位置，存在共享内存里长期复用，从不重算。
  resolver 缩小 peer 集后它可能越过链表尾，起点定位走到 NULL 被解引用；
  即使不崩，i = (i + 1) % number 也永远回不到起点，worker 自旋到被强杀。
  使用前收回当前范围，与同文件 adapte_rr_peer_weight 的写法一致。

* 摘除 peer 时清掉指向它的 last_peer，避免悬垂指针。

* ci.yml —— prove 列表追加 upstream_resolve、upstream_resolve_reload、
  upstream_service、upstream_sticky_resolve、upstream_zone、
  upstream_zone_ssl 六个官方用例。该构建私有宏全开，且这六个用例只依赖
  已经编译进去的模块。

* test-nginx-core.yml —— 新增 upstream-private-round-robin-test，不带任何
  -D 覆盖、最小模块集，只跑 upstream 子集与两个新增的 tengine 用例。sticky
  族 5 个文件排除：它们在宏开与关两种构建下都失败且失败项不固定，属另一簇
  既有问题，纳进来只会让这个 job 长期红着而失去信号。

* test-asan.yml —— 新建。其余 job 都不带 sanitizer，而越界读、共享内存里
  peer 的 use after free、除零这几类问题在无 sanitizer 的构建下可能只表现
  为偶发崩溃甚至静默通过。Test::Nginx 的 DESTROY 里有 no sanitizer errors
  断言（grep error.log 的 Sanitizer 行），所以报告本身就会让用例失败。
  detect_leaks=0：nginx 按设计不释放 pool，退出时的 LSan 报告会淹没信号。
  cc-opt 带 -Wno-error（sanitizer 会让优化器报出其他 job 不会报的告警），
  其他 job 保持 -Werror 不变。

