### PR TITLE
CI: promote strict-release to a blocking check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
        run: |
          sudo make install
 
-# TODO: fix tests so they don't depend on /usr/local/tengine/logs/
-#       so we can run `make`, `make test`, `make install`.
+     # TODO: fix tests so they don't depend on /usr/local/tengine/logs/
+     #       so we can run `make`, `make test`, `make install`.
 
      - name: build
        env:

--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -186,12 +186,6 @@ jobs:
    # Tongsuo is compiled twice (once for xquic, once by Tengine's own configure),
    # plus xquic, LuaJIT and Tengine.
    timeout-minutes: 90
-   # Non-blocking until it has been seen green on a real runner: the dependency
-   # stack has never been built on this image, and an apt package name or a
-   # CMake/OpenSSL incompatibility here would block every pull request for a
-   # reason unrelated to warnings. Promote it to a required check -- and drop
-   # this line -- once the first scheduled run passes.
-   continue-on-error: true
    strategy:
      fail-fast: false
      matrix:


### PR DESCRIPTION
strict-release 已在真实 runner 上首次跑绿，移除临时的 continue-on-error: true 及其说明注释，正式升级为阻塞式检查；inventory 与 next 的非阻塞属设计保留，未受影响。